### PR TITLE
Cleanups and bugfixes for the sdio driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `check_interrupt` method for GPIO pins
 - Basic support for DAC
 
+### Fixed
+- Stability fixes related to SD card write
+
 ## [v0.8.3] - 2020-06-12
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ nb = "0.1.2"
 rand_core = "0.5.1"
 stm32f4 = "0.11"
 synopsys-usb-otg = { version = "0.2.0", features = ["cortex-m"], optional = true }
-sdio-host = { version = "0.2.0", optional = true }
+sdio-host = { version = "0.4.0", optional = true }
 
 [dependencies.bare-metal]
 version = "0.2.5"


### PR DESCRIPTION
This updates the driver to use the latest sdio-host release and has some refactoring of the datapath code. It also fixes some stability issues with sd card writes that I was seeing.

With this patch my [usb mass storage example](https://github.com/jkristell/feather-f405/blob/master/examples/sd-usb-mass-storage.rs) works reliable.

So this is a pretty important patch for the sdio driver.