### PR TITLE
Added open drain Alternate modes and ways to construct them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Added more type states for open drain AF modes so we can prevent (potential fatal) I2C misuse
 - [breaking-change] Updated stm32f4 dependency to v0.9.0.
 
 ### Added

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -30,7 +30,13 @@ pub struct AF13;
 pub struct AF14;
 pub struct AF15;
 
+/// Some alternate mode (type state)
 pub struct Alternate<MODE> {
+    _mode: PhantomData<MODE>,
+}
+
+/// Some alternate mode in open drain configuration (type state)
+pub struct AlternateOD<MODE> {
     _mode: PhantomData<MODE>,
 }
 
@@ -100,7 +106,7 @@ macro_rules! gpio {
 
             use crate::stm32::{RCC, EXTI, SYSCFG};
             use super::{
-                Alternate, Floating, GpioExt, Input, OpenDrain, Output, Speed,
+                Alternate, AlternateOD, Floating, GpioExt, Input, OpenDrain, Output, Speed,
                 PullDown, PullUp, PushPull, AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10,
                 AF11, AF12, AF13, AF14, AF15, Analog, Edge, ExtiPin,
             };
@@ -383,6 +389,102 @@ macro_rules! gpio {
                         $PXi { _mode: PhantomData }
                     }
 
+                    /// Configures the pin to operate in AF0 open drain mode
+                    pub fn into_alternate_af0_open_drain(self) -> $PXi<AlternateOD<AF0>> {
+                        _set_alternate_mode($i, 0);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF1 open drain mode
+                    pub fn into_alternate_af1_open_drain(self) -> $PXi<AlternateOD<AF1>> {
+                        _set_alternate_mode($i, 1);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF2 open drain mode
+                    pub fn into_alternate_af2_open_drain(self) -> $PXi<AlternateOD<AF2>> {
+                        _set_alternate_mode($i, 2);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF3 open drain mode
+                    pub fn into_alternate_af3_open_drain(self) -> $PXi<AlternateOD<AF3>> {
+                        _set_alternate_mode($i, 3);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF4 open drain mode
+                    pub fn into_alternate_af4_open_drain(self) -> $PXi<AlternateOD<AF4>> {
+                        _set_alternate_mode($i, 4);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF5 open drain mode
+                    pub fn into_alternate_af5_open_drain(self) -> $PXi<AlternateOD<AF5>> {
+                        _set_alternate_mode($i, 5);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF6 open drain mode
+                    pub fn into_alternate_af6_open_drain(self) -> $PXi<AlternateOD<AF6>> {
+                        _set_alternate_mode($i, 6);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF7 open drain mode
+                    pub fn into_alternate_af7_open_drain(self) -> $PXi<AlternateOD<AF7>> {
+                        _set_alternate_mode($i, 7);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF8 open drain mode
+                    pub fn into_alternate_af8_open_drain(self) -> $PXi<AlternateOD<AF8>> {
+                        _set_alternate_mode($i, 8);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF9 open drain mode
+                    pub fn into_alternate_af9_open_drain(self) -> $PXi<AlternateOD<AF9>> {
+                        _set_alternate_mode($i, 9);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF10 open drain mode
+                    pub fn into_alternate_af10_open_drain(self) -> $PXi<AlternateOD<AF10>> {
+                        _set_alternate_mode($i, 10);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF11 open drain mode
+                    pub fn into_alternate_af11_open_drain(self) -> $PXi<AlternateOD<AF11>> {
+                        _set_alternate_mode($i, 11);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF12 open drain mode
+                    pub fn into_alternate_af12_open_drain(self) -> $PXi<AlternateOD<AF12>> {
+                        _set_alternate_mode($i, 12);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF13 open drain mode
+                    pub fn into_alternate_af13_open_drain(self) -> $PXi<AlternateOD<AF13>> {
+                        _set_alternate_mode($i, 13);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF14 open drain mode
+                    pub fn into_alternate_af14_open_drain(self) -> $PXi<AlternateOD<AF14>> {
+                        _set_alternate_mode($i, 14);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
+                    /// Configures the pin to operate in AF15 open drain mode
+                    pub fn into_alternate_af15_open_drain(self) -> $PXi<AlternateOD<AF15>> {
+                        _set_alternate_mode($i, 15);
+                        $PXi { _mode: PhantomData }.set_open_drain()
+                    }
+
                     /// Configures the pin to operate as a floating input pin
                     pub fn into_floating_input(self) -> $PXi<Input<Floating>> {
                         let offset = 2 * $i;
@@ -540,7 +642,7 @@ macro_rules! gpio {
 
                 impl<MODE> $PXi<Alternate<MODE>> {
                     /// Turns pin alternate configuration pin into open drain
-                    pub fn set_open_drain(self) -> Self {
+                    pub fn set_open_drain(self) -> $PXi<AlternateOD<MODE>> {
                         let offset = $i;
                         unsafe {
                             &(*$GPIOX::ptr()).otyper.modify(|r, w| {
@@ -548,7 +650,7 @@ macro_rules! gpio {
                             })
                         };
 
-                        self
+                        $PXi { _mode: PhantomData }
                     }
                 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -6,6 +6,25 @@ use crate::stm32::i2c1;
     feature = "stm32f401",
     feature = "stm32f405",
     feature = "stm32f407",
+    feature = "stm32f411",
+    feature = "stm32f412",
+    feature = "stm32f413",
+    feature = "stm32f415",
+    feature = "stm32f417",
+    feature = "stm32f423",
+    feature = "stm32f427",
+    feature = "stm32f429",
+    feature = "stm32f437",
+    feature = "stm32f439",
+    feature = "stm32f446",
+    feature = "stm32f469",
+    feature = "stm32f479"
+))]
+use crate::stm32::I2C3;
+#[cfg(any(
+    feature = "stm32f401",
+    feature = "stm32f405",
+    feature = "stm32f407",
     feature = "stm32f410",
     feature = "stm32f411",
     feature = "stm32f412",
@@ -22,25 +41,6 @@ use crate::stm32::i2c1;
     feature = "stm32f479"
 ))]
 use crate::stm32::{I2C1, I2C2, RCC};
-#[cfg(any(
-    feature = "stm32f401",
-    feature = "stm32f405",
-    feature = "stm32f407",
-    feature = "stm32f411",
-    feature = "stm32f412",
-    feature = "stm32f413",
-    feature = "stm32f415",
-    feature = "stm32f417",
-    feature = "stm32f423",
-    feature = "stm32f427",
-    feature = "stm32f429",
-    feature = "stm32f437",
-    feature = "stm32f439",
-    feature = "stm32f446",
-    feature = "stm32f469",
-    feature = "stm32f479"
-))]
-use crate::stm32::I2C3;
 
 use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 
@@ -64,6 +64,25 @@ use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 ))]
 use crate::gpio::gpioa::PA8;
 
+#[cfg(any(
+    feature = "stm32f405",
+    feature = "stm32f407",
+    feature = "stm32f410",
+    feature = "stm32f411",
+    feature = "stm32f412",
+    feature = "stm32f413",
+    feature = "stm32f415",
+    feature = "stm32f417",
+    feature = "stm32f423",
+    feature = "stm32f427",
+    feature = "stm32f429",
+    feature = "stm32f437",
+    feature = "stm32f439",
+    feature = "stm32f446",
+    feature = "stm32f469",
+    feature = "stm32f479"
+))]
+use crate::gpio::gpiob::PB11;
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f410",
@@ -102,27 +121,10 @@ use crate::gpio::gpiob::PB4;
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-use crate::gpio::gpiob::{PB6, PB7, PB8, PB9, PB10};
-#[cfg(any(
-    feature = "stm32f405",
-    feature = "stm32f407",
-    feature = "stm32f410",
-    feature = "stm32f411",
-    feature = "stm32f412",
-    feature = "stm32f413",
-    feature = "stm32f415",
-    feature = "stm32f417",
-    feature = "stm32f423",
-    feature = "stm32f427",
-    feature = "stm32f429",
-    feature = "stm32f437",
-    feature = "stm32f439",
-    feature = "stm32f446",
-    feature = "stm32f469",
-    feature = "stm32f479"
-))]
-use crate::gpio::gpiob::PB11;
+use crate::gpio::gpiob::{PB10, PB6, PB7, PB8, PB9};
 
+#[cfg(any(feature = "stm32f446"))]
+use crate::gpio::gpioc::PC12;
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f405",
@@ -142,10 +144,6 @@ use crate::gpio::gpiob::PB11;
     feature = "stm32f479"
 ))]
 use crate::gpio::gpioc::PC9;
