### PR TITLE
Add internal pullup setting for AF open drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,7 +322,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support for stm32f407 and stm32f429.
 
-[unreleased]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.9.0...HEAD
 [v0.9.0]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.8.3...v0.9.0
 [v0.8.3]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.8.2...v0.8.3
 [v0.8.2]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.8.1...v0.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added an example of integration with RTIC.
+- Added internal pullup configuaration for the AlternateOD pin type
 
 ### Changed
 
@@ -29,7 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [breaking-change] Sdio is disabled by default, enable with the `sdio` feature flag.
 - Move SDIO card power handling to its own function.
 - [breaking-change] Add a 2 ms delay after changing SDIO card power setting.
-- [breaking-change] Changed sdio::{read, write}_block buf argument to &[u8; 512].
+- [breaking-change] Changed sdio::{read, write}\_block buf argument to &[u8; 512].
 - Voltage regulator overdrive is enabled where supported and required for selected HCLK.
 - I2C driver updated to detect and clear all error condition flags.
 - Allow for skipping an ongoing DMA transfer if not using double buffering.
@@ -61,7 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for hardware-based CRC32 functionality
 - Add `MonoTimer` and `Instant` structs for basic time measurement.
 - Added support for I2S and SAI clocks
-- Added support for canbus with the bxcan crate.[#273] The version range is `<=0.4, <0.6`. (Currently 
+- Added support for canbus with the bxcan crate.[#273] The version range is `<=0.4, <0.6`. (Currently
   the latest version is `0.5.0`) [#286]
 - Added a `freeze_unchecked` method [#231]
 - Added support for the Real Time Clock (RTC)
@@ -321,7 +322,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support for stm32f407 and stm32f429.
 
-[Unreleased]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.9.0...HEAD
+[unreleased]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.9.0...HEAD
 [v0.9.0]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.8.3...v0.9.0
 [v0.8.3]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.8.2...v0.8.3
 [v0.8.2]: https://github.com/stm32-rs/stm32f4xx-hal/compare/v0.8.1...v0.8.2

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -745,6 +745,19 @@ macro_rules! gpio {
                     }
                 }
 
+                impl<MODE> $PXi<AlternateOD<MODE>> {
+                    /// Enables / disables the internal pull up
+                    pub fn internal_pull_up(&mut self, on: bool) {
+                        let offset = 2 * $i;
+                        let value = if on { 0b01 } else { 0b00 };
+                        unsafe {
+                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                                w.bits((r.bits() & !(0b11 << offset)) | (value << offset))
+                            })
+                        };
+                    }
+                }
+
                 impl<MODE> $PXi<MODE> {
                     /// Erases the pin number from the type
                     ///


### PR DESCRIPTION
This PR adds the ability to configure the internal pullup resistor for `AlternateOD` pin types, for example if you want to use i2c with internal pullup resistors etc.

Tested on STM32F411RET6U