### PR TITLE
USART: support reading and writing 9-bit words, change to 32-bit data register access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added an example of integration with RTIC.
+- [breaking-change] Added USART support for sending and receiving 9-bit words [#299]
+
+[#299]: https://github.com/stm32-rs/stm32f4xx-hal/pull/299
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added an example of integration with RTIC.
 - Added internal pullup configuaration for the AlternateOD pin type
-- [breaking-change] Added USART support for sending and receiving 9-bit words [#299]
+- Added USART support for sending and receiving 9-bit words [#299]
 
 [#299]: https://github.com/stm32-rs/stm32f4xx-hal/pull/299
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for I2S communication using SPI peripherals, and two examples [#265]
 
 [#265]: https://github.com/stm32-rs/stm32f4xx-hal/pull/265
-[#299]: https://github.com/stm32-rs/stm32f4xx-hal/pull/299
 
 ### Changed
 
 - Update the sdio driver to match the changes in the PAC
 - Update README.md with current information
+- Updated serial driver to use 32-bit reads and writes when accessing the USART data register [#299]
+
+[#299]: https://github.com/stm32-rs/stm32f4xx-hal/pull/299
 
 ## [v0.9.0] - 2021-04-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,3 +153,7 @@ required-features = ["stm32f411", "rt", "i2s"]
 [[example]]
 name = "rtic"
 required-features = ["rt", "stm32f407"]
+
+[[example]]
+name = "serial-9bit"
+required-features = ["rt", "stm32f411"]

--- a/examples/serial-9bit.rs
+++ b/examples/serial-9bit.rs
@@ -68,7 +68,9 @@ fn main() -> ! {
         Config::default().baudrate(9600.bps()).wordlength_9(),
         clocks,
     )
-    .unwrap();
+    .unwrap()
+    // Make this Serial object use u16s instead of u8s
+    .with_u16_data();
 
     let (mut tx, mut rx) = serial.split();
 
@@ -78,7 +80,6 @@ fn main() -> ! {
         for value in nine_bit_integers.clone() {
             block!(tx.write(value)).unwrap();
             // Receive what we just sent
-            // This type annotation is needed to disambiguate between the u8 and u16 read implementations
             let received: u16 = block!(rx.read()).unwrap();
 
             // Update LEDs to display what was received

--- a/examples/serial-9bit.rs
+++ b/examples/serial-9bit.rs
@@ -1,0 +1,109 @@
+//!
+//! This example demonstrates 9-bit serial (USART) communication. It uses LEDs to display
+//! some bits of the received signals.
+//!
+//! # Hardware required
+//!
+//! Use a 32F411EDISCOVERY evaluation board.
+//! Use a wire to connect pins PA2 and PA3 (this loopback connection makes the microcontroller
+//! receive everything it transmits).
+//!
+//! You can also easily adapt this example to any other STM32F4 evaluation board that has four LEDs.
+//!
+//! # Expected behavior
+//!
+//! The microcontroller sends increasing 9-bit numbers over the USART, and receives them.
+//! The on-board LEDs display some bits of the received numbers:
+//!
+//! * Green LED LD4 (PD12) corresponds to bit 5
+//! * Orange LED LD3 (PD13) corresponds to bit 6
+//! * Red LED LD5 (PD14) corresponds to bit 7
+//! * Blue LED LD6 (PD15) corresponds to bit 8
+//!
+//! Because the microcontroller sends a newly incremented number about every 10 milliseconds,
+//! the green LED should toggle about every 320 milliseconds. The other LEDs, including the
+//! blue LED (bit 8) should toggle appropriately, indicating that the microcontroller is sending
+//! and receiving all 9 bits.
+//!
+
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+use cortex_m_rt::entry;
+use stm32f4xx_hal as hal;
+
+use crate::hal::{block, prelude::*, serial::config::Config, serial::Serial, stm32};
+
+use core::ops::Range;
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+    let cp = cortex_m::peripheral::Peripherals::take().unwrap();
+
+    let gpioa = dp.GPIOA.split();
+    let gpiod = dp.GPIOD.split();
+
+    let mut led_bit5 = gpiod.pd12.into_push_pull_output();
+    let mut led_bit6 = gpiod.pd13.into_push_pull_output();
+    let mut led_bit7 = gpiod.pd14.into_push_pull_output();
+    let mut led_bit8 = gpiod.pd15.into_push_pull_output();
+
+    let rcc = dp.RCC.constrain();
+
+    let clocks = rcc.cfgr.use_hse(8.mhz()).freeze();
+
+    let mut delay = hal::delay::Delay::new(cp.SYST, clocks);
+
+    // define RX/TX pins
+    let tx_pin = gpioa.pa2.into_alternate_af7();
+    let rx_pin = gpioa.pa3.into_alternate_af7();
+
+    // configure serial
+    let serial = Serial::usart2(
+        dp.USART2,
+        (tx_pin, rx_pin),
+        Config::default().baudrate(9600.bps()).wordlength_9(),
+        clocks,
+    )
+    .unwrap();
+
+    let (mut tx, mut rx) = serial.split();
+
+    let nine_bit_integers: Range<u16> = 0x0..0x200;
+
+    loop {
+        for value in nine_bit_integers.clone() {
+            block!(tx.write(value)).unwrap();
+            // Receive what we just sent
+            // This type annotation is needed to disambiguate between the u8 and u16 read implementations
+            let received: u16 = block!(rx.read()).unwrap();
+
+            // Update LEDs to display what was received
+            if ((received >> 5) & 1) == 1 {
+                led_bit5.set_high().unwrap();
+            } else {
+                led_bit5.set_low().unwrap();
+            }
+            if ((received >> 6) & 1) == 1 {
+                led_bit6.set_high().unwrap();
+            } else {
+                led_bit6.set_low().unwrap();
+            }
+            if ((received >> 7) & 1) == 1 {
+                led_bit7.set_high().unwrap();
+            } else {
+                led_bit7.set_low().unwrap();
+            }
+            if ((received >> 8) & 1) == 1 {
+                led_bit8.set_high().unwrap();
+            } else {
+                led_bit8.set_low().unwrap();
+            }
+
+            delay.delay_ms(10u32);
+        }
+    }
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1637,7 +1637,7 @@ where
         } else if sr.ore().bit_is_set() {
             nb::Error::Other(Error::Overrun)
         } else if sr.rxne().bit_is_set() {
-            // NOTE(unsafe) atomic write to stateless register
+            // NOTE(unsafe) atomic read from stateless register
             return Ok(unsafe { &*USART::ptr() }.dr.read().dr().bits());
         } else {
             nb::Error::WouldBlock

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1591,6 +1591,21 @@ where
     }
 }
 
+impl<USART, PINS> serial::Read<u16> for Serial<USART, PINS>
+where
+    PINS: Pins<USART>,
+    USART: Instance,
+{
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<u16, Error> {
+        let mut rx: Rx<USART> = Rx {
+            _usart: PhantomData,
+        };
+        rx.read()
+    }
+}
+
 impl<USART, PINS> serial::Read<u8> for Serial<USART, PINS>
 where
     PINS: Pins<USART>,
@@ -1669,6 +1684,28 @@ where
     }
 
     type MemSize = u8;
+}
+
+impl<USART, PINS> serial::Write<u16> for Serial<USART, PINS>
+where
+    PINS: Pins<USART>,
+    USART: Instance,
+{
+    type Error = Error;
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        let mut tx: Tx<USART> = Tx {
+            _usart: PhantomData,
+        };
+        <Tx<USART> as serial::Write<u16>>::flush(&mut tx)
+    }
+
+    fn write(&mut self, byte: u16) -> nb::Result<(), Self::Error> {
+        let mut tx: Tx<USART> = Tx {
+            _usart: PhantomData,
+        };
+        tx.write(byte)
+    }
 }
 
 impl<USART, PINS> serial::Write<u8> for Serial<USART, PINS>
@@ -1815,6 +1852,28 @@ where
                 Err(nb::Error::Other(err)) => return Err(err),
             }
         }
+    }
+}
+
+impl<USART, PINS> blocking::serial::Write<u16> for Serial<USART, PINS>
+where
+    PINS: Pins<USART>,
+    USART: Instance,
+{
+    type Error = Error;
+
+    fn bwrite_all(&mut self, bytes: &[u16]) -> Result<(), Self::Error> {
+        let mut tx: Tx<USART> = Tx {
+            _usart: PhantomData,
+        };
+        tx.bwrite_all(bytes)
+    }
+
+    fn bflush(&mut self) -> Result<(), Self::Error> {
+        let mut tx: Tx<USART> = Tx {
+            _usart: PhantomData,
+        };
+        <Tx<USART> as blocking::serial::Write<u16>>::bflush(&mut tx)
     }
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,3 +1,17 @@
+//!
+//! Asynchronous serial communication using UART/USART peripherals
+//!
+//! # Word length
+//!
+//! By default, the UART/USART uses 8 data bits. The `Serial`, `Rx`, and `Tx` structs implement
+//! the embedded-hal read and write traits with `u8` as the word type.
+//!
+//! You can also configure the hardware to use 9 data bits with the `Config` `wordlength_9()`
+//! function. The `Serial`, `Rx`, and `Tx` structs also implement
+//! the embedded-hal read and write traits with `u16` as the word type. You can use these
+//! implementations for 9-bit words.
+//!
+
 use core::fmt;
 use core::marker::PhantomData;
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -7,7 +7,11 @@
 //! the embedded-hal read and write traits with `u8` as the word type.
 //!
 //! You can also configure the hardware to use 9 data bits with the `Config` `wordlength_9()`
-//! function. The `Serial`, `Rx`, and `Tx` structs also implement
+//! function. After creating a `Serial` with this option, use the `with_u16_data()` function to
+//! convert the `Serial<_, _, u8>` object into a `Serial<_, _, u16>` that can send and receive
+//! `u16`s.
+//!
+//! In this mode, the `Serial<_, _, u16>`, `Rx<_, u16>`, and `Tx<_, u16>` structs instead implement
 //! the embedded-hal read and write traits with `u16` as the word type. You can use these
 //! implementations for 9-bit words.
 //!
@@ -1396,22 +1400,25 @@ impl PinTx<UART10> for PG12<Alternate<AF11>> {}
 impl PinRx<UART10> for PG11<Alternate<AF11>> {}
 
 /// Serial abstraction
-pub struct Serial<USART, PINS> {
+pub struct Serial<USART, PINS, WORD = u8> {
     usart: USART,
     pins: PINS,
+    _word: PhantomData<WORD>,
 }
 
 /// Serial receiver
-pub struct Rx<USART> {
+pub struct Rx<USART, WORD = u8> {
     _usart: PhantomData<USART>,
+    _word: PhantomData<WORD>,
 }
 
 /// Serial transmitter
-pub struct Tx<USART> {
+pub struct Tx<USART, WORD = u8> {
     _usart: PhantomData<USART>,
+    _word: PhantomData<WORD>,
 }
 
-impl<USART, PINS> Serial<USART, PINS>
+impl<USART, PINS, WORD> Serial<USART, PINS, WORD>
 where
     PINS: Pins<USART>,
     USART: Instance,
@@ -1537,7 +1544,12 @@ where
             DmaConfig::None => {}
         }
 
-        Ok(Serial { usart, pins }.config_stop(config))
+        Ok(Serial {
+            usart,
+            pins,
+            _word: PhantomData,
+        }
+        .config_stop(config))
     }
 
     /// Starts listening for an interrupt event
@@ -1576,13 +1588,15 @@ where
         unsafe { (*USART::ptr()).sr.read().rxne().bit_is_set() }
     }
 
-    pub fn split(self) -> (Tx<USART>, Rx<USART>) {
+    pub fn split(self) -> (Tx<USART, WORD>, Rx<USART, WORD>) {
         (
             Tx {
                 _usart: PhantomData,
+                _word: PhantomData,
             },
             Rx {
                 _usart: PhantomData,
+                _word: PhantomData,
             },
         )
     }
@@ -1591,7 +1605,41 @@ where
     }
 }
 
-impl<USART, PINS> serial::Read<u16> for Serial<USART, PINS>
+impl<USART, PINS> Serial<USART, PINS, u8>
+where
+    PINS: Pins<USART>,
+    USART: Instance,
+{
+    /// Converts this Serial into a version that can read and write `u16` values instead of `u8`s
+    ///
+    /// This can be used with a word length of 9 bits.
+    pub fn with_u16_data(self) -> Serial<USART, PINS, u16> {
+        Serial {
+            usart: self.usart,
+            pins: self.pins,
+            _word: PhantomData,
+        }
+    }
+}
+
+impl<USART, PINS> Serial<USART, PINS, u16>
+where
+    PINS: Pins<USART>,
+    USART: Instance,
+{
+    /// Converts this Serial into a version that can read and write `u8` values instead of `u16`s
+    ///
+    /// This can be used with a word length of 8 bits.
+    pub fn with_u8_data(self) -> Serial<USART, PINS, u8> {
+        Serial {
+            usart: self.usart,
+            pins: self.pins,
+            _word: PhantomData,
+        }
+    }
+}
+
+impl<USART, PINS> serial::Read<u16> for Serial<USART, PINS, u16>
 where
     PINS: Pins<USART>,
     USART: Instance,
@@ -1599,14 +1647,15 @@ where
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u16, Error> {
-        let mut rx: Rx<USART> = Rx {
+        let mut rx: Rx<USART, u16> = Rx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
         rx.read()
     }
 }
 
-impl<USART, PINS> serial::Read<u8> for Serial<USART, PINS>
+impl<USART, PINS> serial::Read<u8> for Serial<USART, PINS, u8>
 where
     PINS: Pins<USART>,
     USART: Instance,
@@ -1614,14 +1663,15 @@ where
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Error> {
-        let mut rx: Rx<USART> = Rx {
+        let mut rx: Rx<USART, u8> = Rx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
         rx.read()
     }
 }
 
-impl<USART> serial::Read<u8> for Rx<USART>
+impl<USART> serial::Read<u8> for Rx<USART, u8>
 where
     USART: Instance,
 {
@@ -1629,7 +1679,11 @@ where
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         // Delegate to the Read<u16> implementation, then truncate to 8 bits
-        <Self as serial::Read<u16>>::read(self).map(|word16| word16 as u8)
+        let mut rx_u16: Rx<USART, u16> = Rx {
+            _usart: PhantomData,
+            _word: PhantomData,
+        };
+        rx_u16.read().map(|word16| word16 as u8)
     }
 }
 
@@ -1638,7 +1692,7 @@ where
 /// If the UART/USART was configured with `WordLength::DataBits9`, the returned value will contain
 /// 9 received data bits and all other bits set to zero. Otherwise, the returned value will contain
 /// 8 received data bits and all other bits set to zero.
-impl<USART> serial::Read<u16> for Rx<USART>
+impl<USART> serial::Read<u16> for Rx<USART, u16>
 where
     USART: Instance,
 {
@@ -1674,7 +1728,7 @@ where
     }
 }
 
-unsafe impl<USART> PeriAddress for Rx<USART>
+unsafe impl<USART> PeriAddress for Rx<USART, u8>
 where
     USART: Instance,
 {
@@ -1686,7 +1740,7 @@ where
     type MemSize = u8;
 }
 
-impl<USART, PINS> serial::Write<u16> for Serial<USART, PINS>
+impl<USART, PINS> serial::Write<u16> for Serial<USART, PINS, u16>
 where
     PINS: Pins<USART>,
     USART: Instance,
@@ -1694,21 +1748,23 @@ where
     type Error = Error;
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        let mut tx: Tx<USART> = Tx {
+        let mut tx: Tx<USART, u16> = Tx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
-        <Tx<USART> as serial::Write<u16>>::flush(&mut tx)
+        tx.flush()
     }
 
     fn write(&mut self, byte: u16) -> nb::Result<(), Self::Error> {
-        let mut tx: Tx<USART> = Tx {
+        let mut tx: Tx<USART, u16> = Tx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
         tx.write(byte)
     }
 }
 
-impl<USART, PINS> serial::Write<u8> for Serial<USART, PINS>
+impl<USART, PINS> serial::Write<u8> for Serial<USART, PINS, u8>
 where
     PINS: Pins<USART>,
     USART: Instance,
@@ -1716,21 +1772,23 @@ where
     type Error = Error;
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        let mut tx: Tx<USART> = Tx {
+        let mut tx: Tx<USART, u8> = Tx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
-        <Tx<USART> as serial::Write<u8>>::flush(&mut tx)
+        tx.flush()
     }
 
     fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
-        let mut tx: Tx<USART> = Tx {
+        let mut tx: Tx<USART, u8> = Tx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
         tx.write(byte)
     }
 }
 
