### PR TITLE
Move I2C write implementation into write_bytes function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Make sure that I2C writes are concluded with a STOP condition
+
 ## [v0.8.2] - 2020-05-29
 
 ### Added


### PR DESCRIPTION
This allows us to reuse the code for both write_read() and write() where
we need to add a STOP condition after sending the data.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>