### PR TITLE
Move sdio response parsing to library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - [breaking-change] Updated synopsys-usb-otg dependency to v0.2.0.
+- Cleanups to the Sdio driver, some hw independent functionality moved to the new sdio-host library.
+- [breaking-change] Sdio is disabled by default, enable with the `sdio` feature flag.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ nb = "0.1.2"
 rand_core = "0.5.1"
 stm32f4 = "0.11"
 synopsys-usb-otg = { version = "0.2.0", features = ["cortex-m"], optional = true }
+sdio-host = { version = "0.2.0", optional = true }
 
 [dependencies.bare-metal]
 version = "0.2.5"
@@ -84,6 +85,8 @@ stm32f479 = ["stm32f4/stm32f469", "device-selected"]
 usb_fs = ["synopsys-usb-otg", "synopsys-usb-otg/fs"]
 usb_hs = ["synopsys-usb-otg", "synopsys-usb-otg/hs"]
 
+sdio = ["sdio-host"]
+
 [profile.dev]
 debug = true
 lto = true
@@ -99,7 +102,7 @@ required-features = ["rt", "stm32f401", "usb_fs"]
 
 [[example]]
 name = "sd"
-required-features = ["rt", "stm32f405"]
+required-features = ["rt", "stm32f405", "sdio"]
 
 [[example]]
 name = "delay-blinky"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub mod qei;
 #[cfg(feature = "device-selected")]
 pub mod rcc;
 #[cfg(all(
-    feature = "device-selected",
+    feature = "sdio",
     not(any(feature = "stm32f410", feature = "stm32f446",))
 ))]
 pub mod sdio;


### PR DESCRIPTION
Clean up the sdio driver by moving the parsing of the various sd response to a separate library https://crates.io/crates/sdio-host. Some other cleanups related to this change was made as well.