### PR TITLE
add otg_fs support for stm32f411

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ pub mod i2c;
         feature = "stm32f401",
         feature = "stm32f405",
         feature = "stm32f407",
+        feature = "stm32f411",
         feature = "stm32f415",
         feature = "stm32f417",
         feature = "stm32f427",


### PR DESCRIPTION
Tested USB device support for STM32411E device using STM32F411E Discovery board. Serial USB example works on STM32F411E (see https://github.com/ericevenchick/stm32-usbd-examples).