### PR TITLE
Add IWDG Watchdog implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Implement IndependentWatchdog for the IWDG peripheral
+
 ## [v0.3.0] - 2019-01-14
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,3 +99,5 @@ pub mod spi;
 pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timer;
+#[cfg(feature = "device-selected")]
+pub mod watchdog;

--- a/src/time.rs
+++ b/src/time.rs
@@ -24,6 +24,9 @@ pub trait U32Ext {
 
     /// Wrap in `MegaHertz`
     fn mhz(self) -> MegaHertz;
+
+    /// Wrap in `MilliSeconds`
+    fn ms(self) -> MilliSeconds;
 }
 
 impl U32Ext for u32 {
@@ -41,6 +44,10 @@ impl U32Ext for u32 {
 
     fn mhz(self) -> MegaHertz {
         MegaHertz(self)
+    }
+
+    fn ms(self) -> MilliSeconds {
+        MilliSeconds(self)
     }
 }
 
@@ -61,3 +68,7 @@ impl Into<KiloHertz> for MegaHertz {
         KiloHertz(self.0 * 1_000)
     }
 }
+
+/// Time unit
+#[derive(PartialEq, PartialOrd, Clone, Copy)]
+pub struct MilliSeconds(pub u32);

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,105 @@
+//! Watchdog peripherals
+
+use crate::{
+    stm32::{IWDG, DBG},
+    hal::watchdog::{Watchdog, WatchdogEnable},
+    time::MilliSeconds,
+};
+
+/// Wraps the Independent Watchdog (IWDG) peripheral
+pub struct IndependentWatchdog {
+    iwdg: IWDG,
+}
+
+const MAX_PR: u8 = 0b110;
+const MAX_RL: u16 = 0xFFF;
+const KR_ACCESS: u16 = 0x5555;
+const KR_RELOAD: u16 = 0xAAAA;
+const KR_START: u16 = 0xCCCC;
+
+
+impl IndependentWatchdog {
+    /// Wrap and start the watchdog
+    pub fn new(iwdg: IWDG) -> Self {
+        IndependentWatchdog { iwdg }
+    }
+
+    /// Debug independent watchdog stopped when core is halted
+    pub fn stop_on_debug(&self, dbg: &DBG, stop: bool) {
+        dbg.dbgmcu_apb1_fz.modify(|_, w| w.dbg_iwdeg_stop().bit(stop));
+    }
+
+    fn setup(&self, timeout_ms: u32) {
+        let mut pr = 0;
+        while pr < MAX_PR && Self::timeout_period(pr, MAX_RL) < timeout_ms {
+            pr += 1;
+        }
+
+        let max_period = Self::timeout_period(pr, MAX_RL);
+        let max_rl = u32::from(MAX_RL);
+        let rl = (timeout_ms * max_rl / max_period).min(max_rl) as u16;
+
+        self.access_registers(|iwdg| {
+            iwdg.pr.modify(|_,w| w.pr().bits(pr));
+            iwdg.rlr.modify(|_, w| w.rl().bits(rl));
+        });
+    }
+
+    fn is_pr_updating(&self) -> bool {
+        self.iwdg.sr.read().pvu().bit()
+    }
+
+    /// Returns the interval in ms
+    pub fn interval(&self) -> MilliSeconds {
+        while self.is_pr_updating() {}
+
+        let pr = self.iwdg.pr.read().pr().bits();
+        let rl = self.iwdg.rlr.read().rl().bits();
+        let ms = Self::timeout_period(pr, rl);
+        MilliSeconds(ms)
+    }
+
+    /// pr: Prescaler divider bits, rl: reload value
+    ///
+    /// Returns ms
+    fn timeout_period(pr: u8, rl: u16) -> u32 {
+        let divider: u32 = match pr {
+            0b000 => 4,
+            0b001 => 8,
+            0b010 => 16,
+            0b011 => 32,
+            0b100 => 64,
+            0b101 => 128,
+            0b110 => 256,
+            0b111 => 256,
+            _ => unreachable!(),
+        };
+        (u32::from(rl) + 1) * divider / 32
+    }
+
+    fn access_registers<A, F: FnMut(&IWDG) -> A>(&self, mut f: F) -> A {
+        // Unprotect write access to registers
+        self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_ACCESS) });
+        let a = f(&self.iwdg);
+
+        // Protect again
+        self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_RELOAD) });
+        a
+    }
+}
+
+impl WatchdogEnable for IndependentWatchdog {
+    type Time = MilliSeconds;
+
+    fn start<T: Into<Self::Time>>(&mut self, period: T) {
+        self.setup(period.into().0);
+
+        self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_START) });
+    }
+}
+
+impl Watchdog for IndependentWatchdog {
+    fn feed(&mut self) {
+        self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_RELOAD) });
+    }
+}


### PR DESCRIPTION
I've had this in [stm32f429-hal](https://github.com/astro/stm32f429-hal) and now I'm happy to contribute here. There are even improvements like `IndependentWatchdog::stop_on_debug()`. Tested on STM32F429.