### PR TITLE
Wait for the new prescalers values to take effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Wait 16 cycles after setting prescalers for some clock domains to follow manual.
+
 ## [v0.7.0] - 2020-03-07
 
 ### Changed


### PR DESCRIPTION
According to the manual:

>The clocks are divided with the new prescaler factor from 1 to 16 AHB cycles after write.

Switching the system clock before that can cause problems since some clock domains have maximum allowed values.