-#[cfg(any(
-    feature = "stm32f446"
-))]
-use crate::gpio::gpioc::PC12;
 
 #[cfg(any(
     feature = "stm32f405",
@@ -179,7 +177,6 @@ use crate::gpio::gpiof::{PF0, PF1};
 ))]
 use crate::gpio::gpioh::{PH4, PH5, PH7, PH8};
 
-use crate::gpio::{Alternate, AF4};
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f410",
@@ -189,6 +186,7 @@ use crate::gpio::{Alternate, AF4};
     feature = "stm32f423"
 ))]
 use crate::gpio::AF9;
+use crate::gpio::{AlternateOD, AF4};
 
 use crate::rcc::Clocks;
 use crate::time::{Hertz, KiloHertz, U32Ext};
@@ -207,7 +205,8 @@ impl<I2c, SCL, SDA> Pins<I2c> for (SCL, SDA)
 where
     SCL: PinScl<I2c>,
     SDA: PinSda<I2c>,
-{}
+{
+}
 
 #[cfg(any(
     feature = "stm32f401",
@@ -228,7 +227,7 @@ where
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinScl<I2C1> for PB6<Alternate<AF4>> {}
+impl PinScl<I2C1> for PB6<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f405",
@@ -248,7 +247,7 @@ impl PinScl<I2C1> for PB6<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinSda<I2C1> for PB7<Alternate<AF4>> {}
+impl PinSda<I2C1> for PB7<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f405",
@@ -268,7 +267,7 @@ impl PinSda<I2C1> for PB7<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinScl<I2C1> for PB8<Alternate<AF4>> {}
+impl PinScl<I2C1> for PB8<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f405",
@@ -288,12 +287,10 @@ impl PinScl<I2C1> for PB8<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinSda<I2C1> for PB9<Alternate<AF4>> {}
+impl PinSda<I2C1> for PB9<AlternateOD<AF4>> {}
 
