### PR TITLE
Require pll48clk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 
 script:
   - tools/check.py $COMMAND
-  - cargo build --examples --features=stm32f411,rt --release
+  - cargo build --examples --features=stm32f401,rt,usb_fs --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added examples in the examples folder.
 - Added USB driver.
+- PLL48Clk configuration.
 
 ## [v0.6.0] - 2019-10-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ arrayvec = { version = "0.5.1", default-features = false }
 panic-halt = "0.2.0"
 ssd1306 = "0.2.6"
 embedded-graphics = "0.4.9"
+usb-device = "0.2.5"
+usbd-serial = "0.1.0"
 
 [features]
 device-selected = []
@@ -89,3 +91,19 @@ lto = true
 debug = true
 lto = true
 opt-level = "s"
+
+[[example]]
+name = "usb_serial"
+required-features = ["rt", "stm32f401", "usb_fs"]
+
+[[example]]
+name = "delay-blinky"
+required-features = ["rt", "stm32f411"]
+
+[[example]]
+name = "ssd1306-image"
+required-features = ["rt", "stm32f411"]
+
+[[example]]
+name = "stopwatch-with-ssd1306-and-interrupts"
+required-features = ["rt", "stm32f411"]

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -1,0 +1,77 @@
+//! CDC-ACM serial port example using polling in a busy loop.
+//! Target board: any STM32F4 with a OTG FS peripheral and a 25MHz HSE crystal
+#![no_std]
+#![no_main]
+
+use panic_semihosting as _;
+
+use cortex_m_rt::entry;
+use stm32f4xx_hal::otg_fs::{UsbBus, USB};
+use stm32f4xx_hal::{prelude::*, stm32};
+use usb_device::prelude::*;
+
+static mut EP_MEMORY: [u32; 1024] = [0; 1024];
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let rcc = dp.RCC.constrain();
+
+    rcc.cfgr
+        .use_hse(25.mhz())
+        .sysclk(48.mhz())
+        .require_pll48clk()
+        .freeze();
+
+    let gpioa = dp.GPIOA.split();
+
+    let usb = USB {
+        usb_global: dp.OTG_FS_GLOBAL,
+        usb_device: dp.OTG_FS_DEVICE,
+        usb_pwrclk: dp.OTG_FS_PWRCLK,
+        pin_dm: gpioa.pa11.into_alternate_af10(),
+        pin_dp: gpioa.pa12.into_alternate_af10(),
+    };
+
+    let usb_bus = UsbBus::new(usb, unsafe { &mut EP_MEMORY });
+
+    let mut serial = usbd_serial::SerialPort::new(&usb_bus);
+
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .manufacturer("Fake company")
+        .product("Serial port")
+        .serial_number("TEST")
+        .device_class(usbd_serial::USB_CLASS_CDC)
+        .build();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut serial]) {
+            continue;
+        }
+
+        let mut buf = [0u8; 64];
+
+        match serial.read(&mut buf) {
+            Ok(count) if count > 0 => {
+                // Echo back in upper case
+                for c in buf[0..count].iter_mut() {
+                    if 0x61 <= *c && *c <= 0x7a {
+                        *c &= !0x20;
+                    }
+                }
+
+                let mut write_offset = 0;
+                while write_offset < count {
+                    match serial.write(&buf[write_offset..count]) {
+                        Ok(len) if len > 0 => {
+                            write_offset += len;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -371,7 +371,7 @@ impl CFGR {
                 })
         });
 
-        Clocks {
+        let clocks = Clocks {
             hclk: Hertz(hclk),
             pclk1: Hertz(pclk1),
             pclk2: Hertz(pclk2),
@@ -379,7 +379,13 @@ impl CFGR {
             ppre2,
             sysclk: Hertz(sysclk),
             pll48clk,
+        };
+
+        if self.pll48clk {
+            assert!(clocks.is_pll48clk_valid());
         }
+
+        clocks
     }
 }
 
@@ -431,5 +437,14 @@ impl Clocks {
     /// Returns the frequency of the PLL48 clock line
     pub fn pll48clk(&self) -> Option<Hertz> {
         self.pll48clk
+    }
+
+    /// Returns true if the PLL48 clock is within USB
+    /// specifications. It is required to use the USB functionality.
+    pub fn is_pll48clk_valid(&self) -> bool {
+        // USB specification allow +-0.25%
+        self.pll48clk
+            .map(|freq| (48_000_000 - freq.0 as i32).abs() <= 48_000_000 * 25 / 10000)
+            .unwrap_or(false)
     }
 }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,5 +1,5 @@
-use crate::stm32::RCC;
 use crate::stm32::rcc::cfgr::{HPRE_A, SW_A};
+use crate::stm32::RCC;
 
 use crate::time::Hertz;
 
@@ -189,12 +189,12 @@ impl CFGR {
         unsafe {
             let flash = &(*FLASH::ptr());
             // Adjust flash wait states
-            flash.acr.modify(|_, w|
-                w.latency().bits(((sysclk - 1) / flash_latency_step) as u8)
-                .prften().set_bit()
-                .icen().set_bit()
-                .dcen().set_bit()
-            )
+            flash.acr.modify(|_, w| {
+                w.latency().bits(((sysclk - 1) / flash_latency_step) as u8);
+                w.prften().set_bit();
+                w.icen().set_bit();
+                w.dcen().set_bit()
+            })
         }
     }
 
@@ -303,7 +303,9 @@ impl CFGR {
         ))]
         let (pclk1_max, pclk2_max) = (50_000_000, 100_000_000);
 
