### PR TITLE
Add method for clearing TIMx interrupt flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Implemented `Qei` trait
+- Implemented `clear_interrupt()` method for TIM timers
 
 ## [v0.5.0] - 2019-04-27
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -177,11 +177,27 @@ macro_rules! hal {
                 }
 
                 /// Starts listening for an `event`
+                ///
+                /// Note, you will also have to enable the TIM2 interrupt in the NVIC to start
+                /// receiving events.
                 pub fn listen(&mut self, event: Event) {
                     match event {
                         Event::TimeOut => {
                             // Enable update event interrupt
                             self.tim.dier.write(|w| w.uie().set_bit());
+                        }
+                    }
+                }
+
+                /// Clears interrupt associated with `event`.
+                ///
+                /// If the interrupt is not cleared, it will immediately retrigger after
+                /// the ISR has finished.
+                pub fn clear_interrupt(&mut self, event: Event) {
+                    match event {
+                        Event::TimeOut => {
+                            // Clear interrupt flag
+                            self.tim.sr.write(|w| w.uif().clear_bit());
                         }
                     }
                 }


### PR DESCRIPTION
When a TIM interrupt fires, it needs to be cleared, otherwise it will immediately retrigger. This patch adds a HAL method to do so, removing the need for unsafe low-level access.

Example:

```rust
/// This variable holds a reference to TIM2, which will be accessed in the ISR in order
/// to clear the interrupt flag.
static TIMER_TIM2: Mutex<RefCell<Option<Timer<stm32::TIM2>>>> = Mutex::new(RefCell::new(None));

fn main () -> ! {
    // ... setup skipped ...
    let mut timer = Timer::tim2(dp.TIM2, 1.khz(), clocks);
    timer.listen(Event::TimeOut);
    // Store the timer reference in the global variable
    free(|cs| *TIMER_TIM2.borrow(cs).borrow_mut() = Some(timer));
}

#[interrupt]
fn TIM2() {
    free(|cs| {
        // Access the global timer reference and clear the timer interrupt
        if let Some(ref mut tim2) = TIMER_TIM2.borrow(cs).borrow_mut().deref_mut() {
            tim2.clear_interrupt(Event::TimeOut);
        }
    })
}
```