### PR TITLE
Make USB peripherals accessible for the f446

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub mod i2c;
         feature = "stm32f429",
         feature = "stm32f437",
         feature = "stm32f439",
+        feature = "stm32f446",
     )
 ))]
 pub mod otg_fs;
@@ -120,6 +121,7 @@ pub mod otg_fs;
         feature = "stm32f429",
         feature = "stm32f437",
         feature = "stm32f439",
+        feature = "stm32f446",
     )
 ))]
 pub mod otg_hs;


### PR DESCRIPTION
Since the [synopsys drivers](https://github.com/stm32-rs/synopsys-usb-otg) now largely support the f446 (give or take a couple endpoints), I thought it'd be a good moment to send this PR to actually enable access to the relevant registers in this crate