### PR TITLE
Update to embedded-hal v1.0.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ default-features = false
 version = "1.0.2"
 
 [dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
+version = "=1.0.0-alpha.1"
 
 [dev-dependencies]
 panic-semihosting = "0.5.3"

--- a/examples/delay-blinky.rs
+++ b/examples/delay-blinky.rs
@@ -31,10 +31,10 @@ fn main() -> ! {
 
         loop {
             // On for 1s, off for 1s.
-            led.set_high().unwrap();
-            delay.delay_ms(1000_u32);
-            led.set_low().unwrap();
-            delay.delay_ms(1000_u32);
+            led.try_set_high().unwrap();
+            delay.try_delay_ms(1000_u32).unwrap();
+            led.try_set_low().unwrap();
+            delay.try_delay_ms(1000_u32).unwrap();
         }
     }
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -24,9 +24,9 @@ fn main() -> ! {
 
         let pwm = pwm::tim1(dp.TIM1, channels, clocks, 20u32.khz());
         let (mut ch1, _ch2) = pwm;
-        let max_duty = ch1.get_max_duty();
-        ch1.set_duty(max_duty / 2);
-        ch1.enable();
+        let max_duty = ch1.try_get_max_duty().unwrap();
+        ch1.try_set_duty(max_duty / 2);
+        ch1.try_enable();
     }
 
     loop {

--- a/examples/rng-display.rs
+++ b/examples/rng-display.rs
@@ -99,7 +99,7 @@ fn main() -> ! {
             }
             disp.flush().unwrap();
             //delay a little while between refreshes so the display is readable
-            delay_source.delay_ms(100u8);
+            delay_source.try_delay_ms(100u8).unwrap();
         }
     }
 

--- a/examples/timer-syst.rs
+++ b/examples/timer-syst.rs
@@ -1,4 +1,4 @@
-//! Start and stop a periodic system timer.
+//! Start and stop a periodic system timer.try_
 //!
 //! This example should run on all stm32f4xx boards but it was tested with
 //! stm32f4-discovery board (model STM32F407G-DISC1).
@@ -36,29 +36,29 @@ fn main() -> ! {
 
     hprintln!("hello!").unwrap();
     // wait until timer expires
-    nb::block!(timer.wait()).unwrap();
+    nb::block!(timer.try_wait()).unwrap();
     hprintln!("timer expired 1").unwrap();
 
     // the function syst() creates a periodic timer, so it is automatically
     // restarted
-    nb::block!(timer.wait()).unwrap();
+    nb::block!(timer.try_wait()).unwrap();
     hprintln!("timer expired 2").unwrap();
 
     // cancel current timer
-    timer.cancel().unwrap();
+    timer.try_cancel().unwrap();
 
     // start it again
-    timer.start(24.hz());
-    nb::block!(timer.wait()).unwrap();
+    timer.try_start(24.hz());
+    nb::block!(timer.try_wait()).unwrap();
     hprintln!("timer expired 3").unwrap();
 
-    timer.cancel().unwrap();
-    let cancel_outcome = timer.cancel();
+    timer.try_cancel().unwrap();
+    let cancel_outcome = timer.try_cancel();
     assert_eq!(cancel_outcome, Err(timer::Error::Disabled));
     hprintln!("ehy, you cannot cancel a timer two times!").unwrap();
     // this time the timer was not restarted, therefore this function should
     // wait forever
-    nb::block!(timer.wait()).unwrap();
+    nb::block!(timer.try_wait()).unwrap();
     // you should never see this print
     hprintln!("if you see this there is something wrong").unwrap();
     panic!();

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -26,7 +26,7 @@ macro_rules! adc_pins {
         $(
             impl Channel<stm32::$adc> for $pin {
                 type ID = u8;
-                fn channel() -> u8 { $chan }
+                const CHANNEL: Self::ID = $chan;
             }
         )+
     };
@@ -665,7 +665,7 @@ macro_rules! adc {
                     }
 
                     let vref_cal = VrefCal::get().read();
-                    let vref_samp = self.read(&mut Vref).unwrap(); //This can't actually fail, it's just in a result to satisfy hal trait
+                    let vref_samp = self.try_read(&mut Vref).unwrap(); //This can't actually fail, it's just in a result to satisfy hal trait
 
                     self.calibrated_vdda = (VDDA_CALIB * u32::from(vref_cal)) / u32::from(vref_samp);
                     if !vref_en {
@@ -873,7 +873,7 @@ macro_rules! adc {
                         }
                     });
 
