### PR TITLE
Add a qei example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,3 +127,7 @@ required-features = ["rt", "stm32f429"]
 [[example]]
 name = "rng-display"
 required-features = ["rt", "stm32f407"]
+
+[[example]]
+name = "qei"
+required-features = ["rt", "stm32f411"]

--- a/examples/qei.rs
+++ b/examples/qei.rs
@@ -1,0 +1,67 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+// Demonstrates the use of a rotary encoder. This example was tested
+// on a "black pill" USB C board:
+// https://stm32-base.org/boards/STM32F411CEU6-WeAct-Black-Pill-V2.0
+//
+// The rotary encoder A and B pins are connected to pins A0 and A1,
+// and they each have a 10K ohm pull-up resistor.
+
+// Halt on panic
+use panic_halt as _;
+
+use cortex_m;
+use cortex_m_rt::entry;
+use embedded_hal::Direction as RotaryDirection;
+use stm32f4xx_hal::{delay::Delay, prelude::*, qei::Qei, stm32};
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().expect("Failed to get stm32 peripherals");
+    let cp = cortex_m::peripheral::Peripherals::take().expect("Failed to get cortex_m peripherals");
+
+    // Set up the LED. This is pin C13 on the "black pill" USB C board here:
+    // https://stm32-base.org/boards/STM32F411CEU6-WeAct-Black-Pill-V2.0
+    let gpioc = dp.GPIOC.split();
+    let mut led = gpioc.pc13.into_push_pull_output();
+
+    // Set up the system clock.
+    let rcc = dp.RCC.constrain();
+    let clocks = rcc.cfgr.freeze();
+
+    // Create a delay abstraction based on SysTick.
+    let mut delay = Delay::new(cp.SYST, clocks);
+
+    let gpioa = dp.GPIOA.split();
+
+    // Connect a rotary encoder to pins A0 and A1.
+    let rotary_encoder_pins = (
+        gpioa.pa0.into_alternate_af1(),
+        gpioa.pa1.into_alternate_af1(),
+    );
+    let rotary_encoder_timer = dp.TIM2;
+    let rotary_encoder = Qei::tim2(rotary_encoder_timer, rotary_encoder_pins);
+
+    let mut current_count = rotary_encoder.count();
+
+    loop {
+        let new_count = rotary_encoder.count();
+
+        if new_count != current_count {
+            let _diff = new_count.wrapping_sub(current_count) as i16;
+
+            // Light up the LED when turning clockwise, turn it off
+            // when turning counter-clockwise.
+            match rotary_encoder.direction() {
+                RotaryDirection::Upcounting => led.set_low().unwrap(),
+                RotaryDirection::Downcounting => led.set_high().unwrap(),
+            }
+
+            current_count = new_count;
+        }
+
+        delay.delay_ms(10_u32);
+    }
+}


### PR DESCRIPTION
I tested this on a ["black pill"](https://stm32-base.org/boards/STM32F411CEU6-WeAct-Black-Pill-V2.0) dev board. This example just lights up the LED based on the rotary encoder direction, though the code also calculates the difference in position as you rotate it, so you could run some other code based on that difference.

On a side note, what are peoples' setups for building/flashing/running these examples? My setup:

* MacOS
* [`STM32F411CEU6`-based board](https://stm32-base.org/boards/STM32F411CEU6-WeAct-Black-Pill-V2.0)
* `CP2102` USB-serial converter <-> `STM32F411`
  * `TX` <-> `A10`
  * `RX` <-> `A9`
  * `3V3` <-> `3.3`
  * `GND` <-> `GND`
* `stm32flash` CLI for flashing the firmware
  * I have to hold the `BOOT0` button down and then press the `NRST` button to put it in flashing mode
* [`serial-monitor`](https://crates.io/crates/serial-monitor) for identifying the correct serial-port path and monitoring serial output

Some other examples are using `cortex_m_semihosting::{hprint, hprintln};` for output. Is that only for the ST-link device? Is it worth switching to that over serial?

Pics with the working QEI example:

![IMG_0065](https://user-images.githubusercontent.com/458432/87777945-616ce500-c865-11ea-9eb1-9744b2693534.JPG)
![IMG_0066](https://user-images.githubusercontent.com/458432/87777966-69c52000-c865-11ea-89de-db46b41a511b.JPG)
