### PR TITLE
Add support for DMA with the ADC wrapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update the sdio driver to match the changes in the PAC
 - Update README.md with current information
 - Updated serial driver to use 32-bit reads and writes when accessing the USART data register [#299]
+- Add possibility to use DMA with the ADC abstraction, add example for ADC with DMA [#258]
 
 [#299]: https://github.com/stm32-rs/stm32f4xx-hal/pull/299
+[#258]: https://github.com/stm32-rs/stm32f4xx-hal/pull/258
 
 ## [v0.9.0] - 2021-04-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,5 +155,9 @@ name = "rtic"
 required-features = ["rt", "stm32f407"]
 
 [[example]]
+name = "adc_dma_rtic"
+required-features = ["rt", "stm32f401"]
+
+[[example]]
 name = "serial-9bit"
 required-features = ["rt", "stm32f411"]

--- a/examples/adc_dma_rtic.rs
+++ b/examples/adc_dma_rtic.rs
@@ -1,0 +1,113 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_semihosting::hprintln;
+use panic_semihosting as _;
+
+use rtic::cyccnt::U32Ext;
+
+use stm32f4xx_hal::{
+    adc::{
+        config::{AdcConfig, Dma, SampleTime, Scan, Sequence},
+        Adc, Temperature,
+    },
+    dma::{config::DmaConfig, Channel0, PeripheralToMemory, Stream0, StreamsTuple, Transfer},
+    prelude::*,
+    signature::{VtempCal110, VtempCal30},
+    stm32,
+    stm32::{ADC1, DMA2},
+};
+
+const POLLING_PERIOD: u32 = 168_000_000 / 2;
+
+type DMATransfer =
+    Transfer<Stream0<DMA2>, Channel0, Adc<ADC1>, PeripheralToMemory, &'static mut [u16; 2]>;
+
+#[rtic::app(device = stm32f4xx_hal::stm32, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
+const APP: () = {
+    struct Resources {
+        transfer: DMATransfer,
+    }
+
+    #[init(schedule=[polling])]
+    fn init(cx: init::Context) -> init::LateResources {
+        let device: stm32::Peripherals = cx.device;
+
+        let rcc = device.RCC.constrain();
+        let _clocks = rcc
+            .cfgr
+            .use_hse(25.mhz())
+            .require_pll48clk()
+            .sysclk(84.mhz())
+            .hclk(84.mhz())
+            .pclk1(42.mhz())
+            .pclk2(84.mhz())
+            .freeze();
+
+        let gpiob = device.GPIOB.split();
+        let voltage = gpiob.pb1.into_analog();
+
+        let dma = StreamsTuple::new(device.DMA2);
+
+        let config = DmaConfig::default()
+            .transfer_complete_interrupt(true)
+            .memory_increment(true)
+            .double_buffer(true);
+
+        let adc_config = AdcConfig::default()
+            .dma(Dma::Continuous)
+            .scan(Scan::Enabled);
+
+        let mut adc = Adc::adc1(device.ADC1, true, adc_config);
+        adc.configure_channel(&Temperature, Sequence::One, SampleTime::Cycles_480);
+        adc.configure_channel(&voltage, Sequence::Two, SampleTime::Cycles_480);
+        adc.enable_temperature_and_vref();
+
+        let first_buffer = cortex_m::singleton!(: [u16; 2] = [0; 2]).unwrap();
+        let second_buffer = cortex_m::singleton!(: [u16; 2] = [0; 2]).unwrap();
+        let transfer = Transfer::init(dma.0, adc, first_buffer, Some(second_buffer), config);
+
+        let now = cx.start;
+        cx.schedule.polling(now + POLLING_PERIOD.cycles()).unwrap();
+
+        init::LateResources { transfer }
+    }
+
+    #[task(resources = [transfer], schedule = [polling])]
+    fn polling(cx: polling::Context) {
+        let transfer: &mut DMATransfer = cx.resources.transfer;
+        transfer.start(|adc| {
+            adc.start_conversion();
+        });
+
+        cx.schedule
+            .polling(cx.scheduled + POLLING_PERIOD.cycles())
+            .unwrap();
+    }
+
+    #[task(binds = DMA2_STREAM0, resources = [transfer])]
+    fn dma(cx: dma::Context) {
+        let transfer: &mut DMATransfer = cx.resources.transfer;
+
+        let result = unsafe {
+            transfer.next_transfer_with(|data, _| {
+                let raw_temp = data[0];
+                let raw_volt = data[1];
+                (data, (raw_temp, raw_volt))
+            })
+        }
+        .unwrap();
+
+        let cal30 = VtempCal30::get().read() as f32;
+        let cal110 = VtempCal110::get().read() as f32;
+
+        let temperature = (110.0 - 30.0) * ((result.0 as f32) - cal30) / (cal110 - cal30) + 30.0;
+        let voltage = (result.1 as f32) / ((2_i32.pow(12) - 1) as f32) * 3.3;
+
+        hprintln!("temperature: {}, voltage: {}", temperature, voltage).unwrap();
+    }
+
+    extern "C" {
+        fn EXTI0();
+    }
+};

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{
+    adc::Adc,
     bb,
     pac::{self, DMA1, DMA2, RCC},
     serial::{Rx, Tx},
@@ -500,22 +501,23 @@ dma_map!(
     (Stream6<DMA1>, Channel4, Tx<pac::USART2>, MemoryToPeripheral), //USART2_TX
     (Stream7<DMA1>, Channel7, pac::I2C2, MemoryToPeripheral),       //I2C2_TX
     (Stream0<DMA2>, Channel0, pac::ADC1, PeripheralToMemory),       //ADC1
-    (Stream0<DMA2>, Channel3, pac::SPI1, PeripheralToMemory),       //SPI1_RX
-    (Stream1<DMA2>, Channel5, pac::USART6, PeripheralToMemory),     //USART6_RX
+    (Stream0<DMA2>, Channel0, Adc<pac::ADC1>, PeripheralToMemory),
+    (Stream0<DMA2>, Channel3, pac::SPI1, PeripheralToMemory), //SPI1_RX
+    (Stream1<DMA2>, Channel5, pac::USART6, PeripheralToMemory), //USART6_RX
     (Stream1<DMA2>, Channel5, Rx<pac::USART6>, PeripheralToMemory), //USART6_RX
-    (Stream2<DMA2>, Channel3, pac::SPI1, PeripheralToMemory),       //SPI1_RX
-    (Stream2<DMA2>, Channel4, pac::USART1, PeripheralToMemory),     //USART1_RX
+    (Stream2<DMA2>, Channel3, pac::SPI1, PeripheralToMemory), //SPI1_RX
+    (Stream2<DMA2>, Channel4, pac::USART1, PeripheralToMemory), //USART1_RX
     (Stream2<DMA2>, Channel4, Rx<pac::USART1>, PeripheralToMemory), //USART1_RX
-    (Stream2<DMA2>, Channel5, pac::USART6, PeripheralToMemory),     //USART6_RX
+    (Stream2<DMA2>, Channel5, pac::USART6, PeripheralToMemory), //USART6_RX
     (Stream2<DMA2>, Channel5, Rx<pac::USART6>, PeripheralToMemory), //USART6_RX
-    (Stream4<DMA2>, Channel0, pac::ADC1, PeripheralToMemory),       //ADC1
-    (Stream5<DMA2>, Channel4, pac::USART1, PeripheralToMemory),     //USART1_RX
+    (Stream4<DMA2>, Channel0, pac::ADC1, PeripheralToMemory), //ADC1
+    (Stream5<DMA2>, Channel4, pac::USART1, PeripheralToMemory), //USART1_RX
     (Stream5<DMA2>, Channel4, Rx<pac::USART1>, PeripheralToMemory), //USART1_RX
-    (Stream6<DMA2>, Channel5, pac::USART6, MemoryToPeripheral),     //USART6_TX
+    (Stream6<DMA2>, Channel5, pac::USART6, MemoryToPeripheral), //USART6_TX
     (Stream6<DMA2>, Channel5, Tx<pac::USART6>, MemoryToPeripheral), //USART6_TX
-    (Stream7<DMA2>, Channel4, pac::USART1, MemoryToPeripheral),     //USART1_TX
+    (Stream7<DMA2>, Channel4, pac::USART1, MemoryToPeripheral), //USART1_TX
     (Stream7<DMA2>, Channel4, Tx<pac::USART1>, MemoryToPeripheral), //USART1_TX
-    (Stream7<DMA2>, Channel5, pac::USART6, MemoryToPeripheral),     //USART6_TX
+    (Stream7<DMA2>, Channel5, pac::USART6, MemoryToPeripheral), //USART6_TX
     (Stream7<DMA2>, Channel5, Tx<pac::USART6>, MemoryToPeripheral), //USART6_TX
     (
         Stream0<DMA2>,


### PR DESCRIPTION
Implements the PeriAddress trait for Adc, making it possible for it to be used with the Transfer DMA implementation.

Fixes a rounding problem in the temperature equation. 
Fixes temperature sensor channel assignment for F405. The problem seems to affect all of the F40x and the F41x as the reference manual claims that the channel is 16 instead of 18.