### PR TITLE
Add implementation for Fastmode+ I2C available on select MCUs

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,4 +1,5 @@
 use core::ops::Deref;
+use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 
 use crate::stm32::i2c1;
 
@@ -41,8 +42,6 @@ use crate::stm32::I2C3;
     feature = "stm32f479"
 ))]
 use crate::stm32::{I2C1, I2C2, RCC};
-
-use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 
 #[cfg(any(
     feature = "stm32f401",
@@ -193,6 +192,13 @@ use crate::time::{Hertz, KiloHertz, U32Ext};
 
 /// I2C abstraction
 pub struct I2c<I2C, PINS> {
+    i2c: I2C,
+    pins: PINS,
+}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+/// I2C FastMode+ abstraction
+pub struct FMPI2c<I2C, PINS> {
     i2c: I2C,
     pins: PINS,
 }
@@ -492,6 +498,54 @@ impl PinScl<I2C3> for PH7<AlternateOD<AF4>> {}
 ))]
 impl PinSda<I2C3> for PH8<AlternateOD<AF4>> {}
 
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+use crate::{
+    gpio::{
+        gpiob::{PB13, PB14, PB15},
+        gpioc::{PC6, PC7},
+        gpiod::{PD12, PD14, PD15},
+        gpiof::{PF14, PF15},
+    },
+    pac::fmpi2c,
+    pac::FMPI2C,
+};
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PC6<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinSda<FMPI2C> for PC7<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinSda<FMPI2C> for PB3<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PB10<AlternateOD<AF9>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinSda<FMPI2C> for PB14<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PB15<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PD12<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PB13<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PD14<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PD15<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PF14<AlternateOD<AF4>> {}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl PinScl<FMPI2C> for PF15<AlternateOD<AF4>> {}
+
 #[derive(Debug)]
 pub enum Error {
     OVERRUN,
@@ -613,6 +667,30 @@ impl<PINS> I2c<I2C3, PINS> {
 
         let i2c = I2c { i2c, pins };
         i2c.i2c_init(speed, clocks.pclk1());
+        i2c
+    }
+}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl<PINS> FMPI2c<FMPI2C, PINS> {
+    pub fn fmpi2c(i2c: FMPI2C, pins: PINS, speed: KiloHertz) -> Self
+    where
+        PINS: Pins<FMPI2C>,
+    {
+        // NOTE(unsafe) This executes only during initialisation
+        let rcc = unsafe { &(*RCC::ptr()) };
+
+        // Enable clock for FMPI2C
+        rcc.apb1enr.modify(|_, w| w.i2c4en().set_bit());
+
+        // Reset FMPI2C
+        rcc.apb1rstr.modify(|_, w| w.i2c4rst().set_bit());
+        rcc.apb1rstr.modify(|_, w| w.i2c4rst().clear_bit());
+
+        rcc.dckcfgr2.modify(|_, w| w.i2cfmp1sel().hsi());
+
+        let i2c = FMPI2c { i2c, pins };
+        i2c.i2c_init(speed);
         i2c
     }
 }
@@ -850,5 +928,250 @@ where
         } else {
             Err(Error::OVERRUN)
         }