-                    let channel = CHANNEL::channel();
+                    let channel = CHANNEL::CHANNEL;
 
                     //Set the channel in the right sequence field
                     match sequence {
@@ -976,7 +976,7 @@ macro_rules! adc {
             {
                 type Error = ();
 
-                fn read(&mut self, pin: &mut PIN) -> nb::Result<u16, Self::Error> {
+                fn try_read(&mut self, pin: &mut PIN) -> nb::Result<u16, Self::Error> {
                     let enabled = self.is_enabled();
                     if !enabled {
                         self.enable();

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,6 +1,8 @@
 //! Delays
 
 use cast::u32;
+use core::convert::Infallible;
+
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
 
@@ -28,25 +30,33 @@ impl Delay {
 }
 
 impl DelayMs<u32> for Delay {
-    fn delay_ms(&mut self, ms: u32) {
-        self.delay_us(ms * 1_000);
+    type Error = Infallible;
+
+    fn try_delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+        self.try_delay_us(ms * 1_000)
     }
 }
 
 impl DelayMs<u16> for Delay {
-    fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(u32(ms));
+    type Error = Infallible;
+
+    fn try_delay_ms(&mut self, ms: u16) -> Result<(), Self::Error> {
+        self.try_delay_ms(u32(ms))
     }
 }
 
 impl DelayMs<u8> for Delay {
-    fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(u32(ms));
+    type Error = Infallible;
+
+    fn try_delay_ms(&mut self, ms: u8) -> Result<(), Self::Error> {
+        self.try_delay_ms(u32(ms))
     }
 }
 
 impl DelayUs<u32> for Delay {
-    fn delay_us(&mut self, us: u32) {
+    type Error = Infallible;
+
+    fn try_delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
         // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
         const MAX_RVR: u32 = 0x00FF_FFFF;
 
@@ -70,17 +80,23 @@ impl DelayUs<u32> for Delay {
 
             self.syst.disable_counter();
         }
+
+        Ok(())
     }
 }
 
 impl DelayUs<u16> for Delay {
-    fn delay_us(&mut self, us: u16) {
-        self.delay_us(u32(us))
+    type Error = Infallible;
+
+    fn try_delay_us(&mut self, us: u16) -> Result<(), Self::Error> {
+        self.try_delay_us(u32(us))
     }
 }
 
 impl DelayUs<u8> for Delay {
-    fn delay_us(&mut self, us: u8) {
-        self.delay_us(u32(us))
+    type Error = Infallible;
+
+    fn try_delay_us(&mut self, us: u8) -> Result<(), Self::Error> {
+        self.try_delay_us(u32(us))
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -244,7 +244,7 @@ macro_rules! gpio {
             use core::marker::PhantomData;
             use core::convert::Infallible;
 
-            use embedded_hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin, toggleable};
+            use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin, toggleable};
             use crate::stm32::$GPIOX;
 
             use crate::stm32::{RCC, EXTI, SYSCFG};
@@ -293,13 +293,13 @@ macro_rules! gpio {
             impl<MODE> OutputPin for $PXx<Output<MODE>> {
                 type Error = Infallible;
 
-                fn set_high(&mut self) -> Result<(), Self::Error> {
+                fn try_set_high(&mut self) -> Result<(), Self::Error> {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << self.i)) };
                     Ok(())
                 }
 
-                fn set_low(&mut self) -> Result<(), Self::Error> {
+                fn try_set_low(&mut self) -> Result<(), Self::Error> {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (self.i + 16))) };
                     Ok(())
@@ -307,11 +307,11 @@ macro_rules! gpio {
             }
 
             impl<MODE> StatefulOutputPin for $PXx<Output<MODE>> {
-                fn is_set_high(&self) -> Result<bool, Self::Error> {
-                    self.is_set_low().map(|v| !v)
+                fn try_is_set_high(&self) -> Result<bool, Self::Error> {
+                    self.try_is_set_low().map(|v| !v)
                 }
 
-                fn is_set_low(&self) -> Result<bool, Self::Error> {
+                fn try_is_set_low(&self) -> Result<bool, Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     Ok(unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << self.i) == 0 })
                 }
@@ -322,11 +322,11 @@ macro_rules! gpio {
             impl<MODE> InputPin for $PXx<Output<MODE>> {
                 type Error = Infallible;
 
-                fn is_high(&self) -> Result<bool, Self::Error> {
-                    self.is_low().map(|v| !v)
+                fn try_is_high(&self) -> Result<bool, Self::Error> {
+                    self.try_is_low().map(|v| !v)
                 }
 
-                fn is_low(&self) -> Result<bool, Self::Error> {
+                fn try_is_low(&self) -> Result<bool, Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 })
                 }
@@ -335,11 +335,11 @@ macro_rules! gpio {
             impl<MODE> InputPin for $PXx<Input<MODE>> {
                 type Error = Infallible;
 
-                fn is_high(&self) -> Result<bool, Self::Error> {
-                    self.is_low().map(|v| !v)
+                fn try_is_high(&self) -> Result<bool, Self::Error> {
+                    self.try_is_low().map(|v| !v)
                 }
 
-                fn is_low(&self) -> Result<bool, Self::Error> {
+                fn try_is_low(&self) -> Result<bool, Self::Error> {
                     // NOTE(unsafe) atomic read with no side effects
                     Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 })
                 }
@@ -754,13 +754,13 @@ macro_rules! gpio {
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
                     type Error = Infallible;
 
-                    fn set_high(&mut self) -> Result<(), Self::Error> {
+                    fn try_set_high(&mut self) -> Result<(), Self::Error> {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) };
                         Ok(())
                     }
 
-                    fn set_low(&mut self) -> Result<(), Self::Error> {
+                    fn try_set_low(&mut self) -> Result<(), Self::Error> {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << ($i + 16))) };
                         Ok(())
@@ -768,11 +768,11 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> StatefulOutputPin for $PXi<Output<MODE>> {
-                    fn is_set_high(&self) -> Result<bool, Self::Error> {
-                        self.is_set_low().map(|v| !v)
+                    fn try_is_set_high(&self) -> Result<bool, Self::Error> {
+                        self.try_is_set_low().map(|v| !v)
                     }
 
-                    fn is_set_low(&self) -> Result<bool, Self::Error> {
+                    fn try_is_set_low(&self) -> Result<bool, Self::Error> {
                         // NOTE(unsafe) atomic read with no side effects
                         Ok(unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << $i) == 0 })
                     }
@@ -783,11 +783,11 @@ macro_rules! gpio {
                 impl<MODE> InputPin for $PXi<Output<MODE>> {
                     type Error = Infallible;
 
-                    fn is_high(&self) -> Result<bool, Self::Error> {
-                        self.is_low().map(|v| !v)
+                    fn try_is_high(&self) -> Result<bool, Self::Error> {
+                        self.try_is_low().map(|v| !v)
                     }
 
-                    fn is_low(&self) -> Result<bool, Self::Error> {
+                    fn try_is_low(&self) -> Result<bool, Self::Error> {
                         // NOTE(unsafe) atomic read with no side effects
                         Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 })
                     }
@@ -796,11 +796,11 @@ macro_rules! gpio {
                 impl<MODE> InputPin for $PXi<Input<MODE>> {
                     type Error = Infallible;
 
-                    fn is_high(&self) -> Result<bool, Self::Error> {
-                        self.is_low().map(|v| !v)
+                    fn try_is_high(&self) -> Result<bool, Self::Error> {
+                        self.try_is_low().map(|v| !v)
                     }
 
-                    fn is_low(&self) -> Result<bool, Self::Error> {
+                    fn try_is_low(&self) -> Result<bool, Self::Error> {
                         // NOTE(unsafe) atomic read with no side effects
                         Ok(unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 })
                     }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -905,9 +905,14 @@ where
 {
     type Error = Error;
 
-    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.write_bytes(addr, bytes)?;
-        self.read(addr, buffer)?;
+    fn try_write_read(
+        &mut self,
+        addr: u8,
+        bytes: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        self.try_write(addr, bytes)?;
+        self.try_read(addr, buffer)?;
 
         Ok(())
     }
@@ -919,7 +924,7 @@ where
 {
     type Error = Error;
 
-    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+    fn try_write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         self.write_bytes(addr, bytes)?;
 
         // Send a STOP condition
@@ -939,7 +944,7 @@ where
 {
     type Error = Error;
 
-    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+    fn try_read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
         if let Some((last, buffer)) = buffer.split_last_mut() {
             // Send a START condition and set ACK bit
             self.i2c

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
-pub use embedded_hal::digital::v2::InputPin as _embedded_hal_digital_v2_InputPin;
-pub use embedded_hal::digital::v2::OutputPin as _embedded_hal_digital_v2_OutputPin;
-pub use embedded_hal::digital::v2::StatefulOutputPin as _embedded_hal_digital_v2_StatefulOutputPin;
-pub use embedded_hal::digital::v2::ToggleableOutputPin as _embedded_hal_digital_v2_ToggleableOutputPin;
+pub use embedded_hal::digital::InputPin as _embedded_hal_digital_v2_InputPin;
+pub use embedded_hal::digital::OutputPin as _embedded_hal_digital_v2_OutputPin;
+pub use embedded_hal::digital::StatefulOutputPin as _embedded_hal_digital_v2_StatefulOutputPin;
+pub use embedded_hal::digital::ToggleableOutputPin as _embedded_hal_digital_v2_ToggleableOutputPin;
 pub use embedded_hal::prelude::*;
 
 #[cfg(all(

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1,4 +1,5 @@
 use cast::{u16, u32};
+use core::convert::Infallible;
 use core::{marker::PhantomData, mem::MaybeUninit};
 
 #[cfg(any(
@@ -220,119 +221,135 @@ macro_rules! pwm_all_channels {
                 unsafe { MaybeUninit::uninit().assume_init() }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C1> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C1> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty.into())) };
+                    Ok(())
                 }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C2> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C2> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 4) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 4) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 4) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 4) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty.into())) };
+                    Ok(())
                 }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C3> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C3> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 8) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 8) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 8) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 8) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty.into())) };
+                    Ok(())
                 }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C4> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C4> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 12) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 12) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 12) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 12) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr4.read().ccr().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr4.read().ccr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr().bits(duty.into())) };