-unsafe impl<USART> PeriAddress for Tx<USART>
+unsafe impl<USART> PeriAddress for Tx<USART, u8>
 where
     USART: Instance,
 {
@@ -1742,7 +1800,7 @@ where
     type MemSize = u8;
 }
 
-impl<USART> serial::Write<u8> for Tx<USART>
+impl<USART> serial::Write<u8> for Tx<USART, u8>
 where
     USART: Instance,
 {
@@ -1750,12 +1808,20 @@ where
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         // Delegate to u16 version
-        <Self as serial::Write<u16>>::write(self, u16::from(word))
+        let mut tx_u16: Tx<USART, u16> = Tx {
+            _usart: PhantomData,
+            _word: PhantomData,
+        };
+        tx_u16.write(u16::from(word))
     }
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         // Delegate to u16 version
-        <Self as serial::Write<u16>>::flush(self)
+        let mut tx_u16: Tx<USART, u16> = Tx {
+            _usart: PhantomData,
+            _word: PhantomData,
+        };
+        tx_u16.flush()
     }
 }
 
@@ -1764,7 +1830,7 @@ where
 /// If the UART/USART was configured with `WordLength::DataBits9`, the 9 least significant bits will
 /// be transmitted and the other 7 bits will be ignored. Otherwise, the 8 least significant bits
 /// will be transmitted and the other 8 bits will be ignored.
