### PR TITLE
Add Rng interface and an example that uses it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added USB driver.
 - PLL48Clk configuration.
 - Added bit-banding implementation.
+- Added support for RNG peripheral and rand_core, and an example that uses it.
 
 ## [v0.6.0] - 2019-10-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ default-target = "x86_64-unknown-linux-gnu"
 cortex-m = ">=0.5.8,<0.7"
 cortex-m-rt = "0.6.10"
 nb = "0.1.2"
+rand_core = "0.5.1"
 stm32f4 = "0.9.0"
 synopsys-usb-otg = { version = "0.1.0", features = ["cortex-m"], optional = true }
 
@@ -107,3 +108,7 @@ required-features = ["rt", "stm32f411"]
 [[example]]
 name = "stopwatch-with-ssd1306-and-interrupts"
 required-features = ["rt", "stm32f411"]
+
+[[example]]
+name = "rng-display"
+required-features = ["rt", "stm32f407"]

--- a/examples/rng-display.rs
+++ b/examples/rng-display.rs
@@ -1,0 +1,105 @@
+//! Generate random numbers using the RNG peripheral and display the values.
+//! This example is specifically tuned to run correctly on the
+//! stm32f4-discovery board (model STM32F407G-DISC1)
+//! This example requires the `rt` feature to be enabled. For example:
+//!
+//! ```bash
+//! cargo run --release --features stm32f407,rt  --example rng-display
+//! ```
+//!
+//! Note that this example requires the `--release` build flag because it is too
+//! large to fit in the default `memory.x` file provided with this crate.
+
+#![no_std]
+#![no_main]
+
+use stm32f4xx_hal as hal;
+
+#[cfg(not(debug_assertions))]
+use panic_halt as _;
+#[cfg(debug_assertions)]
+use panic_semihosting as _;
+
+use cortex_m_rt::ExceptionFrame;
+use cortex_m_rt::{entry, exception};
+use embedded_graphics::{fonts::Font6x8, prelude::*};
+
+use ssd1306::{prelude::*, Builder as SSD1306Builder};
+
+use hal::{i2c::I2c, prelude::*, stm32};
+use rand_core::RngCore;
+
+use arrayvec::ArrayString;
+use core::fmt;
+
+// dimensions of SSD1306 OLED display known to work
+pub const SCREEN_WIDTH: i32 = 128;
+pub const SCREEN_HEIGHT: i32 = 64;
+pub const FONT_HEIGHT: i32 = 8;
+/// height of embedded font, in pixels
+pub const VCENTER_PIX: i32 = (SCREEN_HEIGHT - FONT_HEIGHT) / 2;
+pub const HINSET_PIX: i32 = 20;
+
+#[entry]
+fn main() -> ! {
+    if let (Some(dp), Some(cp)) = (
+        stm32::Peripherals::take(),
+        cortex_m::peripheral::Peripherals::take(),
+    ) {
+        // Set up the system clock.
+        let rcc = dp.RCC.constrain();
+
+        // Clock configuration is critical for RNG to work properly; otherwise
+        // RNG_SR CECS bit will constantly report an error (if RNG_CLK < HCLK/16)
+        // here we pick a simple clock configuration that ensures the pll48clk,
+        // from which RNG_CLK is derived, is about 48 MHz
+        let clocks = rcc
+            .cfgr
+            .use_hse(8.mhz()) //discovery board has 8 MHz crystal for HSE
+            .sysclk(128.mhz())
+            .freeze();
+
+        let mut delay_source = hal::delay::Delay::new(cp.SYST, clocks);
+
+        // Set up I2C1: SCL is PB8 and SDA is PB9; they are set to Alternate Function 4
+        // as per the STM32F407 datasheet. Pin assignment as per the
+        // stm32f4-discovery (ST32F407G-DISC1) board.
+        let gpiob = dp.GPIOB.split();
+        let scl = gpiob.pb8.into_alternate_af4().set_open_drain();
+        let sda = gpiob.pb9.into_alternate_af4().set_open_drain();
+        let i2c = I2c::i2c1(dp.I2C1, (scl, sda), 400.khz(), clocks);
+
+        // Set up the display
+        let mut disp: GraphicsMode<_> = SSD1306Builder::new().connect_i2c(i2c).into();
+        disp.init().unwrap();
+
+        // enable the RNG peripheral and its clock
+        // this will panic if the clock configuration is unsuitable
+        let mut rand_source = dp.RNG.constrain(clocks);
+        let mut format_buf = ArrayString::<[u8; 20]>::new();
+        loop {
+            //this will continuously report an error if RNG_CLK < HCLK/16
+            let rand_val = rand_source.next_u32();
+
+            format_buf.clear();
+            if fmt::write(&mut format_buf, format_args!("{}", rand_val)).is_ok() {
+                disp.draw(
+                    Font6x8::render_str(format_buf.as_str())
+                        .with_stroke(Some(1u8.into()))
+                        .translate(Coord::new(HINSET_PIX, VCENTER_PIX))
+                        .into_iter(),
+                );
+            }
+            disp.flush().unwrap();
+            //delay a little while between refreshes so the display is readable
+            delay_source.delay_ms(100u8);
+        }
+    }
+
+    loop {}
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,18 @@ pub mod otg_fs;
     )
 ))]
 pub mod otg_hs;
