### PR TITLE
serial: simplify baud rate divisor computation, fix fraction overflow

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -964,12 +964,9 @@ macro_rules! halUsartImpl {
                     rcc.$apbXenr.modify(|_, w| w.$usartXen().set_bit());
 
                     // Calculate correct baudrate divisor on the fly
-                    let div = (clocks.$pclkX().0 * 25) / (4 * config.baudrate.0);
-                    let mantissa = div / 100;
-                    let fraction = ((div - mantissa * 100) * 16 + 50) / 100;
-                    usart
-                        .brr
-                        .write(|w| unsafe { w.bits(mantissa << 4 | fraction) });
+                    let div = (clocks.$pclkX().0 + config.baudrate.0 / 2)
+                        / config.baudrate.0;
+                    usart.brr.write(|w| unsafe { w.bits(div) });
 
                     // Reset other registers to disable advanced USART features
                     usart.cr2.reset();


### PR DESCRIPTION
The formula to compute USARTDIV (when OVER8 is 0) is:

    USARTDIV = round (f_CK / (16 * baudrate))

As USARTDIV is a fixed point number with 4 bits fractionnal part (when
OVER8 is 0), this simplifies to:

    USARTDIV_reg = round (f_CK / baudrate)

The original code was computing the rounded fractionnal part which could
overflow. In this case, it could cause an error of 1 when the mantisa is
odd.