### PR TITLE
Make freeze_unchecked method private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `MonoTimer` and `Instant` structs for basic time measurement.
 - Added support for I2S and SAI clocks
 - Added support for canbus with the bxcan crate.
+- Added a `freeze_unchecked` method [#231]
+
+[#231]: https://github.com/stm32-rs/stm32f4xx-hal/pull/231
 
 ### Fixed
 

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -762,11 +762,16 @@ impl CFGR {
 
     /// Initialises the hardware according to CFGR state returning a Clocks instance.
     /// Allows overclocking.
+    ///
+    /// # Safety
+    ///
+    /// This method does not check if the clocks are bigger or smaller than the officially
+    /// recommended.
     pub unsafe fn freeze_unchecked(self) -> Clocks {
         self.freeze_internal(true)
     }
 
-    pub fn freeze_internal(self, unchecked: bool) -> Clocks {
+    fn freeze_internal(self, unchecked: bool) -> Clocks {
         let rcc = unsafe { &*RCC::ptr() };
 
         //let (use_pll, sysclk_on_pll, sysclk, pll48clk) = self.pll_setup();


### PR DESCRIPTION
Also add a missing entry for it to the changelog.

This isn't really breaking because this isn't released yet.