### PR TITLE
CAN: Add more pins, support CAN for more models, add CAN3 where available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for canbus with the bxcan crate.
 - Added a `freeze_unchecked` method [#231]
 - Added support for the Real Time Clock (RTC)
+- Added support for CAN on STM32F412, STM32F413, STM32F415, STM32F417,
+  STM32F423, STM32F427, STM32F429, STM32F437, STM32F439, STM32F469, and
+  STM32F479 [#262]
 
 [#231]: https://github.com/stm32-rs/stm32f4xx-hal/pull/231
+[#262]: https://github.com/stm32-rs/stm32f4xx-hal/pull/262
 
 ### Fixed
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -140,8 +140,8 @@ macro_rules! bus {
                         // Enable peripheral clock
                         crate::bb::set(&rcc.apb1enr, $peren);
                         // Reset peripheral
-                        crate::bb::set(&rcc.apb2rstr, $peren);
-                        crate::bb::clear(&rcc.apb2rstr, $peren);
+                        crate::bb::set(&rcc.apb1rstr, $peren);
+                        crate::bb::clear(&rcc.apb1rstr, $peren);
                     };
                 }
             }

--- a/src/can.rs
+++ b/src/can.rs
@@ -1,89 +1,141 @@
 //! # Controller Area Network (CAN) Interface
 //!
 
-use crate::bb;
-#[cfg(any(feature = "stm32f405", feature = "stm32f407"))]
-use crate::gpio::{
-    gpioa::{PA11, PA12},
-    gpiob::{PB12, PB13, PB5, PB6, PB8, PB9},
-    gpiod::{PD0, PD1},
-    gpioh::PH13,
-    gpioi::PI9,
-    Alternate, AF9,
-};
-
-#[cfg(feature = "stm32f446")]
-use crate::gpio::{
-    gpioa::{PA11, PA12},
-    gpiob::{PB12, PB13, PB5, PB6, PB8, PB9},
-    gpiod::{PD0, PD1},
-    Alternate, AF9,
-};
 use crate::pac::{CAN1, CAN2};
-use crate::stm32::RCC;
 
 mod sealed {
     pub trait Sealed {}
 }
 
+/// A pair of (TX, RX) pins configured for CAN communication
 pub trait Pins: sealed::Sealed {
+    /// The CAN peripheral that uses these pins
     type Instance;
 }
 
-/*
-    order: tx, rx similar to serial
-*/
+/// Implements sealed::Sealed and Pins for a (TX, RX) pair of pins associated with a CAN peripheral
+/// The alternate function number can be specified after each pin name. If not specified, both
+/// default to AF9.
 macro_rules! pins {
-    ($($PER:ident => ($tx:ident, $rx:ident),)+) => {
+    ($($PER:ident => ($tx:ident<$txaf:ident>, $rx:ident<$rxaf:ident>),)+) => {
         $(
-            impl sealed::Sealed for ($tx<Alternate<AF9>>, $rx<Alternate<AF9>>) {}
-            impl Pins for ($tx<Alternate<AF9>>, $rx<Alternate<AF9>>) {
+            impl crate::can::sealed::Sealed for ($tx<crate::gpio::Alternate<$txaf>>, $rx<crate::gpio::Alternate<$rxaf>>) {}
+            impl crate::can::Pins for ($tx<crate::gpio::Alternate<$txaf>>, $rx<crate::gpio::Alternate<$rxaf>>) {
                 type Instance = $PER;
             }
         )+
+    };
+    ($($PER:ident => ($tx:ident, $rx:ident),)+) => {
+        pins! { $($PER => ($tx<crate::gpio::AF9>, $rx<crate::gpio::AF9>),)+ }
     }
 }
 
-/*
-    See DS8626 Rev 9 Table 9.
-*/
-#[cfg(any(feature = "stm32f405", feature = "stm32f407"))]
-pins! {
-    CAN1 => (PA12, PA11),
-    CAN1 => (PB9, PB8),
-    CAN1 => (PD1, PD0),
-    CAN1 => (PH13, PI9),
-    CAN2 => (PB13, PB12),
-    CAN2 => (PB6, PB5),
+mod common_pins {
+    use crate::gpio::{
+        gpioa::{PA11, PA12},
+        gpiob::{PB12, PB13, PB5, PB6},
+        gpiod::{PD0, PD1},
+        AF9,
+    };
+    use crate::pac::{CAN1, CAN2};
+    // All STM32F4 models with CAN support these pins
+    pins! {
+        CAN1 => (PA12<AF9>, PA11<AF9>),
+        CAN1 => (PD1<AF9>, PD0<AF9>),
+        CAN2 => (PB13<AF9>, PB12<AF9>),
+        CAN2 => (PB6<AF9>, PB5<AF9>),
+    }
 }
 
-/*
-    See DS10693 Rev 9 Table 11.
-*/
-#[cfg(feature = "stm32f446")]
-pins! {
-    CAN1 => (PA12, PA11),
-    CAN1 => (PB9, PB8),
-    CAN1 => (PD1, PD0),
-    CAN2 => (PB13, PB12),
-    CAN2 => (PB6, PB5),
+#[cfg(any(feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
+mod pb9_pb8_af8 {
+    use crate::gpio::{
+        gpiob::{PB8, PB9},
+        AF8,
+    };
+    use crate::pac::CAN1;
+    pins! { CAN1 => (PB9<AF8>, PB8<AF8>), }
+}
+
+#[cfg(any(
+    feature = "stm32f405",
+    feature = "stm32f407",
+    feature = "stm32f415",
+    feature = "stm32f417",
+    feature = "stm32f427",
+    feature = "stm32f429",
+    feature = "stm32f437",
+    feature = "stm32f439",
+    feature = "stm32f446",
+    feature = "stm32f469",
+    feature = "stm32f479"
+))]
+mod pb9_pb8_af9 {
+    use crate::gpio::{
+        gpiob::{PB8, PB9},
+        AF9,
+    };
+    use crate::pac::CAN1;
+    pins! { CAN1 => (PB9<AF9>, PB8<AF9>), }
+}
+
+#[cfg(any(feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
+mod pg1_pg0 {
+    use crate::gpio::{
+        gpiog::{PG0, PG1},
+        AF9,
+    };
+    use crate::pac::CAN1;
+    pins! { CAN1 => (PG1<AF9>, PG0<AF9>), }
+}
+
+#[cfg(any(feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
+mod pg12_pg11 {
+    use crate::gpio::{
+        gpiog::{PG11, PG12},
+        AF9,
+    };
+    use crate::pac::CAN2;
+    pins! { CAN2 => (PG12<AF9>, PG11<AF9>), }
+}
+
+#[cfg(any(
+    feature = "stm32f405",
+    feature = "stm32f407",
+    feature = "stm32f415",
+    feature = "stm32f417",
+    feature = "stm32f427",
+    feature = "stm32f429",
+    feature = "stm32f437",
+    feature = "stm32f439",
+    feature = "stm32f469",
+    feature = "stm32f479"
+))]
+mod ph13_pi9 {
+    use crate::gpio::{gpioh::PH13, gpioi::PI9, AF9};
+    use crate::pac::CAN1;
+    pins! { CAN1 => (PH13<AF9>, PI9<AF9>), }
 }
 
 /// Enable/disable peripheral
 pub trait Enable: sealed::Sealed {
+    /// Enables this peripheral by setting the associated enable bit in an RCC enable register
     fn enable();
 }
 
