### PR TITLE
Update stm32f4 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ features = ["stm32f429", "rt"]
 cortex-m = ">=0.5.8,<0.7"
 cortex-m-rt = "0.6.9"
 nb = "0.1.2"
-stm32f4 = "0.7.1"
+stm32f4 = "0.8.0"
 
 [dependencies.bare-metal]
 version = "0.2.4"

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -805,7 +805,7 @@ macro_rules! hal {
                     rcc.$apbrstr.modify(|_, w| w.$timXrst().clear_bit());
 
                     // Configure TxC1 and TxC2 as captures
-                    tim.ccmr1_output
+                    tim.ccmr1_output()
                         .write(|w| unsafe { w.cc1s().bits(0b01).cc2s().bits(0b01) });
 
                     // enable and configure to capture on rising edge

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -221,7 +221,7 @@ macro_rules! hal {
                     let ticks = self.clocks.$pclk().0 * pclk_mul / frequency;
 
                     let psc = u16((ticks - 1) / (1 << 16)).unwrap();
-                    self.tim.psc.write(|w| unsafe { w.psc().bits(psc) });
+                    self.tim.psc.write(|w| w.psc().bits(psc) );
 
                     let arr = u16(ticks / u32(psc + 1)).unwrap();
                     self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });


### PR DESCRIPTION
Updates the crate to use the latest stm32f4 release.
This fixes my build issues in #107

Builds fine with the stm32f411 feature (the controller I have access to).

Tested compile works with tools\check.py 