### PR TITLE
RCC for F412, F413, F423, F446: Add missing configuration of PLLI2SCFGR.PLLI2SN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DMA: Make it possible to create the wrapper types for the timers [#237]
 - DMA: Fix some `compiler_fences` [#237]
 - DMA: Fix docs [#237]
+- RCC for F412, F413, F423, F446: Add missing configuration of PLLI2SCFGR.PLLI2SN [#261]
 
 [#237]: https://github.com/stm32-rs/stm32f4xx-hal/pull/237
+[#261]: https://github.com/stm32-rs/stm32f4xx-hal/pull/261
 
 ## [v0.8.3] - 2020-06-12
 

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -326,8 +326,14 @@ impl I2sPll {
     ))]
     fn apply_config(config: SingleOutputPll) {
         let rcc = unsafe { &*RCC::ptr() };
-        rcc.plli2scfgr
-            .modify(|_, w| unsafe { w.plli2sm().bits(config.m).plli2sr().bits(config.outdiv) });
+        rcc.plli2scfgr.modify(|_, w| unsafe {
+            w.plli2sm()
+                .bits(config.m)
+                .plli2sn()
+                .bits(config.n)
+                .plli2sr()
+                .bits(config.outdiv)
+        });
     }
 }
 


### PR DESCRIPTION
While testing I2S on an STM32F412, I found that the clock setup code was not correctly configuring the I2S PLL. The clock setup code found a good configuration, but did not write it correctly to the PLL configuration register. The PLLI2SCFGR.PLLI2SN field was left at its default value.

This pull request changes one function to write PLLI2SCFGR.PLLI2SN when applying a PLL configuration.

The updated code is working well for I2S on my STM32F412. I don't have an F413, F423, or F446 to test with, but this seems like a simple fix that is unlikely to break other code.