+/// Implements sealed::Sealed and Enable for a CAN peripheral (e.g. CAN1)
+///
+/// $peren is the index in RCC_APB1ENR of the enable bit for the CAN peripheral.
 macro_rules! bus {
     ($($PER:ident => ($peren:literal),)+) => {
         $(
-            impl sealed::Sealed for crate::pac::$PER {}
-            impl Enable for crate::pac::$PER {
+            impl crate::can::sealed::Sealed for crate::pac::$PER {}
+            impl crate::can::Enable for crate::pac::$PER {
                 #[inline(always)]
                 fn enable() {
                     unsafe {
-                        let rcc = &(*RCC::ptr());
-                        bb::set(&rcc.apb1enr, $peren)
+                        let rcc = &(*crate::pac::RCC::ptr());
+                        crate::bb::set(&rcc.apb1enr, $peren)
                     };
                 }
             }
@@ -96,6 +148,31 @@ bus! {
     CAN2 => (26),
 }
 
+/// Pins and definitions for models with a third CAN peripheral
+#[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
+mod can3 {
+    use super::Can;
+    use crate::gpio::{
+        gpioa::{PA15, PA8},
+        gpiob::{PB3, PB4},
+        AF11,
+    };
+    use crate::pac::CAN3;
+    pins! {
+        CAN3 => (PA15<AF11>, PA8<AF11>),
+        CAN3 => (PB4<AF11>, PB3<AF11>),
+    }
+    bus! { CAN3 => (27), }
+
+    unsafe impl bxcan::Instance for Can<CAN3> {
+        const REGISTERS: *mut bxcan::RegisterBlock = CAN3::ptr() as *mut _;
+    }
+
+    unsafe impl bxcan::FilterOwner for Can<CAN3> {
+        const NUM_FILTER_BANKS: u8 = 14;
+    }
+}
+
 /// Interface to the CAN peripheral.
 pub struct Can<Instance> {
     _peripheral: Instance,
@@ -105,7 +182,7 @@ impl<Instance> Can<Instance>
 where
     Instance: Enable,
 {
-    /// Creates a CAN interaface.
+    /// Creates a CAN interface.
     pub fn new<P>(can: Instance, _pins: P) -> Can<Instance>
     where
         P: Pins<Instance = Instance>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,22 @@ pub mod adc;
 pub mod bb;
 #[cfg(all(
     feature = "can",
-    any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f446")
+    any(
+        feature = "stm32f405",
+        feature = "stm32f407",
+        feature = "stm32f412",
+        feature = "stm32f413",
+        feature = "stm32f415",
+        feature = "stm32f417",
+        feature = "stm32f423",
+        feature = "stm32f427",
+        feature = "stm32f429",
+        feature = "stm32f437",
+        feature = "stm32f439",
+        feature = "stm32f446",
+        feature = "stm32f469",
+        feature = "stm32f479",
+    )
 ))]
 pub mod can;
 #[cfg(feature = "device-selected")]


### PR DESCRIPTION
I looked through all the STM32F4 datasheets to find additional pins that can be used for CAN, and added implementations of the `can::Pins` trait for those pins. As part of the process, I enabled the `can` module for several STM32F4 models that support CAN beyond the F405, F407, and F446. I also added CAN3 and the associated pins for F413 and F423 models.

This also includes some small documentation improvements that I thought might be helpful.

I'm not sure if this needs a changelog entry because it's in the same version where CAN support was first added. I added one anyway to make the automated checks happy.