### PR TITLE
Use CamelCase for gpio::Edge enum variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `SysCfg` wrapper to enforce clock enable for `SYSCFG`
 - [breaking-change] gpio::ExtiPin now uses `SysCfg` wrapper instead of `SYSCFG`
 - Change `WriteBuffer + 'static` to `StaticWriteBuffer`in the DMA module.
+- [breaking-change] `gpio::Edge::{RISING, FALLING, RISING_FALLING}` are renamed to `Rising`, `Falling`, `RisingFalling`, respectively.
 
 ### Added
 

--- a/examples/analog-stopwatch-with-spi-ssd1306.rs
+++ b/examples/analog-stopwatch-with-spi-ssd1306.rs
@@ -87,7 +87,7 @@ fn main() -> ! {
     let mut board_btn = gpioa.pa0.into_pull_down_input();
     board_btn.make_interrupt_source(&mut syscfg);
     board_btn.enable_interrupt(&mut dp.EXTI);
-    board_btn.trigger_on_edge(&mut dp.EXTI, Edge::FALLING);
+    board_btn.trigger_on_edge(&mut dp.EXTI, Edge::Falling);
 
     //spi4
     //sck  - pe2

--- a/examples/stopwatch-with-ssd1306-and-interrupts.rs
+++ b/examples/stopwatch-with-ssd1306-and-interrupts.rs
@@ -80,7 +80,7 @@ fn main() -> ! {
         let mut board_btn = gpioc.pc13.into_pull_up_input();
         board_btn.make_interrupt_source(&mut syscfg);
         board_btn.enable_interrupt(&mut dp.EXTI);
-        board_btn.trigger_on_edge(&mut dp.EXTI, Edge::FALLING);
+        board_btn.trigger_on_edge(&mut dp.EXTI, Edge::Falling);
 
         let interface = I2CDIBuilder::new().init(i2c);
         let mut disp: GraphicsMode<_> = Builder::new().connect(interface).into();

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -79,9 +79,9 @@ pub enum Speed {
 
 #[derive(Debug, PartialEq)]
 pub enum Edge {
-    RISING,
-    FALLING,
-    RISING_FALLING,
+    Rising,
+    Falling,
+    RisingFalling,
 }
 
 /// External Interrupt Pin
@@ -128,19 +128,19 @@ macro_rules! exti_erased {
             /// Generate interrupt on rising edge, falling edge or both
             fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                 match edge {
-                    Edge::RISING => {
+                    Edge::Rising => {
                         exti.rtsr
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                         exti.ftsr
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                     }
-                    Edge::FALLING => {
+                    Edge::Falling => {
                         exti.ftsr
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                         exti.rtsr
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                     }
-                    Edge::RISING_FALLING => {
+                    Edge::RisingFalling => {
                         exti.rtsr
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                         exti.ftsr
@@ -190,19 +190,19 @@ macro_rules! exti {
             /// Generate interrupt on rising edge, falling edge or both
             fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                 match edge {
-                    Edge::RISING => {
+                    Edge::Rising => {
                         exti.rtsr
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                         exti.ftsr
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                     }
-                    Edge::FALLING => {
+                    Edge::Falling => {
                         exti.ftsr
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                         exti.rtsr
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                     }
-                    Edge::RISING_FALLING => {
+                    Edge::RisingFalling => {
                         exti.rtsr
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                         exti.ftsr


### PR DESCRIPTION
ref: [h7xx](https://github.com/stm32-rs/stm32h7xx-hal/pull/179), [l4xx](https://github.com/stm32-rs/stm32l4xx-hal/pull/187), [f1xx](https://github.com/stm32-rs/stm32f1xx-hal/pull/303), [f7xx](https://github.com/stm32-rs/stm32f7xx-hal/pull/111)
