### PR TITLE
Added the self reference to the is_enabled function

### DIFF
--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -403,7 +403,7 @@ macro_rules! dma_stream {
                 }
 
                 #[inline(always)]
-                fn is_enabled() -> bool {
+                fn is_enabled(&mut self) -> bool {
                     //NOTE(unsafe) Atomic read with no side effects
                     let dma = unsafe { &*I::ptr() };
                     dma.st[Self::NUMBER].cr.read().en().bit_is_set()

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -74,7 +74,7 @@ pub trait Stream: Sealed {
     unsafe fn enable(&mut self);
 
     /// Returns the state of the DMA stream.
-    fn is_enabled() -> bool;
+    fn is_enabled(&mut self) -> bool;
 
     /// Disable the DMA stream.
     ///


### PR DESCRIPTION
I believe that the self reference for the DMA Stream method `is_enabled` was inadvertently left out when this was originally authored.  I just added it in.  Not much to say here.