### PR TITLE
Spi interrupt config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- API to enable and disable SPI interrupts
+
 ## [v0.3.0] - 2019-01-14
 
 ### Added

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -813,6 +813,24 @@ macro_rules! hal {
                     }
                 }
 
+                /// Return `true` if the TXE flag is set, i.e. new data to transmit
+                /// can be written to the SPI.
+                pub fn is_txe(&self) -> bool {
+                    self.spi.sr.read().txe().bit_is_set()
+                }
+
+                /// Return `true` if the RXNE flag is set, i.e. new data has been received
+                /// and can be read from the SPI.
+                pub fn is_rxne(&self) -> bool {
+                    self.spi.sr.read().rxne().bit_is_set()
+                }
+
+                /// Return `true` if the MODF flag is set, i.e. the SPI has experienced a
+                /// Master Mode Fault. (see chapter 28.3.10 of the STM32F4 Reference Manual)
+                pub fn is_modf(&self) -> bool {
+                    self.spi.sr.read().modf().bit_is_set()
+                }
+
                 pub fn free(self) -> ($SPIX, PINS) {
                     (self.spi, self.pins)
                 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -708,7 +708,7 @@ pins! {
 /// Interrupt events
 pub enum Event {
     /// New data has been received
-    Rxne ,
+    Rxne,
     /// Data can be sent
     Txe,
     /// An error occurred

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -820,30 +820,11 @@ macro_rules! hal {
 
                 /// Convenience function to disable all interrupts
                 pub fn disable_interrupts(&mut self) {
-                    self.spi.cr2.modify(|_, w| {
+                    self.spi.cr2.modify(|_, w| { 
                         w.txeie().clear_bit()
                         .rxneie().clear_bit()
                         .errie().clear_bit()
                     });
-                }
-
-                /// Enable the peripheral, i.e. set the SPE bit in the SPI control register 1
-                pub fn enable(&mut self) {
-                    self.spi.cr1.modify(|_, w| { w.spe().set_bit() });
-                }
-
-                /// Halt the SPI according to the procedure described in chapter
-                /// 28.3.8 of the STM32F4xx reference manual
-                // TODO: this only applies to master bi-directional transfer mode
-                pub fn wait_until_idle(&mut self) {
-                    while self.spi.sr.read().rxne().bit_is_clear() {}
-                    while self.spi.sr.read().txe().bit_is_clear()  {}
-                    while self.spi.sr.read().bsy().bit_is_set()    {}
-                }
-
-                /// Disabe the peripheral, i.e. clear the SPE bit in the control register 1
-                pub fn disable(&mut self) {
-                    self.spi.cr1.modify(|_, w| {w.spe().clear_bit() });
                 }
 
                 pub fn free(self) -> ($SPIX, PINS) {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -779,6 +779,49 @@ macro_rules! hal {
                     Spi { spi, pins }
                 }
 
+                /// Enable transmit register empty interrupt
+                pub fn enable_txe_interrupt(&mut self) {
+                    self.spi.cr2.write(|w| { w.txeie().set_bit() });
+                }
+
+                /// Disable transmit register empty interrupt
+                pub fn disable_txe_interrupt(&mut self) {
+                    self.spi.cr2.write(|w| {w.txeie().clear_bit()});
+                }
+
+                /// Enable receive register not empty interrupt
+                pub fn enable_rxne_interrupt(&mut self) {
+                    self.spi.cr2.write(|w| {w.rxneie().set_bit()});
+                }
+
+                /// Disable receive register not empty interrupt
+                pub fn disable_rxne_interrupt(&mut self) {
+                    self.spi.cr2.write(|w| {w.rxneie().clear_bit()});
+                }
+
+                /// Enable error interrupt
+                pub fn enable_error_interrupt(&mut self) {
+                    self.spi.cr2.write(|w| {w.errie().set_bit()});
+                }
+
+                /// Disable error interrupt
+                pub fn disable_error_interrupt(&mut self) {
+                    self.spi.cr2.write(|w| {w.errie().clear_bit()});
+                }
+
+                /// Convenience function to enable all interrupts
+                pub fn enable_interrupts(&mut self) {
+                    self.enable_txe_interrupt();
+                    self.enable_rxne_interrupt();
+                    self.enable_error_interrupt();
+                }
+
+                /// Convenience function to disable all interrupts
+                pub fn disable_interrupts(&mut self) {
+                    self.disable_txe_interrupt();
+                    self.disable_rxne_interrupt();
+                    self.disable_error_interrupt();
+                }
                 pub fn free(self) -> ($SPIX, PINS) {
                     (self.spi, self.pins)
                 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -781,51 +781,47 @@ macro_rules! hal {
 
                 /// Enable transmit register empty interrupt
                 pub fn enable_txe_interrupt(&mut self) {
-                    self.spi.cr2.write(|w| { w.txeie().set_bit() });
+                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() | (1 << 7))});
                 }
 
                 /// Disable transmit register empty interrupt
                 pub fn disable_txe_interrupt(&mut self) {
-                    self.spi.cr2.write(|w| {w.txeie().clear_bit()});
+                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() & !(1 << 7))});
                 }
 
                 /// Enable receive register not empty interrupt
                 pub fn enable_rxne_interrupt(&mut self) {
-                    self.spi.cr2.write(|w| {w.rxneie().set_bit()});
+                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() | (1 << 6))});
                 }
 
                 /// Disable receive register not empty interrupt
                 pub fn disable_rxne_interrupt(&mut self) {
-                    self.spi.cr2.write(|w| {w.rxneie().clear_bit()});
+                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() & !(1 << 6))});
                 }
 
                 /// Enable error interrupt
                 pub fn enable_error_interrupt(&mut self) {
-                    self.spi.cr2.write(|w| {w.errie().set_bit()});
+                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() | (1 << 5))});
                 }
 
                 /// Disable error interrupt
                 pub fn disable_error_interrupt(&mut self) {
-                    self.spi.cr2.write(|w| {w.errie().clear_bit()});
+                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() & !(1 << 5))});
                 }
 
                 /// Convenience function to enable all interrupts
                 pub fn enable_interrupts(&mut self) {
-                    self.enable_txe_interrupt();
-                    self.enable_rxne_interrupt();
-                    self.enable_error_interrupt();
+                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() | (7 << 5))});
                 }
 
                 /// Convenience function to disable all interrupts
                 pub fn disable_interrupts(&mut self) {
-                    self.disable_txe_interrupt();
-                    self.disable_rxne_interrupt();
-                    self.disable_error_interrupt();
+                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() & !(7 << 5))});
                 }
 
                 /// Enable the peripheral, i.e. set the SPE bit in the SPI control register 1
                 pub fn enable(&mut self) {
-                    self.spi.cr1.write(|w| {w.spe().set_bit()})
+                    self.spi.cr1.modify(|r, w| unsafe {w.bits(r.bits() | (1 << 6))});
                 }
 
                 /// Halt the SPI according to the procedure described in chapter