-#[cfg(any(
-    feature = "stm32f446"
-))]
-impl PinSda<I2C2> for PB3<Alternate<AF4>> {}
+#[cfg(any(feature = "stm32f446"))]
+impl PinSda<I2C2> for PB3<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f410",
@@ -302,7 +299,7 @@ impl PinSda<I2C2> for PB3<Alternate<AF4>> {}
     feature = "stm32f413",
     feature = "stm32f423"
 ))]
-impl PinSda<I2C2> for PB3<Alternate<AF9>> {}
+impl PinSda<I2C2> for PB3<AlternateOD<AF9>> {}
 #[cfg(any(
     feature = "stm32f410",
     feature = "stm32f411",
@@ -310,7 +307,7 @@ impl PinSda<I2C2> for PB3<Alternate<AF9>> {}
     feature = "stm32f413",
     feature = "stm32f423"
 ))]
-impl PinSda<I2C2> for PB9<Alternate<AF9>> {}
+impl PinSda<I2C2> for PB9<AlternateOD<AF9>> {}
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f405",
@@ -330,7 +327,7 @@ impl PinSda<I2C2> for PB9<Alternate<AF9>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinScl<I2C2> for PB10<Alternate<AF4>> {}
+impl PinScl<I2C2> for PB10<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f405",
     feature = "stm32f407",
@@ -349,11 +346,9 @@ impl PinScl<I2C2> for PB10<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinSda<I2C2> for PB11<Alternate<AF4>> {}
-#[cfg(any(
-    feature = "stm32f446"
-))]
-impl PinSda<I2C2> for PC12<Alternate<AF4>> {}
+impl PinSda<I2C2> for PB11<AlternateOD<AF4>> {}
+#[cfg(any(feature = "stm32f446"))]
+impl PinSda<I2C2> for PC12<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f405",
     feature = "stm32f407",
@@ -370,7 +365,7 @@ impl PinSda<I2C2> for PC12<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinScl<I2C2> for PF1<Alternate<AF4>> {}
+impl PinScl<I2C2> for PF1<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f405",
     feature = "stm32f407",
@@ -387,7 +382,7 @@ impl PinScl<I2C2> for PF1<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinSda<I2C2> for PF0<Alternate<AF4>> {}
+impl PinSda<I2C2> for PF0<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f405",
     feature = "stm32f407",
@@ -400,7 +395,7 @@ impl PinSda<I2C2> for PF0<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinScl<I2C2> for PH4<Alternate<AF4>> {}
+impl PinScl<I2C2> for PH4<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f405",
     feature = "stm32f407",
