### PR TITLE
Fix duplicate "Added" sections in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added an example of integration with RTIC.
 - Added internal pullup configuaration for the AlternateOD pin type
+- Added support for I2S communication using SPI peripherals, and two examples [#265]
+
+[#265]: https://github.com/stm32-rs/stm32f4xx-hal/pull/265
 
 ### Changed
 
 - Update the sdio driver to match the changes in the PAC
 - Update README.md with current information
-
-### Added
-
-- Added support for I2S communication using SPI peripherals, and two examples [#265]
-
-[#265]: https://github.com/stm32-rs/stm32f4xx-hal/pull/265
 
 ## [v0.9.0] - 2021-04-04
 


### PR DESCRIPTION
With three recently merged pull requests, we ended up with two "Added" sections in different parts of the unreleased section of the changelog. I propose to combine them into one section, above the "Changed" section.