### PR TITLE
Allow reuse of I2C code without macros

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -49,10 +49,6 @@ impl<PINS> I2c<I2C1, PINS> {
         i2c.i2c_init(speed, clocks.pclk1());
         i2c
     }
-
-    pub fn release(self) -> (I2C1, PINS) {
-        (self.i2c, self.pins)
-    }
 }
 
 impl<PINS> I2c<I2C2, PINS> {
@@ -73,10 +69,6 @@ impl<PINS> I2c<I2C2, PINS> {
         let i2c = I2c { i2c, pins };
         i2c.i2c_init(speed, clocks.pclk1());
         i2c
-    }
-
-    pub fn release(self) -> (I2C2, PINS) {
-        (self.i2c, self.pins)
     }
 }
 
@@ -152,6 +144,10 @@ where
 
         // Enable the I2C processing
         self.i2c.cr1.modify(|_, w| w.pe().set_bit());
+    }
+
+    pub fn release(self) -> (I2C, PINS) {
+        (self.i2c, self.pins)
     }
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -30,6 +30,56 @@ pub enum Error {
     NACK,
 }
 
+impl<PINS> I2c<I2C1, PINS> {
+    pub fn i2c1(i2c: I2C1, pins: PINS, speed: KiloHertz, clocks: Clocks) -> Self
+    where
+        PINS: Pins<I2C1>,
+    {
+        // NOTE(unsafe) This executes only during initialisation
+        let rcc = unsafe { &(*RCC::ptr()) };
+
+        // Enable clock for I2C1
+        rcc.apb1enr.modify(|_, w| w.i2c1en().set_bit());
+
+        // Reset I2C2
+        rcc.apb1rstr.modify(|_, w| w.i2c1rst().set_bit());
+        rcc.apb1rstr.modify(|_, w| w.i2c1rst().clear_bit());
+
+        let i2c = I2c { i2c, pins };
+        i2c.i2c_init(speed, clocks.pclk1());
+        i2c
+    }
+
+    pub fn release(self) -> (I2C1, PINS) {
+        (self.i2c, self.pins)
+    }
+}
+
+impl<PINS> I2c<I2C2, PINS> {
+    pub fn i2c2(i2c: I2C2, pins: PINS, speed: KiloHertz, clocks: Clocks) -> Self
+    where
+        PINS: Pins<I2C2>,
+    {
+        // NOTE(unsafe) This executes only during initialisation
+        let rcc = unsafe { &(*RCC::ptr()) };
+
+        // Enable clock for I2C2
+        rcc.apb1enr.modify(|_, w| w.i2c2en().set_bit());
+
+        // Reset I2C2
+        rcc.apb1rstr.modify(|_, w| w.i2c2rst().set_bit());
+        rcc.apb1rstr.modify(|_, w| w.i2c2rst().clear_bit());
+
+        let i2c = I2c { i2c, pins };
+        i2c.i2c_init(speed, clocks.pclk1());
+        i2c
+    }
+
+    pub fn release(self) -> (I2C2, PINS) {
+        (self.i2c, self.pins)
+    }
+}
+
 type I2cRegisterBlock = i2c3::RegisterBlock;
 
 impl<I2C, PINS> I2c<I2C, PINS>
@@ -251,55 +301,5 @@ where
 
         // Fallthrough is success
         Ok(())
