### PR TITLE
Correct Serial Baudrate calculation

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1454,12 +1454,18 @@ macro_rules! halUsartImpl {
                     let (over8, div) = if (pclk_freq / 16) >= baud {
                         // We have the ability to oversample to 16 bits, take
                         // advantage of it.
-                        let div = pclk_freq / baud;
+                        //
+                        // We also add `baud / 2` to the `pclk_freq` to ensure
+                        // rounding of values to the closest scale, rather than the
+                        // floored behavior of normal integer division.
+                        let div = (pclk_freq + (baud / 2)) / baud;
                         (false, div)
                     } else if (pclk_freq / 8) >= baud {
                         // We are close enough to pclk where we can only
                         // oversample 8.
-                        let div = (pclk_freq * 2) / baud;
+                        //
+                        // See note above regarding `baud` and rounding.
+                        let div = ((pclk_freq * 2) + (baud / 2)) / baud;
 
                         // Ensure the the fractional bits (only 3) are
                         // right-aligned.


### PR DESCRIPTION
I think the baudrate calculation before was... ~~really wrong~~ slightly misunderstood.

As far as I can tell, this new method is correct according to the stm32F411 datasheet, I'm not sure if the calculation is consistent across all stm32f4xx devices.

This was validated with an stm32f411, a pclk2 of 96MHz, and a baudrate of 12mbps.