-impl<USART> serial::Write<u16> for Tx<USART>
+impl<USART> serial::Write<u16> for Tx<USART, u16>
 where
     USART: Instance,
 {
@@ -1795,7 +1861,7 @@ where
     }
 }
 
-impl<USART> blocking::serial::Write<u16> for Tx<USART>
+impl<USART> blocking::serial::Write<u16> for Tx<USART, u16>
 where
     USART: Instance,
 {
@@ -1825,7 +1891,7 @@ where
     }
 }
 
-impl<USART> blocking::serial::Write<u8> for Tx<USART>
+impl<USART> blocking::serial::Write<u8> for Tx<USART, u8>
 where
     USART: Instance,
 {
@@ -1855,7 +1921,7 @@ where
     }
 }
 
-impl<USART, PINS> blocking::serial::Write<u16> for Serial<USART, PINS>
+impl<USART, PINS> blocking::serial::Write<u16> for Serial<USART, PINS, u16>
 where
     PINS: Pins<USART>,
     USART: Instance,
@@ -1863,21 +1929,23 @@ where
     type Error = Error;
 
     fn bwrite_all(&mut self, bytes: &[u16]) -> Result<(), Self::Error> {
-        let mut tx: Tx<USART> = Tx {
+        let mut tx: Tx<USART, u16> = Tx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
         tx.bwrite_all(bytes)
     }
 
     fn bflush(&mut self) -> Result<(), Self::Error> {
-        let mut tx: Tx<USART> = Tx {
+        let mut tx: Tx<USART, u16> = Tx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
-        <Tx<USART> as blocking::serial::Write<u16>>::bflush(&mut tx)
+        tx.bflush()
     }
 }
 
-impl<USART, PINS> blocking::serial::Write<u8> for Serial<USART, PINS>
+impl<USART, PINS> blocking::serial::Write<u8> for Serial<USART, PINS, u8>
 where
     PINS: Pins<USART>,
     USART: Instance,
@@ -1885,21 +1953,23 @@ where
     type Error = Error;
 
     fn bwrite_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
-        let mut tx: Tx<USART> = Tx {
+        let mut tx: Tx<USART, u8> = Tx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
         tx.bwrite_all(bytes)
     }
 
     fn bflush(&mut self) -> Result<(), Self::Error> {
-        let mut tx: Tx<USART> = Tx {
+        let mut tx: Tx<USART, u8> = Tx {
             _usart: PhantomData,
+            _word: PhantomData,
         };
-        <Tx<USART> as blocking::serial::Write<u8>>::bflush(&mut tx)
+        tx.bflush()
     }
 }
 
-impl<USART, PINS> Serial<USART, PINS>
+impl<USART, PINS, WORD> Serial<USART, PINS, WORD>
 where
     PINS: Pins<USART>,
     USART: Instance,


### PR DESCRIPTION
# Motivation

In [issue 280](https://github.com/stm32-rs/stm32f4xx-hal/issues/280), Maldus512 asked how to use 9-bit words with the serial driver. I noticed that the current code did not allow that use, so I decided to improve the code.

# Part 1: 16-bit reads and writes for 9-bit words

I added a `WORD` type parameter to `Serial`, `Tx`, and `Rx`. It defaults to `u8`, so that existing code will not break. I also added functions to convert between `Serial<USART, PINS, u8>` and `Serial<USART, PINS, u16>`.

I added some trait implementations that use `u16` as the word type instead of `u8`:

* `impl<USART> serial::Read<u16> for Rx<USART, u16>`
* `impl<USART> serial::Write<u16> for Tx<USART, u16>`
* `impl<USART> blocking::serial::Write<u16> for Tx<USART, u16>`
* `impl<USART, PINS> serial::Read<u16> for Serial<USART, PINS, u16>`
* `impl<USART, PINS> serial::Write<u16> for Serial<USART, PINS, u16>`
* `impl<USART, PINS> blocking::serial::Write<u16> for Serial<USART, PINS, u16>`

I also added a simple example that demonstrates that the hardware can send and receive 9 bits.

## Probably not a breaking change

Because the `WORD` type parameter has a default value of `u8`, existing code that does not specify `WORD` should continue to compile and work correctly. When `WORD` is not specified, `Serial`, `Tx`, and `Rx` implement the same traits as before.

## Limitations

It is possible to configure a USART with 8-bit word length and then send/receive `u16`s. We could prevent this error, but it would require a major breaking change to the configuration code that is probably not worth it.

DMA with 16-bit words is not yet supported.

# Part 2: 32-bit read and write operations on USART_DR

While working on part 1, I noticed that the current code goes out of its way to read or write only 8 bits when accessing the USART data register. Based on the reference manuals, this might be incorrect.

In most STM32F4 reference manuals, the beginning of the "USART registers" section says that "The peripheral registers have to be accessed by half-words (16 bits) or words (32 bits)."
The STM32F446 reference manual is more restrictive: "The peripheral registers have to be accessed by words (32 bits)."
The C drivers provided by ST appear to use 32-bit reads and writes on the data register.

Therefore, I have replaced the custom 8-bit reads and writes with 32-bit reads and writes that use the normal svd2rust API.

With this change applied, the `serial` example still works.
