### PR TITLE
Move power handling to its own function and add short delay to register update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [breaking-change] Updated synopsys-usb-otg dependency to v0.2.0.
 - Cleanups to the Sdio driver, some hw independent functionality moved to the new sdio-host library.
 - [breaking-change] Sdio is disabled by default, enable with the `sdio` feature flag.
+- Move SDIO card power handling to its own function.
+- [breaking-change] Add a 2 ms delay after changing SDIO card power setting.
 
 ### Added
 

--- a/examples/sd.rs
+++ b/examples/sd.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
     let d3 = gpioc.pc11.into_alternate_af12().internal_pull_up(true);
     let clk = gpioc.pc12.into_alternate_af12().internal_pull_up(false);
     let cmd = gpiod.pd2.into_alternate_af12().internal_pull_up(true);
-    let mut sdio = Sdio::new(device.SDIO, (clk, cmd, d0, d1, d2, d3));
+    let mut sdio = Sdio::new(device.SDIO, (clk, cmd, d0, d1, d2, d3), clocks);
 
     hprintln!("Waiting for card...").ok();
 


### PR DESCRIPTION
Did a quick read of the Reference manual, and the ST hal driver looking for potential timing issues. Noticed that their driver have a delay, to make sure the time between disabling and enabling the clock is long enough. So I implemented that and moved the card power functionality to its own function.

The sdio registers are sensitive to consecutive writes (If I understand the Reference manual correctly) in relation to both SDIOCLK and PCLK2,  and shouldn't be written to repeatable within certain number of cycles. But as far as I can tell now we should be ok without adding additional delays in block read/write.

Made this a draft as I'm not sure my approach to using the clocks struct to create a 2 ms delay is correct.