### PR TITLE
change Serial to use generics instead of macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `SysCfg` wrapper to enforce clock enable for `SYSCFG`
 - [breaking-change] gpio::ExtiPin now uses `SysCfg` wrapper instead of `SYSCFG`
 - Change `WriteBuffer + 'static` to `StaticWriteBuffer`in the DMA module.
+- Implement generics on the serial module.
 
 ### Added
 


### PR DESCRIPTION
This PR modifies the serial module to use generics instead of macros, so that downstream libraries can take advantage of generics. It also includes compatibility functions so that existing code continues to work without modifications.

Feedback is appreciated. The implementation here is ugly, IMO, but the advantage to users of the library is clear.