+
+#[cfg(all(
+    feature = "device-selected",
+    not(any(
+        feature = "stm32f401",
+        feature = "stm32f410",
+        feature = "stm32f411",
+        feature = "stm32f446",
+    ))
+))]
+pub mod rng;
+
 #[cfg(feature = "device-selected")]
 pub mod prelude;
 #[cfg(feature = "device-selected")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,4 +7,14 @@ pub use embedded_hal::prelude::*;
 pub use crate::gpio::GpioExt as _stm32f4xx_hal_gpio_GpioExt;
 pub use crate::i2c::Pins as _stm32f4xx_hal_i2c_Pins;
 pub use crate::rcc::RccExt as _stm32f4xx_hal_rcc_RccExt;
+#[cfg(all(
+    feature = "device-selected",
+    not(any(
+        feature = "stm32f401",
+        feature = "stm32f410",
+        feature = "stm32f411",
+        feature = "stm32f446",
+    ))
+))]
+pub use crate::rng::RngExt as _stm32f4xx_hal_rng_RngExt;
 pub use crate::time::U32Ext as _stm32f4xx_hal_time_U32Ext;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,129 @@
+use core::cmp;
+use core::mem;
+
+use crate::hal::blocking::rng;
+use crate::rcc::Clocks;
+use crate::stm32;
+use crate::stm32::RNG;
+use crate::time::U32Ext;
+use core::num::NonZeroU32;
+use core::ops::Shl;
+use rand_core::RngCore;
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// The RNG_CLK was not correctly detected (fRNG_CLK< fHCLK/16).
+    /// See CECS in RNG peripheral documentation.
+    ClockError = 2,
+    /// RNG detected more than 64 consecutive bits of the same value (0 or 1) OR
+    /// more than 32 consecutive 01 pairs.
+    /// See SECS in RNG peripheral documentation.
+    SeedError = 4,
+}
+
+impl From<ErrorKind> for rand_core::Error {
+    fn from(err: ErrorKind) -> rand_core::Error {
+        let err_code = NonZeroU32::new(rand_core::Error::CUSTOM_START + err as u32).unwrap();
+        rand_core::Error::from(err_code)
+    }
+}
+
+pub trait RngExt {
+    fn constrain(self, clocks: Clocks) -> Rng;
+}
+
+impl RngExt for RNG {
+    /// Enable RNG_CLK and the RNG peripheral.
+    /// Note that clocks must already be configured such that RNG_CLK is not less than 1/16 HCLK,
+    /// otherwise all reads of the RNG would return a ClockError (CECS error).
+    /// This function will panic if pll48clk < 1/16 hclk.
+    fn constrain(self, clocks: Clocks) -> Rng {
+        let rcc = unsafe { &*stm32::RCC::ptr() };
+
+        cortex_m::interrupt::free(|_| {
+            // enable RNG_CLK (peripheral clock)
+            rcc.ahb2enr.modify(|_, w| w.rngen().enabled());
+            // give RNG_CLK time to start
+            let _ = rcc.ahb2enr.read().rngen().is_enabled();
+
+            // reset the RNG
+            rcc.ahb2rstr.modify(|_, w| w.rngrst().set_bit());
+            rcc.ahb2rstr.modify(|_, w| w.rngrst().clear_bit());
+
+            // verify the clock configuration is valid
+            let hclk = clocks.hclk();
+            let rng_clk = clocks.pll48clk().unwrap_or(0u32.hz());
+            assert!(rng_clk.0 >= (hclk.0 / 16));
+
+            // enable the RNG peripheral
+            self.cr.modify(|_, w| w.rngen().set_bit());
+        });
+
+        Rng { rb: self }
+    }
+}
+
+pub struct Rng {
+    rb: RNG,
+}
+
+impl Rng {
+    /// Returns 32 bits of random data from RNDATA, or error.
+    /// May fail if, for example RNG_CLK is misconfigured.
+    fn next_random_word(&mut self) -> Result<u32, ErrorKind> {
+        loop {
+            let status = self.rb.sr.read();
+            if status.cecs().bit() {
+                return Err(ErrorKind::ClockError);
+            }
+            if status.secs().bit() {
+                return Err(ErrorKind::SeedError);
+            }
+            if status.drdy().bit() {
+                return Ok(self.rb.dr.read().rndata().bits());
+            }
+        }
+    }
+
+    pub fn release(self) -> RNG {
+        self.rb
+    }
+}
+
+impl rng::Read for Rng {
+    type Error = rand_core::Error;
+
+    fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.try_fill_bytes(buffer)
+    }
+}
+
+impl RngCore for Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.next_random_word().unwrap()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let w1 = self.next_u32();
+        let w2 = self.next_u32();
+        (w1 as u64).shl(32) | (w2 as u64)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.try_fill_bytes(dest).unwrap()
+    }
+
+    /// Fills buffer with random values, or returns an error
+    fn try_fill_bytes(&mut self, buffer: &mut [u8]) -> Result<(), rand_core::Error> {
+        const BATCH_SIZE: usize = 4 / mem::size_of::<u8>();
+        let mut i = 0_usize;
+        while i < buffer.len() {
+            let random_word = self.next_random_word()?;
+            let bytes = random_word.to_ne_bytes();
+            let n = cmp::min(BATCH_SIZE, buffer.len() - i);
+            buffer[i..i + n].copy_from_slice(&bytes[..n]);
+            i += n;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Enables use of the RNG (random number generator) peripheral available on some stm32f4 chips. 

This PR includes an example openocd configuration for running the example. 
