### PR TITLE
Adding NACK detection and fault condition clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [breaking-change] Add a 2 ms delay after changing SDIO card power setting.
 - [breaking-change] Changed sdio::{read, write}_block buf argument to &[u8; 512].
 - Voltage regulator overdrive is enabled where supported and required for selected HCLK.
+- I2C driver updated to detect and clear all error condition flags.
 
 ### Added
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -772,46 +772,37 @@ where
     }
 
     fn check_and_clear_error_flags(&self) -> Result<(), Error> {
+        // Note that flags should only be cleared once they have been registered. If flags are
+        // cleared otherwise, there may be an inherent race condition and flags may be missed.
         let sr1 = self.i2c.sr1.read();
 
-        // Clear all pending error flags. We have already read the SR1, so it's safe to clear them
-        // before returning the error code.
-        self.i2c.sr1.modify(|_, w| {
-            w.timeout()
-                .clear_bit()
-                .pecerr()
-                .clear_bit()
-                .ovr()
-                .clear_bit()
-                .af()
-                .clear_bit()
-                .arlo()
-                .clear_bit()
-                .berr()
-                .clear_bit()
-        });
-
         if sr1.timeout().bit_is_set() {
+            self.i2c.sr1.modify(|_, w| w.timeout().clear_bit());
             return Err(Error::TIMEOUT);
         }
 
         if sr1.pecerr().bit_is_set() {
+            self.i2c.sr1.modify(|_, w| w.pecerr().clear_bit());
             return Err(Error::CRC);
         }
 
         if sr1.ovr().bit_is_set() {
+            self.i2c.sr1.modify(|_, w| w.ovr().clear_bit());
             return Err(Error::OVERRUN);
         }
 
         if sr1.af().bit_is_set() {
+            self.i2c.sr1.modify(|_, w| w.af().clear_bit());
             return Err(Error::NACK);
         }
 
         if sr1.arlo().bit_is_set() {
+            self.i2c.sr1.modify(|_, w| w.arlo().clear_bit());
             return Err(Error::ARBITRATION);
         }
 
         if sr1.berr().bit_is_set() {
+            self.i2c.sr1.modify(|_, w| w.berr().clear_bit());
             return Err(Error::BUS);
         }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -816,12 +816,6 @@ where
             sr1.addr().bit_is_clear()
         } {}
 
-        // Check for address faults (NACK received).
-        if self.i2c.sr1.read().af().bit_is_set() {
-            self.i2c.sr1.modify(|_, w| w.af().clear_bit());
-            return Err(Error::NACK);
-        }
-
         // Clear condition by reading SR2
         self.i2c.sr2.read();
 


### PR DESCRIPTION
This PR fixes #202 by adding the following:
1. During all busy-wait I2C loops, error flags are continually checked.
2. All fault flags have been updated to manually clear the fault indication.

cc: @therealprof 