-    }
-}
-
-impl<PINS> I2c<I2C1, PINS> {
-    pub fn i2c1(i2c: I2C1, pins: PINS, speed: KiloHertz, clocks: Clocks) -> Self
-    where
-        PINS: Pins<I2C1>,
-    {
-        // NOTE(unsafe) This executes only during initialisation
-        let rcc = unsafe { &(*RCC::ptr()) };
-
-        // Enable clock for I2C1
-        rcc.apb1enr.modify(|_, w| w.i2c1en().set_bit());
-
-        // Reset I2C2
-        rcc.apb1rstr.modify(|_, w| w.i2c1rst().set_bit());
-        rcc.apb1rstr.modify(|_, w| w.i2c1rst().clear_bit());
-
-        let i2c = I2c { i2c, pins };
-        i2c.i2c_init(speed, clocks.pclk1());
-        i2c
-    }
-
-    pub fn release(self) -> (I2C1, PINS) {
-        (self.i2c, self.pins)
-    }
-}
-
-impl<PINS> I2c<I2C2, PINS> {
-    pub fn i2c2(i2c: I2C2, pins: PINS, speed: KiloHertz, clocks: Clocks) -> Self
-    where
-        PINS: Pins<I2C2>,
-    {
-        // NOTE(unsafe) This executes only during initialisation
-        let rcc = unsafe { &(*RCC::ptr()) };
-
-        // Enable clock for I2C2
-        rcc.apb1enr.modify(|_, w| w.i2c2en().set_bit());
-
-        // Reset I2C2
-        rcc.apb1rstr.modify(|_, w| w.i2c2rst().set_bit());
-        rcc.apb1rstr.modify(|_, w| w.i2c2rst().clear_bit());
-
-        let i2c = I2c { i2c, pins };
-        i2c.i2c_init(speed, clocks.pclk1());
-        i2c
-    }
-
-    pub fn release(self) -> (I2C2, PINS) {
-        (self.i2c, self.pins)
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -122,7 +122,7 @@ trait I2cCommon {
         // Push out a byte of data
         self.i2c().dr.write(|w| unsafe { w.bits(u32::from(byte)) });
 
-        // While until byte is transferred
+        // Wait until byte is transferred
         while {
             let sr1 = self.i2c().sr1.read();
 
@@ -302,7 +302,7 @@ impl<PINS> I2cInit for I2c<I2C1, PINS> {
 impl<PINS> I2c<I2C2, PINS> {
     pub fn i2c2(i2c: I2C2, pins: PINS, speed: KiloHertz, clocks: Clocks) -> Self
     where
-        PINS: Pins<I2C1>,
+        PINS: Pins<I2C2>,
     {
         let i2c = I2c { i2c, pins };
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -21,6 +21,7 @@ pub trait Pins<I2c> {}
 
 impl Pins<I2C1> for (PB6<Alternate<AF4>>, PB7<Alternate<AF4>>) {}
 impl Pins<I2C1> for (PB8<Alternate<AF4>>, PB9<Alternate<AF4>>) {}
+impl Pins<I2C1> for (PB6<Alternate<AF4>>, PB9<Alternate<AF4>>) {}
 
 impl Pins<I2C2> for (PB10<Alternate<AF4>>, PB11<Alternate<AF4>>) {}
 
@@ -30,8 +31,10 @@ pub enum Error {
     NACK,
 }
 
+type I2cRegisterBlock = i2c3::RegisterBlock;
+
 trait I2cInit {
-    fn i2c(&self) -> &i2c3::RegisterBlock;
+    fn i2c(&self) -> &I2cRegisterBlock;
 
     fn enable_peripheral(&self, rcc: &rcc::RegisterBlock);
 
@@ -113,7 +116,7 @@ trait I2cInit {
 }
 
 trait I2cCommon {
-    fn i2c(&self) -> &i2c3::RegisterBlock;
+    fn i2c(&self) -> &I2cRegisterBlock;
 
     fn send_byte(&self, byte: u8) -> Result<(), Error> {
         // Wait until we're ready for sending
@@ -146,16 +149,16 @@ trait I2cCommon {
 
 impl<I2C, PINS> I2cCommon for I2c<I2C, PINS>
 where
-    I2C: Deref<Target = i2c3::RegisterBlock>,
+    I2C: Deref<Target = I2cRegisterBlock>,
 {
-    fn i2c(&self) -> &i2c3::RegisterBlock {
+    fn i2c(&self) -> &I2cRegisterBlock {
         &self.i2c
     }
 }
 
 impl<I2C, PINS> WriteRead for I2c<I2C, PINS>
 where
-    I2C: Deref<Target = i2c3::RegisterBlock>,
+    I2C: Deref<Target = I2cRegisterBlock>,
 {
     type Error = Error;
 
@@ -169,7 +172,7 @@ where
 
 impl<I2C, PINS> Write for I2c<I2C, PINS>
 where
-    I2C: Deref<Target = i2c3::RegisterBlock>,
+    I2C: Deref<Target = I2cRegisterBlock>,
 {
     type Error = Error;
 
@@ -215,7 +218,7 @@ where
 
 impl<I2C, PINS> Read for I2c<I2C, PINS>
 where
-    I2C: Deref<Target = i2c3::RegisterBlock>,
+    I2C: Deref<Target = I2cRegisterBlock>,
 {
     type Error = Error;
 
@@ -281,7 +284,7 @@ impl<PINS> I2c<I2C1, PINS> {
 }
 
 impl<PINS> I2cInit for I2c<I2C1, PINS> {
-    fn i2c(&self) -> &i2c3::RegisterBlock {
+    fn i2c(&self) -> &I2cRegisterBlock {
         &self.i2c
     }
 
@@ -316,7 +319,7 @@ impl<PINS> I2c<I2C2, PINS> {
 }
 
 impl<PINS> I2cInit for I2c<I2C2, PINS> {
-    fn i2c(&self) -> &i2c3::RegisterBlock {
+    fn i2c(&self) -> &I2cRegisterBlock {
         &self.i2c
     }
 


### PR DESCRIPTION
This is a mutation (actually not bad) of my first thought on how to get code reuse of the I2C peripherals without resorting to macros. The bare minimum pins and peripherals were added to get the point across. Currently untested, I have some sort of wiring issue or bad chip to deal with.

The core of this is the fact that I2C1, 2, and 3 all implement `Deref<Target = i2c3::RegisterBlock>`, I'm assuming due to some deduplication (also assuming it lives somewhere in `svd2rust`). If this deduplication will continue to exist in the future, I don't see any negatives associated with it.

Two traits were needed so the `embedded_hal` traits could directly use the `Deref` constraint instead of requiring a new `impl` for each I2C peripheral due to the enable bits and pclk.

Correct me if I'm wrong, but I believe this is not a breaking change.

Will resolve issues on my end and get this tested.