-        let pclk1 = self.pclk1.unwrap_or_else(|| core::cmp::min(pclk1_max, hclk));
+        let pclk1 = self
+            .pclk1
+            .unwrap_or_else(|| core::cmp::min(pclk1_max, hclk));
         let (ppre1_bits, ppre1) = match (hclk + pclk1 - 1) / pclk1 {
             0 => unreachable!(),
             1 => (0b000, 1),
@@ -318,7 +320,9 @@ impl CFGR {
 
         assert!(pclk1 <= pclk1_max);
 
-        let pclk2 = self.pclk2.unwrap_or_else(|| core::cmp::min(pclk2_max, hclk));
+        let pclk2 = self
+            .pclk2
+            .unwrap_or_else(|| core::cmp::min(pclk2_max, hclk));
         let (ppre2_bits, ppre2) = match (hclk + pclk2 - 1) / pclk2 {
             0 => unreachable!(),
             1 => (0b000, 1),


### PR DESCRIPTION
Tested here, and ported my keyboard using this. Working as expected.

https://github.com/TeXitoi/keyberon-f4/commit/3375e744b7fb6cd476455a52bd423f4f08184d41

So, writing this with this code.

Some hand testing:

```
            .use_hse(25_000.khz())
            .sysclk(84.mhz())
            .require_pll48clk() // same without this

Clocks {
    hclk: Hertz(
        84000000,
    ),
    pclk1: Hertz(
        42000000,
    ),
    pclk2: Hertz(
        84000000,
    ),
    ppre1: 2,
    ppre2: 1,
    sysclk: Hertz(
        84000000,
    ),
    pll48clk: Some(
        Hertz(
            48000000,
        ),
    ),
}

            .use_hse(25_000.khz())
            .sysclk(83.mhz())
            .require_pll48clk()

clocks = Clocks {
    hclk: Hertz(
        84000000,
    ),
    pclk1: Hertz(
        42000000,
    ),
    pclk2: Hertz(
        84000000,
    ),
    ppre1: 2,
    ppre2: 1,
    sysclk: Hertz(
        84000000,
    ),
    pll48clk: Some(
        Hertz(
            48000000,
        ),
    ),
}


            .use_hse(25_000.khz())
            .sysclk(83.mhz())
            //.require_pll48clk()

clocks = Clocks {
    hclk: Hertz(
        83000000,
    ),
    pclk1: Hertz(
        41500000,
    ),
    pclk2: Hertz(
        83000000,
    ),
    ppre1: 2,
    ppre2: 1,
    sysclk: Hertz(
        83000000,
    ),
    pll48clk: Some(
        Hertz(
            47428571,
        ),
    ),
}


            .use_hse(25_001.khz())
            .sysclk(83.mhz())
            .require_pll48clk()

clocks = Clocks {
    hclk: Hertz(
        83857494,
    ),
    pclk1: Hertz(
        41928747,
    ),
    pclk2: Hertz(
        83857494,
    ),
    ppre1: 2,
    ppre2: 1,
    sysclk: Hertz(
        83857494,
    ),
    pll48clk: Some(
        Hertz(
            47918568,
        ),
    ),
}


            .use_hse(25_001.khz())
            .sysclk(83.mhz())
            //.require_pll48clk()

clocks = Clocks {
    hclk: Hertz(
        82989404,
    ),
    pclk1: Hertz(
        41494702,
    ),
    pclk2: Hertz(
        82989404,
    ),
    ppre1: 2,
    ppre2: 1,
    sysclk: Hertz(
        82989404,
    ),
    pll48clk: Some(
        Hertz(
            47422516,
        ),
    ),
}
```

But I can't make the usb_serial example working, it hangs on my dev board in cortex-m-rt in `pre_init`. I don't have any idea why. Tried several things without any success. @Disasm maybe you have an idea?