### PR TITLE
Implement bit-banding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added examples in the examples folder.
 - Added USB driver.
 - PLL48Clk configuration.
+- Added bit-banding implementation.
 
 ## [v0.6.0] - 2019-10-19
 

--- a/src/bb.rs
+++ b/src/bb.rs
@@ -1,0 +1,48 @@
+//! Bit banding
+//!
+//! Support for the manipulation of peripheral registers through bit-banding.
+//! Not all peripherals are mapped to the bit-banding alias region, the peripheral bit-band region
+//! is from `0x4000_0000` to `0x400F_FFFF`. Bit-banding allows the manipulation of individual bits
+//! atomically.
+
+use core::ptr;
+
+// Start address of the peripheral memory region capable of being addressed by bit-banding
+const PERI_ADDRESS_START: usize = 0x4000_0000;
+const PERI_ADDRESS_END: usize = 0x400F_FFFF;
+
+const PERI_BIT_BAND_BASE: usize = 0x4200_0000;
+
+/// Clears the bit on the provided register without modifying other bits.
+///
+/// # Safety
+///
+/// Some registers have reserved bits which should not be modified.
+pub unsafe fn clear<T>(register: *const T, bit: u8) {
+    write(register, bit, false);
+}
+
+/// Sets the bit on the provided register without modifying other bits.
+///
+/// # Safety
+///
+/// Some registers have reserved bits which should not be modified.
+pub unsafe fn set<T>(register: *const T, bit: u8) {
+    write(register, bit, true);
+}
+
+/// Sets or clears the bit on the provided register without modifying other bits.
+///
+/// # Safety
+///
+/// Some registers have reserved bits which should not be modified.
+pub unsafe fn write<T>(register: *const T, bit: u8, set: bool) {
+    let addr = register as usize;
+
+    assert!(addr >= PERI_ADDRESS_START && addr <= PERI_ADDRESS_END);
+    assert!(bit < 32);
+
+    let bit = bit as usize;
+    let bb_addr = (PERI_BIT_BAND_BASE + (addr - PERI_ADDRESS_START) * 32) + 4 * bit;
+    ptr::write_volatile(bb_addr as *mut u32, if set { 1 } else { 0 });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 #![allow(non_camel_case_types)]
 
 #[cfg(not(feature = "device-selected"))]
-compile_error!("This crate requires one of the following device features enabled:
+compile_error!(
+        "This crate requires one of the following device features enabled:
         stm32f401
         stm32f405
         stm32f407
@@ -19,7 +20,8 @@ compile_error!("This crate requires one of the following device features enabled
         stm32f439
         stm32f446
         stm32f469
-        stm32f479");
+        stm32f479"
+);
 
 pub use embedded_hal as hal;
 
@@ -82,6 +84,10 @@ pub use stm32f4::stm32f469 as stm32;
 pub use crate::stm32::interrupt;
 
 #[cfg(feature = "device-selected")]
+pub mod adc;
+#[cfg(feature = "device-selected")]
+pub mod bb;
+#[cfg(feature = "device-selected")]
 pub mod delay;
 #[cfg(feature = "device-selected")]
 pub mod gpio;
@@ -119,9 +125,13 @@ pub mod otg_hs;
 #[cfg(feature = "device-selected")]
 pub mod prelude;
 #[cfg(feature = "device-selected")]
+pub mod qei;
+#[cfg(feature = "device-selected")]
 pub mod rcc;
 #[cfg(feature = "device-selected")]
 pub mod serial;
+#[cfg(feature = "device-selected")]
+pub mod signature;
 #[cfg(feature = "device-selected")]
 pub mod spi;
 #[cfg(feature = "device-selected")]
@@ -129,10 +139,4 @@ pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timer;
 #[cfg(feature = "device-selected")]
-pub mod qei;
-#[cfg(feature = "device-selected")]
 pub mod watchdog;
-#[cfg(feature = "device-selected")]
-pub mod adc;
-#[cfg(feature = "device-selected")]
-pub mod signature;


### PR DESCRIPTION
I started a PWM implementation for this HAL and since different channels share the same register we need to make sure that only a single channel modifies the register at a time if we want to split them. So I decided to make this PR to pave the way. Also It can be a solution to the problem of the non-atomically modifying of the `RCC` registers during peripheral initialization.

I would appreciate some opinions about this approach. 
CC @therealprof 

PS: Inspired by the implementation in the F1 HAL.