### PR TITLE
Clear SPI errors on send to prevent races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `SysCfg` wrapper to enforce clock enable for `SYSCFG`
 - [breaking-change] gpio::ExtiPin now uses `SysCfg` wrapper instead of `SYSCFG`
 - Change `WriteBuffer + 'static` to `StaticWriteBuffer`in the DMA module.
+- Fixed a race condition where SPI writes could get stuck in an error state forever (PR #269).
 
 ### Added
 


### PR DESCRIPTION
I'm already aware of #223 but I tried it and...  It doesn't work.  I sort of went back to the drawing board on it and created my own PR that I've tested so I know it works 👍

If errors are encountered during an SPI write it'll automatically clear any bits that need clearing *then* return the error.  So you get the bit cleared and the error.  What more could you ask for? :smile: 