### PR TITLE
Gpio external interrupt

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -80,6 +80,7 @@ pub trait ExtiPin {
     fn trigger_on_edge(&mut self, exti: &mut EXTI, level: Edge);
     fn enable_interrupt(&mut self, exti: &mut EXTI);
     fn disable_interrupt(&mut self, exti: &mut EXTI);
+    fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI);
 }
 
 macro_rules! gpio {
@@ -557,6 +558,11 @@ macro_rules! gpio {
                     /// Disable external interrupts from this pin
                     fn disable_interrupt(&mut self, exti: &mut EXTI) {
                         exti.imr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
+                    }
+
+                    /// Clear the interrupt pending bit for this pin
+                    fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI) {
+                        exti.pr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                     }
                 }
 


### PR DESCRIPTION
I've introduced a new GPIO trait called `ExtiPin` with functions to configure, enable, and disable interrupts from a pin. Pins configured as Input implement this trait.

 - `trigger_on_edge()` sets the necessary bits in the FTSR and/or RTSR to select whether the interrupt is generated on rising, falling, or both edges. There is also an enum (`Edge`) for the three cases.
 - `enable_interrupt()` sets the interrupt enable bit in the EXTI interrupt mask register for the pin and configures the correct GPIO port for that pin in the SYSCFG_EXTICR.
 - `disable_interrupt()` clears the interrupt enable bit in the EXTI interrupt mask register.

I was only able to test this on an stm32f407 but since the register names are the same across all stm32f4 cores I assume this works -- it compiles without name errors for all the devices, anyway.

I welcome any discussion on the interface design be it about the structure or the names of the traits and functions.
For example, it might be convenient to have a function to clear the interrupt pending bit for a given pin.