+                    Ok(())
                 }
             }
         )+
@@ -397,61 +414,69 @@ macro_rules! pwm_2_channels {
                 unsafe { MaybeUninit::uninit().assume_init() }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C1> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C1> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty.into())) };
+                    Ok(())
                 }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C2> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C2> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 4) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 4) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 4) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 4) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty.into())) };
+                    Ok(())
                 }
             }
         )+
@@ -509,32 +534,36 @@ macro_rules! pwm_1_channel {
                 unsafe { MaybeUninit::uninit().assume_init() }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C1> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C1> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty.into())) };
+                    Ok(())
                 }
             }
         )+
@@ -608,119 +637,135 @@ macro_rules! pwm_tim5_f410 {
                 unsafe { MaybeUninit::uninit().assume_init() }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C1> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C1> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 0) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 0) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr1_l().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr1.read().ccr1_l().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr_l().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr_l().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr1_l().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr1_l().bits(duty.into())) };
+                    Ok(())
                 }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C2> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C2> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 4) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 4) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 4) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 4) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr1_l().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr2.read().ccr1_l().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr_l().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr_l().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr1_l().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr1_l().bits(duty.into())) };
+                    Ok(())
                 }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C3> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C3> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 8) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 8) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 8) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 8) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr3.read().ccr1_l().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr3.read().ccr1_l().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr_l().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr_l().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr1_l().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr1_l().bits(duty.into())) };
