### PR TITLE
Added STOP to end of Write, per I2C spec.  

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -436,7 +436,7 @@ macro_rules! gpio {
                         let offset = $i;
                         unsafe {
                             &(*$GPIOX::ptr()).otyper.modify(|r, w| {
-                                w.bits(r.bits() & (1 << offset))
+                                w.bits(r.bits() | (1 << offset))
                          })};
 
                         self

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,7 +1,6 @@
 use core::cmp::min;
 
-use stm32::{FLASH, RCC};
-
+use stm32::{FLASH, RCC, rcc};
 use time::Hertz;
 
 /// Extension trait that constrains the `RCC` peripheral
@@ -13,6 +12,9 @@ pub trait RccExt {
 impl RccExt for RCC {
     fn constrain(self) -> Rcc {
         Rcc {
+            ahb: AHB { _0: () },
+            apb1: APB1 { _0: () },
+            apb2: APB2 { _0: () },
             cfgr: CFGR {
                 hclk: None,
                 pclk1: None,
@@ -25,7 +27,64 @@ impl RccExt for RCC {
 
 /// Constrained RCC peripheral
 pub struct Rcc {
+    /// AMBA High-performance Bus (AHB) registers
+    pub ahb: AHB,
+    /// Advanced Peripheral Bus 1 (APB1) registers
+    pub apb1: APB1,
+    /// Advanced Peripheral Bus 2 (APB2) registers
+    pub apb2: APB2,
     pub cfgr: CFGR,
+}
+
+/// AMBA High-performance Bus (AHB) registers
+pub struct AHB {
+    _0: (),
+}
+
+impl AHB {
+    pub(crate) fn enr1(&mut self) -> &rcc::AHB1ENR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).ahb1enr }
+    }
+
+    pub(crate) fn enr2(&mut self) -> &rcc::AHB2ENR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).ahb2enr }
+    }
+}
+
+/// Advanced Peripheral Bus 1 (APB1) registers
+pub struct APB1 {
+    _0: (),
+}
+
+impl APB1 {
+    pub(crate) fn enr(&mut self) -> &rcc::APB1ENR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).apb1enr }
+    }
+
+    pub(crate) fn rstr(&mut self) -> &rcc::APB1RSTR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).apb1rstr }
+    }
+}
+
+/// Advanced Peripheral Bus 2 (APB2) registers
+pub struct APB2 {
+    _0: (),
+}
+
+impl APB2 {
+    pub(crate) fn enr(&mut self) -> &rcc::APB2ENR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).apb2enr }
+    }
+
+    pub(crate) fn rstr(&mut self) -> &rcc::APB2RSTR {
+        // NOTE(unsafe) this proxy grants exclusive access to this register
+        unsafe { &(*RCC::ptr()).apb2rstr }
+    }
 }
 
 const HSI: u32 = 16_000_000; // Hz


### PR DESCRIPTION
To do this, created send private 'send_without_stop' and 'send_stop' methods and changed Write & WriteRead to use it.  This is modeled after https://github.com/japaric/stm32f103xx-hal/blob/master/src/i2c.rs

Sorry for the strange looking diff -- the Write and WriteRead methods didn't move, but the large move of code from within Write to inside of the i2c1 impl makes it look like they did.