@@ -413,7 +408,7 @@ impl PinScl<I2C2> for PH4<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinSda<I2C2> for PH5<Alternate<AF4>> {}
+impl PinSda<I2C2> for PH5<AlternateOD<AF4>> {}
 
 #[cfg(any(
     feature = "stm32f401",
@@ -433,11 +428,9 @@ impl PinSda<I2C2> for PH5<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinScl<I2C3> for PA8<Alternate<AF4>> {}
-#[cfg(any(
-    feature = "stm32f446"
-))]
-impl PinSda<I2C3> for PB4<Alternate<AF4>> {}
+impl PinScl<I2C3> for PA8<AlternateOD<AF4>> {}
+#[cfg(any(feature = "stm32f446"))]
+impl PinSda<I2C3> for PB4<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f411",
@@ -445,14 +438,14 @@ impl PinSda<I2C3> for PB4<Alternate<AF4>> {}
     feature = "stm32f413",
     feature = "stm32f423"
 ))]
-impl PinSda<I2C3> for PB4<Alternate<AF9>> {}
+impl PinSda<I2C3> for PB4<AlternateOD<AF9>> {}
 #[cfg(any(
     feature = "stm32f411",
     feature = "stm32f412",
     feature = "stm32f413",
     feature = "stm32f423"
 ))]
-impl PinSda<I2C3> for PB8<Alternate<AF9>> {}
+impl PinSda<I2C3> for PB8<AlternateOD<AF9>> {}
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f405",
@@ -471,7 +464,7 @@ impl PinSda<I2C3> for PB8<Alternate<AF9>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinSda<I2C3> for PC9<Alternate<AF4>> {}
+impl PinSda<I2C3> for PC9<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f405",
     feature = "stm32f407",
@@ -484,7 +477,7 @@ impl PinSda<I2C3> for PC9<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinScl<I2C3> for PH7<Alternate<AF4>> {}
+impl PinScl<I2C3> for PH7<AlternateOD<AF4>> {}
 #[cfg(any(
     feature = "stm32f405",
     feature = "stm32f407",
@@ -497,7 +490,7 @@ impl PinScl<I2C3> for PH7<Alternate<AF4>> {}
     feature = "stm32f469",
     feature = "stm32f479"
 ))]
-impl PinSda<I2C3> for PH8<Alternate<AF4>> {}
+impl PinSda<I2C3> for PH8<AlternateOD<AF4>> {}
 
 #[derive(Debug)]
 pub enum Error {
@@ -774,7 +767,9 @@ where
         } {}
 
         // Set up current address, we're trying to talk to
-        self.i2c.dr.write(|w| unsafe { w.bits(u32::from(addr) << 1) });
+        self.i2c
+            .dr
+            .write(|w| unsafe { w.bits(u32::from(addr) << 1) });
 
         // Wait until address was sent
         while self.i2c.sr1.read().addr().bit_is_clear() {}
@@ -801,7 +796,9 @@ where
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
         if let Some((last, buffer)) = buffer.split_last_mut() {
             // Send a START condition and set ACK bit
-            self.i2c.cr1.modify(|_, w| w.start().set_bit().ack().set_bit());
+            self.i2c
+                .cr1
+                .modify(|_, w| w.start().set_bit().ack().set_bit());
 
             // Wait until START condition was generated
             while self.i2c.sr1.read().sb().bit_is_clear() {}
@@ -813,7 +810,9 @@ where
             } {}
 
             // Set up current address, we're trying to talk to
-            self.i2c.dr.write(|w| unsafe { w.bits((u32::from(addr) << 1) + 1) });
+            self.i2c
+                .dr
+                .write(|w| unsafe { w.bits((u32::from(addr) << 1) + 1) });
 
             // Wait until address was sent
             while self.i2c.sr1.read().addr().bit_is_clear() {}
@@ -827,7 +826,9 @@ where
             }
 
             // Prepare to send NACK then STOP after next byte
-            self.i2c.cr1.modify(|_, w| w.ack().clear_bit().stop().set_bit());
+            self.i2c
+                .cr1
+                .modify(|_, w| w.ack().clear_bit().stop().set_bit());
 
             // Receive last byte
             *last = self.recv_byte()?;


### PR DESCRIPTION
This allows us to differentiate between a non open-drain and open-drain
alternate function configuration and require the open-drain variant for
I2C use to prevent hot smoke resulting from a misconfiguration.

Fixes #99

Signed-off-by: Daniel Egger <daniel@eggers-club.de>