### PR TITLE
Add fmt::Write impl for Serial<USART, PINS>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow for skipping an ongoing DMA transfer if not using double buffering.
 - Change DMA traits to `embedded-dma`.
 - Use bitbanding during clock enabling and peripheral reset to avoid data races.
+- Add missing `Write` implementation for `Serial` and implemented better error handling.
 
 ### Added
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1862,12 +1862,26 @@ halUsart! {
     UART10: (uart10, apb2enr, 7, uart10en, pclk2),
 }
 
+impl<USART, PINS> fmt::Write for Serial<USART, PINS>
+where
+    Serial<USART, PINS>: serial::Write<u8>,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        s.as_bytes()
+            .iter()
+            .try_for_each(|c| block!(self.write(*c)))
+            .map_err(|_| fmt::Error)
+    }
+}
+
 impl<USART> fmt::Write for Tx<USART>
 where
     Tx<USART>: serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
-        Ok(())
+        s.as_bytes()
+            .iter()
+            .try_for_each(|c| block!(self.write(*c)))
+            .map_err(|_| fmt::Error)
     }
 }


### PR DESCRIPTION
This allows to send formatted output directly to the serial port instead
of having to split it as found in #214.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>