### PR TITLE
Make SDIO bus frequency selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Allow specifying the desired SDIO bus speed during initialization
+
 ## [v0.8.1] - 2020-05-10
 
 ### Added

--- a/examples/sd.rs
+++ b/examples/sd.rs
@@ -5,7 +5,12 @@ use cortex_m_rt::entry;
 use cortex_m_semihosting::{hprint, hprintln};
 use panic_semihosting as _;
 
-use stm32f4xx_hal::{delay, prelude::*, sdio::Sdio, stm32};
+use stm32f4xx_hal::{
+    delay,
+    prelude::*,
+    sdio::{ClockFreq, Sdio},
+    stm32,
+};
 
 #[entry]
 fn main() -> ! {
@@ -42,7 +47,7 @@ fn main() -> ! {
 
     // Wait for card to be ready
     loop {
-        match sdio.init_card() {
+        match sdio.init_card(ClockFreq::F24Mhz) {
             Ok(_) => break,
             Err(_err) => (),
         }

--- a/src/sdio.rs
+++ b/src/sdio.rs
@@ -116,7 +116,6 @@ enum PowerCtrl {
 }
 
 /// Clock frequency of a SDIO bus.
-#[allow(dead_code)]
 pub enum ClockFreq {
     F24Mhz = 0,
     F16Mhz = 1,

--- a/src/sdio.rs
+++ b/src/sdio.rs
@@ -115,8 +115,9 @@ enum PowerCtrl {
     On = 0b11,
 }
 
+/// Clock frequency of a SDIO bus.
 #[allow(dead_code)]
-enum ClockFreq {
+pub enum ClockFreq {
     F24Mhz = 0,
     F16Mhz = 1,
     F12Mhz = 2,
@@ -285,8 +286,8 @@ impl Sdio {
         }
     }
 
-    /// initialize card
-    pub fn init_card(&mut self) -> Result<(), Error> {
+    /// Initializes card (if present) and sets the bus at the specified frequency.
+    pub fn init_card(&mut self, freq: ClockFreq) -> Result<(), Error> {
         // Enable power to card
         self.sdio
             .power
@@ -361,7 +362,7 @@ impl Sdio {
 
         self.get_scr(&mut card)?;
 
-        self.set_bus(self.bw, ClockFreq::F24Mhz, &card)?;
+        self.set_bus(self.bw, freq, &card)?;
 
         self.card.replace(card);
         self.read_card_status()?;


### PR DESCRIPTION
There are cases in which the bus cannot run at 24MHz, for example due to PCB layout issues.

This PR makes the bus frequency selection a part of the public API, allowing the user to run the SDIO bus at a lower frequency, if necessary.