@@ -837,11 +833,9 @@ macro_rules! hal {
                     while self.spi.sr.read().bsy().bit_is_set()    {}
                 }
 
-                /// Shut down, i.e. go into halt and then turn off the SPI peripheral
+                /// Disabe the peripheral, i.e. clear the SPE bit in the control register 1
                 pub fn disable(&mut self) {
-                    self.disable_interrupts();
-                    self.wait_until_idle();
-                    self.spi.cr1.write(|w| {w.spe().clear_bit()});
+                    self.spi.cr1.modify(|r, w| unsafe {w.bits(r.bits() & !(1 << 6))});
                 }
 
                 pub fn free(self) -> ($SPIX, PINS) {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -781,47 +781,55 @@ macro_rules! hal {
 
                 /// Enable transmit register empty interrupt
                 pub fn enable_txe_interrupt(&mut self) {
-                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() | (1 << 7))});
+                    self.spi.cr2.modify(|_, w| { w.txeie().set_bit() });
                 }
 
                 /// Disable transmit register empty interrupt
                 pub fn disable_txe_interrupt(&mut self) {
-                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() & !(1 << 7))});
+                    self.spi.cr2.modify(|_, w| { w.txeie().clear_bit() });
                 }
 
                 /// Enable receive register not empty interrupt
                 pub fn enable_rxne_interrupt(&mut self) {
-                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() | (1 << 6))});
+                    self.spi.cr2.modify(|_, w| { w.rxneie().set_bit() });
                 }
 
                 /// Disable receive register not empty interrupt
                 pub fn disable_rxne_interrupt(&mut self) {
-                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() & !(1 << 6))});
+                    self.spi.cr2.modify(|_, w| { w.rxneie().clear_bit() });
                 }
 
                 /// Enable error interrupt
                 pub fn enable_error_interrupt(&mut self) {
-                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() | (1 << 5))});
+                    self.spi.cr2.modify(|_, w| { w.errie().set_bit() });
                 }
 
                 /// Disable error interrupt
                 pub fn disable_error_interrupt(&mut self) {
-                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() & !(1 << 5))});
+                    self.spi.cr2.modify(|_, w| { w.errie().clear_bit() });
                 }
 
                 /// Convenience function to enable all interrupts
                 pub fn enable_interrupts(&mut self) {
-                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() | (7 << 5))});
+                    self.spi.cr2.modify(|_, w| {
+                        w.txeie().set_bit()
+                        .rxneie().set_bit()
+                        .errie().set_bit()
+                    });
                 }
 
                 /// Convenience function to disable all interrupts
                 pub fn disable_interrupts(&mut self) {
-                    self.spi.cr2.modify(|r, w| unsafe {w.bits(r.bits() & !(7 << 5))});
+                    self.spi.cr2.modify(|_, w| {
+                        w.txeie().clear_bit()
+                        .rxneie().clear_bit()
+                        .errie().clear_bit()
+                    });
                 }
 
                 /// Enable the peripheral, i.e. set the SPE bit in the SPI control register 1
                 pub fn enable(&mut self) {
-                    self.spi.cr1.modify(|r, w| unsafe {w.bits(r.bits() | (1 << 6))});
+                    self.spi.cr1.modify(|_, w| { w.spe().set_bit() });
                 }
 
                 /// Halt the SPI according to the procedure described in chapter
@@ -835,7 +843,7 @@ macro_rules! hal {
 
                 /// Disabe the peripheral, i.e. clear the SPE bit in the control register 1
                 pub fn disable(&mut self) {
-                    self.spi.cr1.modify(|r, w| unsafe {w.bits(r.bits() & !(1 << 6))});
+                    self.spi.cr1.modify(|_, w| {w.spe().clear_bit() });
                 }
 
                 pub fn free(self) -> ($SPIX, PINS) {


### PR DESCRIPTION
Extend the SPI API to enable and disable interrupts, and to enable and disable the peripheral alltogether.