### PR TITLE
RCC: Add option to bypass HSE oscillator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for canbus with the bxcan crate.
 - Added a `freeze_unchecked` method [#231]
 - Added support for the Real Time Clock (RTC)
+- Added option to bypass the HSE oscillator and use a clock input [#263]
 
 [#231]: https://github.com/stm32-rs/stm32f4xx-hal/pull/231
+[#263]: https://github.com/stm32-rs/stm32f4xx-hal/pull/263
 
 ### Fixed
 


### PR DESCRIPTION
This change adds an option to set the HSEBYP bit of RCC_CR, which disables the built-in oscillator for the HSE clock. Instead, the microcontroller can use a clock signal from an external oscillator or other source.

I have tested this mode on a 32F412GDISCOVERY board.