### PR TITLE
Added compatibility constants to keep `Alternate<AFx>` working just as before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Instead of `Alternate<AF1>` use just `Alternate<1>`.
+- Instead of `Alternate<AF1>` you can just use `Alternate<1>`.
 - `PinState` and `get/set_state`.
 - Inherent methods for infallible digital operations.
 - Generic `into_alternate` and `into_alternate_open_drain`. Non-generic ones are deprecated
-- Internal implementation of GPIO Pin API changed to use Const Generics
 - `PinExt` trait. Make `ExtiPin` implementation generic
 - `Enable`, `LPEnable` and `Reset` traits in `rcc`. Implemented for all used peripherals
 - Features corresponding to peripherals
@@ -39,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Internal implementation of GPIO Pin API changed to use Const Generics
 - Update the sdio driver to match the changes in the PAC
 - Update README.md with current information
 - Updated serial driver to use 32-bit reads and writes when accessing the USART data register [#299]

--- a/examples/i2s-audio-out-dma.rs
+++ b/examples/i2s-audio-out-dma.rs
@@ -55,6 +55,7 @@ use stm32f4xx_hal::dma::{Channel0, Stream5, StreamsTuple, Transfer};
 use stm32f4xx_hal::gpio::gpioa::PA4;
 use stm32f4xx_hal::gpio::gpioc::{PC10, PC12, PC7};
 use stm32f4xx_hal::gpio::Alternate;
+use stm32f4xx_hal::gpio::AF6;
 use stm32f4xx_hal::i2c::I2c;
 use stm32f4xx_hal::i2s::I2s;
 use stm32f4xx_hal::pac::{interrupt, Interrupt};
@@ -216,10 +217,10 @@ type I2sDmaTransfer = Transfer<
         I2s<
             SPI3,
             (
-                PA4<Alternate<6>>,
-                PC10<Alternate<6>>,
-                PC7<Alternate<6>>,
-                PC12<Alternate<6>>,
+                PA4<Alternate<AF6>>,
+                PC10<Alternate<AF6>>,
+                PC7<Alternate<AF6>>,
+                PC12<Alternate<AF6>>,
             ),
         >,
         TransmitMode<Data16Frame16>,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -33,6 +33,24 @@ pub struct Alternate<const A: u8>;
 /// Some alternate mode in open drain configuration (type state)
 pub struct AlternateOD<const A: u8>;
 
+// Compatibility constants
+pub const AF0: u8 = 0;
+pub const AF1: u8 = 1;
+pub const AF2: u8 = 2;
+pub const AF3: u8 = 3;
+pub const AF4: u8 = 4;
+pub const AF5: u8 = 5;
+pub const AF6: u8 = 6;
+pub const AF7: u8 = 7;
+pub const AF8: u8 = 8;
+pub const AF9: u8 = 9;
+pub const AF10: u8 = 10;
+pub const AF11: u8 = 11;
+pub const AF12: u8 = 12;
+pub const AF13: u8 = 13;
+pub const AF14: u8 = 14;
+pub const AF15: u8 = 15;
+
 /// Input mode (type state)
 pub struct Input<MODE> {
     _mode: PhantomData<MODE>,


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>