### PR TITLE
implement device electronic signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Implement IndependentWatchdog for the IWDG peripheral
 
+- Implement reading the device electronic signature from flash
+
 ## [v0.3.0] - 2019-01-14
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,3 +103,5 @@ pub mod timer;
 pub mod watchdog;
 #[cfg(feature = "device-selected")]
 pub mod adc;
+#[cfg(feature = "device-selected")]
+pub mod signature;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -68,3 +68,42 @@ impl FlashSize {
         usize::from(self.kilo_bytes()) * 1024
     }
 }
+
+/// ADC VREF calibration value is stored in at the factory
+#[derive(Debug)]
+#[repr(C)]
+pub struct VrefCal(u16);
+define_ptr_type!(VrefCal, 0x1FFF_7A2A);
+
+impl VrefCal {
+    /// Read calibration value
+    pub fn read(&self) -> u16 {
+        self.0
+    }
+}
+
+/// A temperature reading taken at 30°C stored at the factory
+#[derive(Debug)]
+#[repr(C)]
+pub struct VtempCal30(u16);
+define_ptr_type!(VtempCal30, 0x1FFF_7A2C);
+
+impl VtempCal30 {
+    /// Read calibration value
+    pub fn read(&self) -> u16 {
+        self.0
+    }
+}
+
+/// A temperature reading taken at 110°C stored at the factory
+#[derive(Debug)]
+#[repr(C)]
+pub struct VtempCal110(u16);
+define_ptr_type!(VtempCal110, 0x1FFF_7A2E);
+
+impl VtempCal110 {
+    /// Read calibration value
+    pub fn read(&self) -> u16 {
+        self.0
+    }
+}

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -4,6 +4,21 @@
 
 use core::str::from_utf8_unchecked;
 
+macro_rules! define_ptr_type {
+    ($name: ident, $ptr: expr) => (
+        impl $name {
+            fn ptr() -> *const Self {
+                $ptr as *const _
+            }
+
+            /// Returns a wrapped reference to the value in flash memory
+            pub fn get() -> &'static Self {
+                unsafe { &*Self::ptr() }
+            }
+        }
+    )
+}
+
 /// Uniqure Device ID register
 #[derive(Hash, Debug)]
 #[repr(C)]
@@ -12,17 +27,9 @@ pub struct Uid {
     y: u16,
     waf_lot: [u8; 8],
 }
+define_ptr_type!(Uid, 0x1FFF_7A10);
 
 impl Uid {
-    fn ptr() -> *const Self {
-        0x1FFF_7A10 as *const _
-    }
-
-    /// Returns a wrapped reference to the value in flash memory
-    pub fn get() -> &'static Self {
-        unsafe { &*Self::ptr() }
-    }
-
     /// X coordinate on wafer
     pub fn x(&self) -> u16 {
         self.x
@@ -48,17 +55,9 @@ impl Uid {
 #[derive(Debug)]
 #[repr(C)]
 pub struct FlashSize(u16);
+define_ptr_type!(FlashSize, 0x1FFF_7A22);
 
 impl FlashSize {
-    fn ptr() -> *const Self {
-        0x1FFF_7A22 as *const _
-    }
-
-    /// Returns a wrapped reference to the value in flash memory
-    pub fn get() -> &'static Self {
-        unsafe { &*Self::ptr() }
-    }
-
     /// Read flash size in kilobytes
     pub fn kilo_bytes(&self) -> u16 {
         self.0

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -46,8 +46,10 @@ impl Uid {
     }
 
     /// Lot number
-    pub unsafe fn lot_num(&self) -> &str {
-        from_utf8_unchecked(&self.waf_lot[1..])
+    pub fn lot_num(&self) -> &str {
+        unsafe {
+            from_utf8_unchecked(&self.waf_lot[1..])
+        }
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,0 +1,71 @@
+//! Device electronic signature
+//!
+//! (stored in flash memory)
+
+use core::str::from_utf8_unchecked;
+
+/// Uniqure Device ID register
+#[derive(Hash, Debug)]
+#[repr(C)]
+pub struct Uid {
+    x: u16,
+    y: u16,
+    waf_lot: [u8; 8],
+}
+
+impl Uid {
+    fn ptr() -> *const Self {
+        0x1FFF_7A10 as *const _
+    }
+
+    /// Returns a wrapped reference to the value in flash memory
+    pub fn get() -> &'static Self {
+        unsafe { &*Self::ptr() }
+    }
+
+    /// X coordinate on wafer
+    pub fn x(&self) -> u16 {
+        self.x
+    }
+
+    /// Y coordinate on wafer
+    pub fn y(&self) -> u16 {
+        self.y
+    }
+
+    /// Wafer number
+    pub fn waf_num(&self) -> u8 {
+        self.waf_lot[0].into()
+    }
+
+    /// Lot number
+    pub unsafe fn lot_num(&self) -> &str {
+        from_utf8_unchecked(&self.waf_lot[1..])
+    }
+}
+
+/// Size of integrated flash
+#[derive(Debug)]
+#[repr(C)]
+pub struct FlashSize(u16);
+
+impl FlashSize {
+    fn ptr() -> *const Self {
+        0x1FFF_7A22 as *const _
+    }
+
+    /// Returns a wrapped reference to the value in flash memory
+    pub fn get() -> &'static Self {
+        unsafe { &*Self::ptr() }
+    }
+
+    /// Read flash size in kilobytes
+    pub fn kilo_bytes(&self) -> u16 {
+        self.0
+    }
+
+    /// Read flash size in bytes
+    pub fn bytes(&self) -> usize {
+        usize::from(self.kilo_bytes()) * 1024
+    }
+}


### PR DESCRIPTION
This data is not a peripheral (hence not in SVDs) but in flash memory.

Example use case: generating unique stable device addresses for network communications.

Should exist across the whole f4xx line.