### PR TITLE
Add second downgrade function that removes both pin and port from the type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for CAN on additional models: STM32F412, STM32F413, STM32F415,
   STM32F417, STM32F423, STM32F427, STM32F429, STM32F437, STM32F439, STM32F469,
   and STM32F479 [#262]
+- Added `gpio::gpiox::Pxi::downgrade2` method [#272]
 
 [#231]: https://github.com/stm32-rs/stm32f4xx-hal/pull/231
 [#262]: https://github.com/stm32-rs/stm32f4xx-hal/pull/262
 [#263]: https://github.com/stm32-rs/stm32f4xx-hal/pull/263
 [#278]: https://github.com/stm32-rs/stm32f4xx-hal/issues/278
+[#272]: https://github.com/stm32-rs/stm32f4xx-hal/issues/272
 
 ### Fixed
 


### PR DESCRIPTION
I did three things here.

* added a `downgrade2` function to all pins. It returns a `Pin` that is no longer generic over the pin number or its port.
* added a `PinInfo` trait with `pin_id()` and `port_id()` functions
* moved the `ExtiPin` trait implementation out of the macro and into the trait definition since otherwise I would have needed a third `exti` macro

Names are just temporaries.

Why I believe this is necessary:
The current downgrade implementation feels useless to me. If you need to combine pins from different ports you're left with either trait objects or monomorphized generic implementations which both have their downsides.

Are my changes ok?
If so what should the function be called and do we want to remove the current downgrade function?