### PR TITLE
Port MonoTimer from stm32f1xx-hal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improved Serial baudrate calculation to be correct for higher baudrates or lower PCLKs
 - Added `SysCfg` wrapper to enforce clock enable for `SYSCFG`
 - [breaking-change] gpio::ExtiPin now uses `SysCfg` wrapper instead of `SYSCFG`
+- Add `MonoTimer` and `Instant` structs for basic time measurement.
 
 ### Added
 


### PR DESCRIPTION
This is a straight-up copy of the `MonoTimer` from the `stm32f1xx-hal` crate:

https://github.com/stm32-rs/stm32f1xx-hal/blob/d976ba2312fae2f1b15707573bc5d82ea00ba73f/src/time.rs#L229-L278

I wanted the same functionality in a stm32f4-based project. I tested it on an `stm32f411CE` [WeAct USB C board](https://stm32-base.org/boards/STM32F401CEU6-WeAct-Black-Pill-V3.0), and it seems to behave properly.