### PR TITLE
Add check_interrupt method for GPIO pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Reexport PAC as `pac` for consistency with other crates, consider `stm32` virtually deprecated
 - Added external interrupt (EXTI) support for output pins
+- Added `check_interrupt` method for GPIO pins
 
 ## [v0.8.3] - 2020-06-12
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -90,6 +90,7 @@ pub trait ExtiPin {
     fn enable_interrupt(&mut self, exti: &mut EXTI);
     fn disable_interrupt(&mut self, exti: &mut EXTI);
     fn clear_interrupt_pending_bit(&mut self);
+    fn check_interrupt(&self) -> bool;
 }
 
 macro_rules! exti_erased {
@@ -163,6 +164,11 @@ macro_rules! exti_erased {
             fn clear_interrupt_pending_bit(&mut self) {
                 unsafe { (*EXTI::ptr()).pr.write(|w| w.bits(1 << self.i)) };
             }
+
+            /// Reads the interrupt pending bit for this pin
+            fn check_interrupt(&self) -> bool {
+                unsafe { ((*EXTI::ptr()).pr.read().bits() & (1 << self.i)) != 0 }
+            }
         }
     };
 }
@@ -219,6 +225,11 @@ macro_rules! exti {
             /// Clear the interrupt pending bit for this pin
             fn clear_interrupt_pending_bit(&mut self) {
                 unsafe { (*EXTI::ptr()).pr.write(|w| w.bits(1 << $i)) };
+            }
+
+            /// Reads the interrupt pending bit for this pin
+            fn check_interrupt(&self) -> bool {
+                unsafe { ((*EXTI::ptr()).pr.read().bits() & (1 << $i)) != 0 }
             }
         }
     };


### PR DESCRIPTION
This is needed to properly use pins where the interrupt vector is shared between multiple pins. Copied and pasted from stm32f1xx-hal, except that I changed the method to `&self` as opposed to `&mut self` because that makes more sense for a getter.

Personally I'd prefer a single method that both checks and clears the interrupt bit in one operation and returns if it was set, but I'm not sure if that has issues in some use cases. This way the user gets to decide.