### PR TITLE
Fix CRC32 peripheral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DMA: Fix docs [#237]
 - RCC for F412, F413, F423, F446: Add missing configuration of PLLI2SCFGR.PLLI2SN [#261]
 - RCC for F411: Add missing configuration of PLLI2SCFGR.PLLI2SM [#264]
+- CRC: Fixed CRC clock not being enabled [#283]
 
 [#237]: https://github.com/stm32-rs/stm32f4xx-hal/pull/237
 [#261]: https://github.com/stm32-rs/stm32f4xx-hal/pull/261
 [#264]: https://github.com/stm32-rs/stm32f4xx-hal/pull/264
+[#283]: https://github.com/stm32-rs/stm32f4xx-hal/pull/283
 
 ## [v0.8.3] - 2020-06-12
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -21,16 +21,16 @@ pub struct Crc32 {
 impl Crc32 {
     /// Create a new Crc32 HAL peripheral
     pub fn new(crc: CRC) -> Self {
-        let mut new = Self { periph: crc };
-        new.init();
-
         unsafe {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.
-            let rcc_raw =  &(*RCC::ptr());
+            let rcc_raw = &(*RCC::ptr());
             // CRCEN = true; enable CRC clock.
-            bb::clear(&rcc_raw.ahb1enr, 12);
+            bb::set(&rcc_raw.ahb1enr, 12);
             dsb();
         }
+
+        let mut new = Self { periph: crc };
+        new.init();
 
         new
     }
@@ -123,9 +123,9 @@ impl Crc32 {
     pub fn free(self) -> CRC {
         unsafe {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.
-            let rcc_raw =  &(*RCC::ptr());
+            let rcc_raw = &(*RCC::ptr());
             // Disable CRC clock
-            bb::set(&rcc_raw.ahb1enr, 12);
+            bb::clear(&rcc_raw.ahb1enr, 12);
             dsb();
         }
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -26,9 +26,9 @@ impl Crc32 {
 
         unsafe {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.
-            let rcc_raw = unsafe { &(*RCC::ptr()) };
+            let rcc_raw =  &(*RCC::ptr());
             // CRCEN = true; enable CRC clock.
-            bb::write(&rcc_raw.ahb1enr, 12, true);
+            bb::clear(&rcc_raw.ahb1enr, 12);
             dsb();
         }
 
@@ -123,9 +123,9 @@ impl Crc32 {
     pub fn free(self) -> CRC {
         unsafe {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.
-            let rcc_raw = unsafe { &(*RCC::ptr()) };
+            let rcc_raw =  &(*RCC::ptr());
             // Disable CRC clock
-            bb::write(&rcc_raw.ahb1enr, 12, false);
+            bb::set(&rcc_raw.ahb1enr, 12);
             dsb();
         }
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -10,7 +10,6 @@
 use crate::stm32::{CRC, RCC};
 use core::mem::MaybeUninit;
 use core::ptr::copy_nonoverlapping;
-use cortex_m::asm::{nop, delay};
 
 /// A handle to a HAL CRC32 peripheral
 pub struct Crc32 {
@@ -27,7 +26,7 @@ impl Crc32 {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.
             let rcc_raw = unsafe { &(*RCC::ptr()) };
             // Enable CRC clock
-            rcc_raw.ahb1enr.modify(|_, w| {w.crcen().enabled()});
+            rcc_raw.ahb1enr.modify(|_, w| w.crcen().enabled());
         }
 
         new
@@ -123,7 +122,7 @@ impl Crc32 {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.
             let rcc_raw = unsafe { &(*RCC::ptr()) };
             // Disable CRC clock
-            rcc_raw.ahb1enr.modify(|_, w| {w.crcen().disabled()});
+            rcc_raw.ahb1enr.modify(|_, w| w.crcen().disabled());
         }
 
         self.periph


### PR DESCRIPTION
The current implementation of the CRC32 perhipheral does not enable the CRC32 clock.
On the STM32F446﻿, this causes **all** calculations against this peripheral to emit an incorrect null instead of the checksum.

This PR enables the CRC clock when the HAL's peripheral is acquired, and disables it when released.

Fixes #281 