+                    Ok(())
                 }
             }
 
-            impl hal::PwmPin for PwmChannels<$TIMX, C4> {
+            impl hal::pwm::PwmPin for PwmChannels<$TIMX, C4> {
+                type Error = Infallible;
                 type Duty = u16;
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn disable(&mut self) {
-                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 12) }
+                fn try_disable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::clear(&(*$TIMX::ptr()).ccer, 12) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn enable(&mut self) {
-                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 12) }
+                fn try_enable(&mut self) -> Result<(), Self::Error> {
+                    unsafe { bb::set(&(*$TIMX::ptr()).ccer, 12) };
+                    Ok(())
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).ccr4.read().ccr1_l().bits() as u16 }
+                fn try_get_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).ccr4.read().ccr1_l().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
-                fn get_max_duty(&self) -> u16 {
-                    unsafe { (*$TIMX::ptr()).arr.read().arr_l().bits() as u16 }
+                fn try_get_max_duty(&self) -> Result<u16, Self::Error> {
+                    Ok(unsafe { (*$TIMX::ptr()).arr.read().arr_l().bits() as u16 })
                 }
 
                 //NOTE(unsafe) atomic write with no side effects
-                fn set_duty(&mut self, duty: u16) {
-                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr1_l().bits(duty.into())) }
+                fn try_set_duty(&mut self, duty: u16) -> Result<(), Self::Error> {
+                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr1_l().bits(duty.into())) };
+                    Ok(())
                 }
             }
         )+

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -1,6 +1,7 @@
 //! # Quadrature Encoder Interface
