### PR TITLE
timer: trigger update event to load the registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Stability fixes related to SD card write
+- Fixed issue where timer generated a spurious interrupt after start
 
 ## [v0.8.3] - 2020-06-12
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -263,6 +263,11 @@ macro_rules! hal {
                     let arr = u16(ticks / u32(psc + 1)).unwrap();
                     self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
 
+                    // Trigger update event to load the registers
+                    self.tim.cr1.modify(|_, w| w.urs().set_bit());
+                    self.tim.egr.write(|w| w.ug().set_bit());
+                    self.tim.cr1.modify(|_, w| w.urs().clear_bit());
+
                     // start counter
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
                 }


### PR DESCRIPTION
@thalesfragoso suggested this fix in matrix.

rtic init:
```rust
let mut timer = Timer::tim5(ctx.device.TIM5, 10.hz(), clocks);
timer.listen(Event::TimeOut);
pb5.set_high().ok();
```

rtic isr:
```rust
#[task(binds = TIM5, resources = [led, sm, pb5])]
fn timer5_isr(ctx: timer5_isr::Context) {
    let tim = unsafe { &(*stm32::TIM5::ptr()) };
    ctx.resources.pb5.toggle().ok();
    tim.sr.modify(|_, w| w.uif().clear_bit());
}
```
PB5 pin trace, notice the glitch:
![Screenshot 2020-11-08 at 17 14 06](https://user-images.githubusercontent.com/809232/98472346-15babe80-21fb-11eb-9849-d8cf2d49810a.jpg)

With this fix timings are perfect:
![Screenshot 2020-11-08 at 19 35 28](https://user-images.githubusercontent.com/809232/98472366-3daa2200-21fb-11eb-8248-05d42e731f61.jpg)
