### PR TITLE
RCC for F411: Add missing configuration of PLLI2SCFGR.PLLI2SM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DMA: Fix some `compiler_fences` [#237]
 - DMA: Fix docs [#237]
 - RCC for F412, F413, F423, F446: Add missing configuration of PLLI2SCFGR.PLLI2SN [#261]
+- RCC for F411: Add missing configuration of PLLI2SCFGR.PLLI2SM [#264]
 
 [#237]: https://github.com/stm32-rs/stm32f4xx-hal/pull/237
 [#261]: https://github.com/stm32-rs/stm32f4xx-hal/pull/261
+[#264]: https://github.com/stm32-rs/stm32f4xx-hal/pull/264
 
 ## [v0.8.3] - 2020-06-12
 

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -305,6 +305,7 @@ impl I2sPll {
     }
 
     #[cfg(not(any(
+        feature = "stm32f411",
         feature = "stm32f412",
         feature = "stm32f413",
         feature = "stm32f423",
@@ -319,6 +320,7 @@ impl I2sPll {
             .modify(|_, w| unsafe { w.plli2sn().bits(config.n).plli2sr().bits(config.outdiv) });
     }
     #[cfg(any(
+        feature = "stm32f411",
         feature = "stm32f412",
         feature = "stm32f413",
         feature = "stm32f423",


### PR DESCRIPTION
I was testing I2S and noticed that the actual sample rate was wrong (on an STM32F411 this time). I noticed that while the STM32F411 has a separate M divider before the I2S PLL, the clock setup code was not configuring it in the PLLI2SCFGR.

This pull request proposes to change two of the #[cfg] attributes so that the code sets PLLI2SCFGR.PLLI2SM on the STM32F411, like it already does on the F412/413/423/446.

The changed code works and generates the correct sample rate on my STM32F411.