-use crate::hal::{self, Direction};
+use crate::hal::{self, qei::Direction};
 use crate::stm32::RCC;
+use core::convert::Infallible;
 
 #[cfg(any(
     feature = "stm32f401",
@@ -126,18 +127,19 @@ macro_rules! hal {
                 }
             }
 
-            impl<PINS> hal::Qei for Qei<$TIM, PINS> {
+            impl<PINS> hal::qei::Qei for Qei<$TIM, PINS> {
+                type Error = Infallible;
                 type Count = $bits;
 
-                fn count(&self) -> $bits {
-                    self.tim.cnt.read().bits() as $bits
+                fn try_count(&self) -> Result<Self::Count, Self::Error> {
+                    Ok(self.tim.cnt.read().bits() as $bits)
                 }
 
-                fn direction(&self) -> Direction {
+                fn try_direction(&self) -> Result<Direction, Self::Error> {
                     if self.tim.cr1.read().dir().bit_is_clear() {
-                        hal::Direction::Upcounting
+                        Ok(Direction::Upcounting)
                     } else {
-                        hal::Direction::Downcounting
+                        Ok(Direction::Downcounting)
                     }
                 }
             }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -93,7 +93,7 @@ impl Rng {
 impl rng::Read for Rng {
     type Error = rand_core::Error;
 
-    fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+    fn try_read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
         self.try_fill_bytes(buffer)
     }
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1013,7 +1013,7 @@ where
 {
     type Error = Error;
 
-    fn read(&mut self) -> nb::Result<u8, Error> {
+    fn try_read(&mut self) -> nb::Result<u8, Error> {
         let sr = self.spi.sr.read();
 
         Err(if sr.ovr().bit_is_set() {
@@ -1031,7 +1031,7 @@ where
         })
     }
 
-    fn send(&mut self, byte: u8) -> nb::Result<(), Error> {
+    fn try_send(&mut self, byte: u8) -> nb::Result<(), Error> {
         let sr = self.spi.sr.read();
 
         Err(if sr.ovr().bit_is_set() {

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -5,6 +5,7 @@ use crate::{
     stm32::{DBGMCU, IWDG},
     time::MilliSeconds,
 };
+use core::convert::Infallible;
 
 /// Wraps the Independent Watchdog (IWDG) peripheral
 pub struct IndependentWatchdog {
@@ -88,17 +89,24 @@ impl IndependentWatchdog {
 }
 
 impl WatchdogEnable for IndependentWatchdog {
+    type Error = Infallible;
     type Time = MilliSeconds;
 
-    fn start<T: Into<Self::Time>>(&mut self, period: T) {
+    fn try_start<T: Into<Self::Time>>(&mut self, period: T) -> Result<(), Self::Error> {
         self.setup(period.into().0);
 
         self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_START) });
+
+        Ok(())
     }
 }
 
 impl Watchdog for IndependentWatchdog {
-    fn feed(&mut self) {
+    type Error = Infallible;
+
+    fn try_feed(&mut self) -> Result<(), Self::Error> {
         self.iwdg.kr.write(|w| unsafe { w.key().bits(KR_RELOAD) });
+
+        Ok(())
     }
 }


### PR DESCRIPTION
I needed to have the crate updated to use the new embedded-hal traits for the development of the I2S proposal (https://github.com/rust-embedded/embedded-hal/pull/204).

I'm new to the Rust and Rust embedded eco systems and not familiar with how the updates are usually done to all the HAL crates under stm32-rs, but I'll be glad to provide this if helpful. I'll leave it open for comments and further work until embedded-hal has released its next version (1.0?).

- [ ] Return correct errors where possible. Needs work to understand where we can get statuses from the MCU etc.
- [x] Decide which error to use for functions that is not expected to fail. Suggestions?
- [ ] Handle ignored return values in a idiomatic way. Suggestions?