### PR TITLE
Add open-drain pin mode support for PWM output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added an example for using the new FSMC interface with the provided
   `display-interface` driver and the `st7789` driver on a F413Discovery board [#302]
 - Derive `Eq`, `PartialEq`, `Copy` and `Clone` for error types
+- Added open-drain pin mode support for PWM output [#313]
 
 [#265]: https://github.com/stm32-rs/stm32f4xx-hal/pull/265
 [#297]: https://github.com/stm32-rs/stm32f4xx-hal/pull/297
 [#302]: https://github.com/stm32-rs/stm32f4xx-hal/pull/302
+[#313]: https://github.com/stm32-rs/stm32f4xx-hal/pull/313
 
 ### Changed
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,4 +1,7 @@
 //! Timers
+//!
+//! Pins can be used for PWM output in both push-pull mode (`Alternate`) and open-drain mode
+//! (`AlternateOD`).
 
 use cast::{u16, u32};
 use cortex_m::peripheral::syst::SystClkSource;
@@ -626,7 +629,7 @@ use crate::gpio::AF2;
 ))]
 use crate::gpio::AF3;
 
-use crate::gpio::{gpioa::*, Alternate};
+use crate::gpio::{gpioa::*, Alternate, AlternateOD};
 
 // Output channels marker traits
 pub trait PinC1<TIM> {}
@@ -637,7 +640,8 @@ pub trait PinC4<TIM> {}
 macro_rules! channel_impl {
     ( $( $TIM:ident, $PINC:ident, $PINX:ident, $MODE:ident<$AF:ident>; )+ ) => {
         $(
-            impl $PINC<$TIM> for $PINX<$MODE<$AF>> {}
+            impl $PINC<$TIM> for $PINX<Alternate<$AF>> {}
+            impl $PINC<$TIM> for $PINX<AlternateOD<$AF>> {}
         )+
     };
 }


### PR DESCRIPTION
### Motivation

ATX-compatible fans have PWM speed control inputs that they internally pull up (to 5.2.5 V maximum). To correctly control the speed of these fans, a microcontroller needs to generate a PWM signal with a pin in open-drain mode.

### Changes

This pull request makes the PWM code support `AlternateOD` mode in addition to `Alternate` mode for all currently supported pins.