### PR TITLE
Fix examples, test them in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,6 @@ matrix:
 install:
   - rustup target add thumbv7em-none-eabihf
 
-script: tools/check.py $COMMAND
+script:
+  - tools/check.py $COMMAND
+  - cargo build --examples --features=stm32f411,rt --release

--- a/examples/ssd1306-image.rs
+++ b/examples/ssd1306-image.rs
@@ -1,3 +1,14 @@
+//! Draw Ferris the Rust mascot on an SSD1306 display
+//!
+//! This example requires the `rt` feature to be enabled. For example, to run on an STM32F411 Nucleo
+//! dev board, run the following:
+//!
+//! ```bash
+//! cargo run --features stm32f411,rt --release --example ssd1306-image
+//! ```
+//!
+//! Note that `--release` is required to fix link errors for smaller devices.
+
 #![no_std]
 #![no_main]
 

--- a/examples/ssd1306-image.rs
+++ b/examples/ssd1306-image.rs
@@ -19,14 +19,10 @@ extern crate stm32f4xx_hal as hal;
 
 use cortex_m_rt::ExceptionFrame;
 use cortex_m_rt::{entry, exception};
-use ssd1306::{prelude::*, Builder as SSD1306Builder};
 use embedded_graphics::{image::Image1BPP, prelude::*};
+use ssd1306::{prelude::*, Builder as SSD1306Builder};
 
-use crate::hal::{
-    prelude::*,
-    stm32,
-    i2c::I2c
-};
+use crate::hal::{i2c::I2c, prelude::*, stm32};
 
 #[entry]
 fn main() -> ! {
@@ -98,7 +94,7 @@ fn get_next_rotation(rotation: DisplayRotation) -> DisplayRotation {
         // reset to 0 degrees landscape. On most SSD1306 displays, this means down is towards
         // the flat flex coming out of the display (and up is towards the breakout board pins).
         _ => DisplayRotation::Rotate0,
-    }
+    };
 }
 
 #[exception]

--- a/examples/ssd1306-image.rs
+++ b/examples/ssd1306-image.rs
@@ -30,8 +30,8 @@ fn main() -> ! {
         // Set up I2C - SCL is PB8 and SDA is PB9; they are set to Alternate Function 4
         // as per the STM32F446xC/E datasheet page 60. Pin assignment as per the Nucleo-F446 board.
         let gpiob = dp.GPIOB.split();
-        let scl = gpiob.pb8.into_alternate_af4();
-        let sda = gpiob.pb9.into_alternate_af4();
+        let scl = gpiob.pb8.into_alternate_af4().set_open_drain();
+        let sda = gpiob.pb9.into_alternate_af4().set_open_drain();
         let i2c = I2c::i2c1(dp.I2C1, (scl, sda), 400.khz(), clocks);
 
         // There's a button on PC13. On the Nucleo board, it's pulled up by a 4.7kOhm resistor

--- a/examples/stopwatch-with-ssd1306-and-interrupts.rs
+++ b/examples/stopwatch-with-ssd1306-and-interrupts.rs
@@ -80,10 +80,10 @@ fn main() -> ! {
         });
 
         // Enable interrupts
-        stm32::NVIC::unpend(hal::interrupt::TIM2);
-        stm32::NVIC::unpend(hal::interrupt::EXTI15_10);
+        stm32::NVIC::unpend(hal::stm32::Interrupt::TIM2);
+        stm32::NVIC::unpend(hal::stm32::Interrupt::EXTI15_10);
         unsafe {
-            stm32::NVIC::unmask(hal::interrupt::EXTI15_10);
+            stm32::NVIC::unmask(hal::stm32::Interrupt::EXTI15_10);
         };
 
         let mut delay = Delay::new(cp.SYST, clocks);
@@ -138,8 +138,7 @@ fn TIM2() {
 fn EXTI15_10() {
     free(|cs| {
         let mut btn_ref = BUTTON.borrow(cs).borrow_mut();
-        if let Some(ref mut btn) = btn_ref.deref_mut()
-        {
+        if let Some(ref mut btn) = btn_ref.deref_mut() {
             // We cheat and don't bother checking _which_ exact interrupt line fired - there's only
             // ever going to be one in this example.
             btn.clear_interrupt_pending_bit();
@@ -175,12 +174,12 @@ fn setup_clocks(rcc: Rcc) -> Clocks {
 fn stopwatch_start<'cs>(cs: &'cs CriticalSection) {
     ELAPSED_MS.borrow(cs).replace(0);
     unsafe {
-        stm32::NVIC::unmask(hal::interrupt::TIM2);
+        stm32::NVIC::unmask(hal::stm32::Interrupt::TIM2);
     }
 }
 
 fn stopwatch_stop<'cs>(_cs: &'cs CriticalSection) {
-    stm32::NVIC::mask(hal::interrupt::TIM2);
+    stm32::NVIC::mask(hal::stm32::Interrupt::TIM2);
 }
 
 // Formatting requires the arrayvec crate

--- a/examples/stopwatch-with-ssd1306-and-interrupts.rs
+++ b/examples/stopwatch-with-ssd1306-and-interrupts.rs
@@ -9,7 +9,6 @@
 //!
 //! Note that `--release` is required to fix link errors for smaller devices.
 //!
-//!
 //! Press the User button on an STM32 Nucleo board to start/stop the timer. Pressing the Reset
 //! button will reset the stopwatch to zero.
 //!

--- a/examples/stopwatch-with-ssd1306-and-interrupts.rs
+++ b/examples/stopwatch-with-ssd1306-and-interrupts.rs
@@ -1,7 +1,22 @@
+//! A simple stopwatch app running on an SSD1306 display
+//!
+//! This example requires the `rt` feature to be enabled. For example, to run on an STM32F411 Nucleo
+//! dev board, run the following:
+//!
+//! ```bash
+//! cargo run --features stm32f411,rt --release --example stopwatch-with-ssd1306-and-interrupts
+//! ```
+//!
+//! Note that `--release` is required to fix link errors for smaller devices.
+//!
+//!
+//! Press the User button on an STM32 Nucleo board to start/stop the timer. Pressing the Reset
+//! button will reset the stopwatch to zero.
+//!
+//! Video of this example running: https://imgur.com/a/lQTQFLy
+
 #![no_std]
 #![no_main]
-
-// Video of this example running: https://imgur.com/a/lQTQFLy
 
 extern crate panic_semihosting; // logs messages to the host stderr; requires a debugger
 extern crate stm32f4xx_hal as hal;

--- a/examples/stopwatch-with-ssd1306-and-interrupts.rs
+++ b/examples/stopwatch-with-ssd1306-and-interrupts.rs
@@ -52,8 +52,8 @@ fn main() -> ! {
         let i2c = I2c::i2c1(
             dp.I2C1,
             (
-                gpiob.pb8.into_alternate_af4(),
-                gpiob.pb9.into_alternate_af4(),
+                gpiob.pb8.into_alternate_af4().set_open_drain(),
+                gpiob.pb9.into_alternate_af4().set_open_drain(),
             ),
             400.khz(),
             clocks,


### PR DESCRIPTION
Tested on an STM32F411 Nucleo dev board.

Solution found in #99 to get the examples to actually show something on the display. The Travis command to test the examples should obviously be folded into the Python check script - can someone help me do that? I have zero Python knowledge.

Closes #116 

Cc jamwaffles/ssd1306#100
