### PR TITLE
Add in serial Read and Write hal implementations for Serial

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -364,6 +364,17 @@ macro_rules! halUsart {
                 }
             }
 
+            impl<PINS> hal::serial::Read<u8> for Serial<$USARTX, PINS> {
+                type Error = Error;
+
+                fn read(&mut self) -> nb::Result<u8, Error> {
+                    let mut rx: Rx<$USARTX> = Rx {
+                        _usart: PhantomData,
+                    };
+                    rx.read()
+                }
+            }
+
             impl hal::serial::Read<u8> for Rx<$USARTX> {
                 type Error = Error;
 
@@ -394,6 +405,24 @@ macro_rules! halUsart {
                     } else {
                         nb::Error::WouldBlock
                     })
+                }
+            }
+
+            impl<PINS> hal::serial::Write<u8> for Serial<$USARTX, PINS> {
+                type Error = Error;
+
+                fn flush(&mut self) -> nb::Result<(), Self::Error> {
+                    let mut tx: Tx<$USARTX> = Tx {
+                        _usart: PhantomData,
+                    };
+                    tx.flush()
+                }
+
+                fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
+                    let mut tx: Tx<$USARTX> = Tx {
+                        _usart: PhantomData,
+                    };
+                    tx.write(byte)
                 }
             }
 


### PR DESCRIPTION
This change came about in my playing with `cortex-m-rtfm` and serial. What I discovered is that once you have the Tx and Rx structs, you can no longer mask and unmask the interrupts of the usart. This breaks common patterns like unmasking `TxE` to send data, then masking it when done transmitting.

This seems to be the more intuitive way as opposed to adding an `impl` of listen and unlisten to Tx and Rx.