### PR TITLE
Add an RTIC example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added an example of integration with RTIC.
+
 ## [v0.9.0] - 2021-04-04
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ embedded-graphics = "0.6.2"
 usb-device = "0.2.5"
 usbd-serial = "0.1.0"
 micromath = "1.0.0"
+cortex-m-rtic = "0.5.6"
 
 [features]
 device-selected = []
@@ -134,3 +135,7 @@ required-features = ["rt", "stm32f411"]
 [[example]]
 name = "can-send"
 required-features = ["can", "stm32f405"]
+
+[[example]]
+name = "rtic"
+required-features = ["rt", "stm32f407"]

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -1,0 +1,43 @@
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_std]
+#![no_main]
+
+extern crate rtic;
+
+use panic_halt as _;
+use rtic::app;
+use stm32f4xx_hal::{
+    gpio::{gpioa::PA0, gpiod::PD12, Edge, Input, Output, PullDown, PushPull},
+    prelude::*,
+};
+
+#[app(device = stm32f4xx_hal::stm32, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        button: PA0<Input<PullDown>>,
+        led: PD12<Output<PushPull>>,
+    }
+
+    #[init]
+    fn init(mut ctx: init::Context) -> init::LateResources {
+        let mut syscfg = ctx.device.SYSCFG.constrain();
+
+        let gpiod = ctx.device.GPIOD.split();
+        let led = gpiod.pd12.into_push_pull_output();
+
+        let gpioa = ctx.device.GPIOA.split();
+        let mut button = gpioa.pa0.into_pull_down_input();
+        button.make_interrupt_source(&mut syscfg);
+        button.enable_interrupt(&mut ctx.device.EXTI);
+        button.trigger_on_edge(&mut ctx.device.EXTI, Edge::RISING);
+
+        init::LateResources { button, led }
+    }
+
+    #[task(binds = EXTI0, resources = [button, led])]
+    fn button_click(ctx: button_click::Context) {
+        ctx.resources.button.clear_interrupt_pending_bit();
+        ctx.resources.led.toggle().unwrap();
+    }
+};


### PR DESCRIPTION
This example presents integration with RTIC [1]. Built for STM32F4
Discovery, toggles an onboard LED upon an interrupt fired by an onboard
button.

[1] https://rtic.rs/

Signed-off-by: Petr Horacek <hrck@protonmail.com>