### PR TITLE
Fix clear_interrupt_pending_bit()

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -83,7 +83,7 @@ pub trait ExtiPin {
     fn trigger_on_edge(&mut self, exti: &mut EXTI, level: Edge);
     fn enable_interrupt(&mut self, exti: &mut EXTI);
     fn disable_interrupt(&mut self, exti: &mut EXTI);
-    fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI);
+    fn clear_interrupt_pending_bit(&mut self);
 }
 
 macro_rules! gpio {
@@ -254,8 +254,8 @@ macro_rules! gpio {
                 }
 
                 /// Clear the interrupt pending bit for this pin
-                fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI) {
-                    exti.pr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
+                fn clear_interrupt_pending_bit(&mut self) {
+                    unsafe { (*EXTI::ptr()).pr.write(|w| w.bits(1 << self.i) ) };
                 }
             }
 
@@ -660,8 +660,8 @@ macro_rules! gpio {
                     }
 
                     /// Clear the interrupt pending bit for this pin
-                    fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI) {
-                        exti.pr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
+                    fn clear_interrupt_pending_bit(&mut self) {
+                        unsafe { (*EXTI::ptr()).pr.write(|w| w.bits(1 << $i) ) };
                     }
                 }
 


### PR DESCRIPTION
According to RM0090 12.3.6, a "bit is cleared by programming it to 1".

I have compiled, but not tested this on stm32f4xx. However, I found this issue while porting the ExtiPin trait to stm32f1xx. I have tested this change on my stm32f1xx-hal working copy.

See also https://github.com/stm32-rs/stm32h7xx-hal/pull/41