### PR TITLE
 Allow DMA on both halves of a split Serial<USART> separately.

### DIFF
--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{
     bb,
     pac::{self, DMA1, DMA2, RCC},
+    serial::{Rx, Tx},
 };
 use core::ops::Deref;
 
@@ -485,19 +486,28 @@ dma_map!(
     (Stream4<DMA1>, Channel0, pac::SPI2, MemoryToPeripheral),       //SPI2_TX
     (Stream5<DMA1>, Channel1, pac::I2C1, PeripheralToMemory),       //I2C1_RX
     (Stream5<DMA1>, Channel4, pac::USART2, PeripheralToMemory),     //USART2_RX
+    (Stream5<DMA1>, Channel4, Rx<pac::USART2>, PeripheralToMemory), //USART2_RX
     (Stream6<DMA1>, Channel4, pac::USART2, MemoryToPeripheral),     //USART2_TX
+    (Stream6<DMA1>, Channel4, Tx<pac::USART2>, MemoryToPeripheral), //USART2_TX
     (Stream7<DMA1>, Channel7, pac::I2C2, MemoryToPeripheral),       //I2C2_TX
     (Stream0<DMA2>, Channel0, pac::ADC1, PeripheralToMemory),       //ADC1
     (Stream0<DMA2>, Channel3, pac::SPI1, PeripheralToMemory),       //SPI1_RX
     (Stream1<DMA2>, Channel5, pac::USART6, PeripheralToMemory),     //USART6_RX
+    (Stream1<DMA2>, Channel5, Rx<pac::USART6>, PeripheralToMemory), //USART6_RX
     (Stream2<DMA2>, Channel3, pac::SPI1, PeripheralToMemory),       //SPI1_RX
     (Stream2<DMA2>, Channel4, pac::USART1, PeripheralToMemory),     //USART1_RX
+    (Stream2<DMA2>, Channel4, Rx<pac::USART1>, PeripheralToMemory), //USART1_RX
     (Stream2<DMA2>, Channel5, pac::USART6, PeripheralToMemory),     //USART6_RX
+    (Stream2<DMA2>, Channel5, Rx<pac::USART6>, PeripheralToMemory), //USART6_RX
     (Stream4<DMA2>, Channel0, pac::ADC1, PeripheralToMemory),       //ADC1
     (Stream5<DMA2>, Channel4, pac::USART1, PeripheralToMemory),     //USART1_RX
+    (Stream5<DMA2>, Channel4, Rx<pac::USART1>, PeripheralToMemory), //USART1_RX
     (Stream6<DMA2>, Channel5, pac::USART6, MemoryToPeripheral),     //USART6_TX
+    (Stream6<DMA2>, Channel5, Tx<pac::USART6>, MemoryToPeripheral), //USART6_TX
     (Stream7<DMA2>, Channel4, pac::USART1, MemoryToPeripheral),     //USART1_TX
+    (Stream7<DMA2>, Channel4, Tx<pac::USART1>, MemoryToPeripheral), //USART1_TX
     (Stream7<DMA2>, Channel5, pac::USART6, MemoryToPeripheral),     //USART6_TX
+    (Stream7<DMA2>, Channel5, Tx<pac::USART6>, MemoryToPeripheral), //USART6_TX
     (
         Stream0<DMA2>,
         Channel0,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1471,7 +1471,7 @@ macro_rules! halUsartImpl {
                                     .dmat().enabled()
                             })
                         }
-                        _ => {}
+                        DmaConfig::None => {}
                     }
 
                     Ok(Serial { usart, pins }.config_stop(config))


### PR DESCRIPTION
Based upon and dependent upon https://github.com/stm32-rs/stm32f4xx-hal/pull/186