### PR TITLE
Errata workaround: Removing error return on I2C bus error detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Removing error on I2C bus errors due to errata workaround.
 - [breaking-change] Updated synopsys-usb-otg dependency to v0.2.0.
 - Cleanups to the Sdio driver, some hw independent functionality moved to the new sdio-host library.
 - [breaking-change] Sdio is disabled by default, enable with the `sdio` feature flag.

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -551,6 +551,8 @@ pub enum Error {
     OVERRUN,
     NACK,
     TIMEOUT,
+    // Note: The BUS error type is not currently returned, but is maintained for backwards
+    // compatibility.
     BUS,
     CRC,
     ARBITRATION,
@@ -816,9 +818,10 @@ where
             return Err(Error::ARBITRATION);
         }
 
+        // The errata indicates that BERR may be incorrectly detected. It recommends ignoring and
+        // clearing the BERR bit instead.
         if sr1.berr().bit_is_set() {
             self.i2c.sr1.modify(|_, w| w.berr().clear_bit());
-            return Err(Error::BUS);
         }
 
         Ok(sr1)


### PR DESCRIPTION
As outlined in #274, the I2C module may indicate spurious bus errors. This PR removes the `Error::BUS` variant from the I2C interface and updates the status flags check to ignore BERR bit assertions.

This fixes #274 

TODO:
- [x] I'm testing this update on our hardware to verify that it resolves our spurious reset issue