+    }
+}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl<I2C, PINS> FMPI2c<I2C, PINS>
+where
+    I2C: Deref<Target = fmpi2c::RegisterBlock>,
+{
+    fn i2c_init(&self, speed: KiloHertz) {
+        use core::cmp;
+
+        // Make sure the I2C unit is disabled so we can configure it
+        self.i2c.cr1.modify(|_, w| w.pe().clear_bit());
+
+        // Calculate settings for I2C speed modes
+        let presc;
+        let scldel;
+        let sdadel;
+        let sclh;
+        let scll;
+
+        // We're using the HSI clock to keep things simple so this is going to be always 16 MHz
+        const FREQ: u32 = 16_000_000;
+
+        // Normal I2C speeds use a different scaling than fast mode below and fast mode+ even more
+        // below
+        if speed <= 100.khz() {
+            presc = 3;
+            scll = cmp::max((((FREQ >> presc) >> 1) / speed.0) - 1, 255) as u8;
+            sclh = scll - 4;
+            sdadel = 2;
+            scldel = 4;
+        } else if speed <= 400.khz() {
+            presc = 1;
+            scll = cmp::max((((FREQ >> presc) >> 1) / speed.0) - 1, 255) as u8;
+            sclh = scll - 6;
+            sdadel = 2;
+            scldel = 3;
+        } else {
+            presc = 0;
+            scll = cmp::max((((FREQ >> presc) >> 1) / speed.0) - 4, 255) as u8;
+            sclh = scll - 2;
+            sdadel = 0;
+            scldel = 2;
+        }
+
+        // Enable I2C signal generator, and configure I2C for configured speed
+        self.i2c.timingr.write(|w| unsafe {
+            w.presc()
+                .bits(presc)
+                .scldel()
+                .bits(scldel)
+                .sdadel()
+                .bits(sdadel)
+                .sclh()
+                .bits(sclh)
+                .scll()
+                .bits(scll)
+        });
+
+        // Enable the I2C processing
+        self.i2c.cr1.modify(|_, w| w.pe().set_bit());
+    }
+
+    pub fn release(self) -> (I2C, PINS) {
+        (self.i2c, self.pins)
+    }
+
+    fn check_and_clear_error_flags(&self, isr: &fmpi2c::isr::R) -> Result<(), Error> {
+        // If we received a NACK, then this is an error
+        if isr.nackf().bit_is_set() {
+            self.i2c
+                .icr
+                .write(|w| w.stopcf().set_bit().nackcf().set_bit());
+            return Err(Error::NACK);
+        }
+
+        Ok(())
+    }
+
+    fn send_byte(&self, byte: u8) -> Result<(), Error> {
+        // Wait until we're ready for sending
+        while {
+            let isr = self.i2c.isr.read();
+            self.check_and_clear_error_flags(&isr)?;
+            isr.txis().bit_is_clear()
+        } {}
+
+        // Push out a byte of data
+        self.i2c.txdr.write(|w| unsafe { w.bits(u32::from(byte)) });
+
+        self.check_and_clear_error_flags(&self.i2c.isr.read())?;
+        Ok(())
+    }
+
+    fn recv_byte(&self) -> Result<u8, Error> {
+        while {
+            let isr = self.i2c.isr.read();
+            self.check_and_clear_error_flags(&isr)?;
+            isr.rxne().bit_is_clear()
+        } {}
+
+        let value = self.i2c.rxdr.read().bits() as u8;
+        Ok(value)
+    }
+}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl<I2C, PINS> WriteRead for FMPI2c<I2C, PINS>
+where
+    I2C: Deref<Target = fmpi2c::RegisterBlock>,
+{
+    type Error = Error;
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
+        // Set up current slave address for writing and disable autoending
+        self.i2c.cr2.modify(|_, w| unsafe {
+            w.sadd1_7()
+                .bits(addr)
+                .nbytes()
+                .bits(bytes.len() as u8)
+                .rd_wrn()
+                .clear_bit()
+                .autoend()
+                .clear_bit()
+        });
+
+        // Send a START condition
+        self.i2c.cr2.modify(|_, w| w.start().set_bit());
+
+        // Wait until the transmit buffer is empty and there hasn't been any error condition
+        while {
+            let isr = self.i2c.isr.read();
+            self.check_and_clear_error_flags(&isr)?;
+            isr.txis().bit_is_clear() && isr.tc().bit_is_clear()
+        } {}
+
+        // Send out all individual bytes
+        for c in bytes {
+            self.send_byte(*c)?;
+        }
+
+        // Wait until data was sent
+        while {
+            let isr = self.i2c.isr.read();
+            self.check_and_clear_error_flags(&isr)?;
+            isr.tc().bit_is_clear()
+        } {}
+
+        // Set up current address for reading
+        self.i2c.cr2.modify(|_, w| unsafe {
+            w.sadd1_7()
+                .bits(addr)
+                .nbytes()
+                .bits(buffer.len() as u8)
+                .rd_wrn()
+                .set_bit()
+        });
+
+        // Send another START condition
+        self.i2c.cr2.modify(|_, w| w.start().set_bit());
+
+        // Send the autoend after setting the start to get a restart
+        self.i2c.cr2.modify(|_, w| w.autoend().set_bit());
+
+        // Now read in all bytes
+        for c in buffer.iter_mut() {
+            *c = self.recv_byte()?;
+        }
+
+        // Check and clear flags if they somehow ended up set
+        self.check_and_clear_error_flags(&self.i2c.isr.read())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl<I2C, PINS> Read for FMPI2c<I2C, PINS>
+where
+    I2C: Deref<Target = fmpi2c::RegisterBlock>,
+{
+    type Error = Error;
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
+        // Set up current address for reading
+        self.i2c.cr2.modify(|_, w| unsafe {
+            w.sadd1_7()
+                .bits(addr)
+                .nbytes()
+                .bits(buffer.len() as u8)
+                .rd_wrn()
+                .set_bit()
+        });
+
+        // Send a START condition
+        self.i2c.cr2.modify(|_, w| w.start().set_bit());
+
+        // Send the autoend after setting the start to get a restart
+        self.i2c.cr2.modify(|_, w| w.autoend().set_bit());
+
+        // Now read in all bytes
+        for c in buffer.iter_mut() {
+            *c = self.recv_byte()?;
+        }
+
+        // Check and clear flags if they somehow ended up set
+        self.check_and_clear_error_flags(&self.i2c.isr.read())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(any(feature = "stm32f413", feature = "stm32f423",))]
+impl<I2C, PINS> Write for FMPI2c<I2C, PINS>
+where
+    I2C: Deref<Target = fmpi2c::RegisterBlock>,
+{
+    type Error = Error;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+        // Set up current slave address for writing and enable autoending
+        self.i2c.cr2.modify(|_, w| unsafe {
+            w.sadd1_7()
+                .bits(addr)
+                .nbytes()
+                .bits(bytes.len() as u8)
+                .rd_wrn()
+                .clear_bit()
+                .autoend()
+                .set_bit()
+        });
+
+        // Send a START condition
+        self.i2c.cr2.modify(|_, w| w.start().set_bit());
+
+        // Send out all individual bytes
+        for c in bytes {
+            self.send_byte(*c)?;
+        }
+
+        // Check and clear flags if they somehow ended up set
+        self.check_and_clear_error_flags(&self.i2c.isr.read())?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This peripheral is very similar to the one found in newer MCUs e.g.
STM32F0 and was taken from there.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>