### PR TITLE
Add wrapper around SYSCFG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added examples in the examples folder.
+- [breaking-change] Added a wrapper around SYSCFG.
 
 ## [v0.6.0] - 2019-10-19
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,8 @@ pub mod serial;
 #[cfg(feature = "device-selected")]
 pub mod spi;
 #[cfg(feature = "device-selected")]
+pub mod syscfg;
+#[cfg(feature = "device-selected")]
 pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timer;

--- a/src/syscfg.rs
+++ b/src/syscfg.rs
@@ -1,0 +1,20 @@
+use crate::stm32;
+
+pub struct Syscfg {
+    pub(crate) raw: stm32::SYSCFG,
+}
+
+impl Syscfg {
+    pub fn new(syscfg: stm32::SYSCFG) -> Self {
+        let rcc = unsafe {&*stm32::RCC::ptr()};
+
+        // Reset SYSCFG peripheral
+        rcc.apb2rstr.modify(|_, w| w.syscfgrst().set_bit());
+        rcc.apb2rstr.modify(|_, w| w.syscfgrst().clear_bit());
+
+        //// Enable SYSCFG peripheral
+        rcc.apb2enr.write(|w| w.syscfgen().enabled());
+
+        Syscfg { raw: syscfg }
+    }
+}


### PR DESCRIPTION
Move the enabling off the syscfg clock to the new Syscfg wrapper.

With inspiration from stm32l0xx-hal crate. Tested on stm32f401 with external interrupt.