### PR TITLE
Update SDIO_D0 pin to PB7 for stm32f411

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Change `WriteBuffer + 'static` to `StaticWriteBuffer`in the DMA module.
 - Fixed a race condition where SPI writes could get stuck in an error state forever (PR #269).
 - Implement generics on the serial module.
+- Updated SDIO_D0 pin to PB7 for stm32f411 [#277]
 
 ### Added
 

--- a/src/sdio.rs
+++ b/src/sdio.rs
@@ -94,16 +94,21 @@ pins! {
     D3: [PC11<Alternate<AF12>>]
 }
 
-#[cfg(any(
-    feature = "stm32f411",
-    feature = "stm32f412",
-    feature = "stm32f413",
-    feature = "stm32f423",
-))]
+#[cfg(any(feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
 pins! {
     CLK: [PB15<Alternate<AF12>>]
     CMD: [PA6<Alternate<AF12>>]
     D0: [PB4<Alternate<AF12>>, PB6<Alternate<AF12>>]
+    D1: [PA8<Alternate<AF12>>]
+    D2: [PA9<Alternate<AF12>>]
+    D3: [PB5<Alternate<AF12>>]
+}
+
+#[cfg(feature = "stm32f411")]
+pins! {
+    CLK: [PB15<Alternate<AF12>>]
+    CMD: [PA6<Alternate<AF12>>]
+    D0: [PB4<Alternate<AF12>>, PB7<Alternate<AF12>>]
     D1: [PA8<Alternate<AF12>>]
     D2: [PA9<Alternate<AF12>>]
     D3: [PB5<Alternate<AF12>>]


### PR DESCRIPTION
As per page 46 of https://www.st.com/resource/en/datasheet/stm32f411ce.pdf, the `SDIO_D0` pin option is actually on PB7, not `PB6`.

The `PB6` assignment appears to be correct for the other three microcontrollers.