### PR TITLE
Add compile time barrier to make sure a device is chosen.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,42 @@
 
 #[cfg(not(any(
     feature = "stm32f401",
+    feature = "stm32f405",
     feature = "stm32f407",
+    feature = "stm32f410",
     feature = "stm32f411",
     feature = "stm32f412",
+    feature = "stm32f413",
+    feature = "stm32f415",
+    feature = "stm32f417",
+    feature = "stm32f423",
+    feature = "stm32f427",
     feature = "stm32f429",
+    feature = "stm32f437",
+    feature = "stm32f439",
+    feature = "stm32f446",
+    feature = "stm32f469",
+    feature = "stm32f479",
     )))]
-compile_error!("This crate requires one of the following features enabled: stm32f401, stm32f407, stm32f411, stm32f412 or stm32f429.");
+compile_error!("This crate requires one of the following device features enabled:
+        stm32f401
+        stm32f405
+        stm32f407
+        stm32f410
+        stm32f411
+        stm32f412
+        stm32f413
+        stm32f415
+        stm32f417
+        stm32f423
+        stm32f427
+        stm32f429
+        stm32f437
+        stm32f439
+        stm32f446
+        stm32f469
+        stm32f479
+                ");
 
 extern crate bare_metal;
 extern crate cast;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,15 @@
 #![no_std]
 #![allow(non_camel_case_types)]
 
+#[cfg(not(any(
+    feature = "stm32f401",
+    feature = "stm32f407",
+    feature = "stm32f411",
+    feature = "stm32f412",
+    feature = "stm32f429",
+    )))]
+compile_error!("This crate requires one of the following features enabled: stm32f401, stm32f407, stm32f411, stm32f412 or stm32f429.");
+
 extern crate bare_metal;
 extern crate cast;
 extern crate cortex_m;


### PR DESCRIPTION
This is something I just added to the l4 hal. I found when compiling, If I forgot to add the features I would get confusing error messages about the hal missing modules etc.