### PR TITLE
Accessor for SPI OVR flag

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -831,6 +831,12 @@ macro_rules! hal {
                     self.spi.sr.read().modf().bit_is_set()
                 }
 
+                /// Return `true` if the OVR flag is set, i.e. new data has been received
+                /// whil the receive data register was already filled.
+                pub fn is_ovr(&self) -> bool {
+                    self.spi.sr.read().ovr().bit_is_set()
+                }
+
                 pub fn free(self) -> ($SPIX, PINS) {
                     (self.spi, self.pins)
                 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -832,7 +832,7 @@ macro_rules! hal {
                 }
 
                 /// Return `true` if the OVR flag is set, i.e. new data has been received
-                /// whil the receive data register was already filled.
+                /// while the receive data register was already filled.
                 pub fn is_ovr(&self) -> bool {
                     self.spi.sr.read().ovr().bit_is_set()
                 }


### PR DESCRIPTION
In #82 I added only an accessor for the MODF flag, because I thought it was the only error that could happen using the current API ([see discussion here](https://github.com/stm32-rs/stm32f4xx-hal/pull/82#discussion_r265199725)). However, I just had to find out just know that it is also possible to overrun the SPI by repeatedly calling `send()` without intermediate `read()` calls on the bare `FullDuplex` abstraction (not one of the `Default` blocking implementations from `embedded_hal::blocking::spi{read, write, transfer}).

That's why I added this accessor so users can poll the OVR flag when handling error interrupts. I'm sorry to open a new PR for this, I should have noticed it before.