### PR TITLE
DMA: Support both WriteBuffer and ReadBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated serial driver to use 32-bit reads and writes when accessing the USART data register [#299]
 - Add possibility to use DMA with the ADC abstraction, add example for ADC with DMA [#258]
 - Remove unsafe code from ADC DMA example
+- [breaking-change] DMA: Memory to peripheral transfers now only require `StaticReadBuffer` [#257].
 
 [#299]: https://github.com/stm32-rs/stm32f4xx-hal/pull/299
 [#258]: https://github.com/stm32-rs/stm32f4xx-hal/pull/258
+[#257]: https://github.com/stm32-rs/stm32f4xx-hal/pull/257
 
 ## [v0.9.0] - 2021-04-04
 
@@ -67,9 +69,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Address ST erratum 2.1.13 (DM00037591) [#278]
 - Implement generics on the qei module.
 - Bump ssd1306 dev-dependency and cleanup examples
-- DMA: Memory to peripheral transfers now only require `StaticReadBuffer` [#257].
-
-[#257]: https://github.com/stm32-rs/stm32f4xx-hal/pull/257
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Address ST erratum 2.1.13 (DM00037591) [#278]
 - Implement generics on the qei module.
 - Bump ssd1306 dev-dependency and cleanup examples
+- DMA: Memory to peripheral transfers now only require `StaticReadBuffer` [#257].
+
+[#257]: https://github.com/stm32-rs/stm32f4xx-hal/pull/257
 
 ### Added
 

--- a/examples/adc_dma_rtic.rs
+++ b/examples/adc_dma_rtic.rs
@@ -66,7 +66,7 @@ const APP: () = {
 
         let first_buffer = cortex_m::singleton!(: [u16; 2] = [0; 2]).unwrap();
         let second_buffer = Some(cortex_m::singleton!(: [u16; 2] = [0; 2]).unwrap());
-        let transfer = Transfer::init(dma.0, adc, first_buffer, None, config);
+        let transfer = Transfer::init_peripheral_to_memory(dma.0, adc, first_buffer, None, config);
 
         let now = cx.start;
         cx.schedule.polling(now + POLLING_PERIOD.cycles()).unwrap();

--- a/examples/i2s-audio-out-dma.rs
+++ b/examples/i2s-audio-out-dma.rs
@@ -194,7 +194,7 @@ fn main() -> ! {
         .memory_increment(true)
         .transfer_complete_interrupt(true);
     let mut dma_transfer: I2sDmaTransfer =
-        Transfer::init(dma1_streams.5, i2s, SINE_750_MUT, None, dma_config);
+        Transfer::init_memory_to_peripheral(dma1_streams.5, i2s, SINE_750_MUT, None, dma_config);
 
     dma_transfer.start(|i2s| i2s.enable());
     // Hand off transfer to interrupt handler


### PR DESCRIPTION
Memory to peripheral transfers now only require read access to the buffer

I tried to reduce code duplication, but some of it is necessary. This removes a big constrain on memory-to-peripheral transfers.

Draft because I need to look at some stuff and do some testing.