### PR TITLE
Clear SPI errors on a fresh transmit

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1070,7 +1070,9 @@ where
 
         if txe {
             // NOTE(write_volatile) see note above
-            unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte); }
+            unsafe {
+                ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte);
+            }
             Ok(())
         } else {
             Err(nb::Error::WouldBlock)


### PR DESCRIPTION
Previous to this, all errors on the SPI port were latching. Instead, default to clearing errors at the start of every new transaction.