### PR TITLE
Send NACK on I2C read

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -838,13 +838,13 @@ where
         if buffer.len() <= 2 {
 
             // Clear the ack flag and set the pos flag to the nack gets sent
-            // after the next recieved byte
+            // after the next received byte
             self.i2c.cr1.modify(|_, w| w.ack().clear_bit().pos().set_bit());
 
             // Clear addr by reading SR2
             self.i2c.sr2.read();
 
-            // Wait untill both bytes are recived. Byte 1 will be in dr,
+            // Wait until both bytes are received. Byte 1 will be in dr,
             // and byte 2 will be in the shift register
             while {
                 let sr1 = self.i2c.sr1.read();
@@ -895,7 +895,7 @@ where
             // Set the stop bit to finish the transaction
             self.i2c.cr1.modify(|_, w| w.stop().set_bit());
 
-            // Recieve the last 2 bytes
+            // Receive the last 2 bytes
             last[1] = self.recv_byte()?;
             last[2] = self.recv_byte()?;
         }


### PR DESCRIPTION
When writing a driver for the [VL6180x rangefinder](https://www.st.com/en/imaging-and-photonics-solutions/vl6180x.html), I noticed that my stm32f405rg was not sending a NACK at the end of a read sequence. This caused the VL6180x to send an extra byte before the clock stopped, but more importantly, it left the SDA line pulled low for the next I2C operation. This caused the I2C peripheral to think the line was busy, thus not allowing any bytes to be sent.

At first, I fixed this by resetting the I2C peripheral and manually setting both the SDA and SCL lines to a high, open drain configuration after a read. However, I noticed that the stm32f405 reference guide specifies a rather specific sequence to properly send the NACK at the end of a sequence of reading bytes. This can be found on page 850 of the reference guide. This involves clearing the ACK bit during the right byte being read, which depends on the total number of bytes being read. Currently, the I2C read method does not even attempt to send a NACK, so I implemented what the datasheet specifies in the read method. It have been tested with the stm32f405 and a VL6180x, reading 16, 8, 4, 3, 2, and 1 byte(s) of data repeatedly.