### PR TITLE
NoPin & no Pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Filler `NoPin` type 
 - Add inherent impl of `PwmPin` methods on `PwmChannel`s.
 - `Serial:tx` and `Serial::rx` that take only 1 pin
 - Instead of `Alternate<AF1>` you can just use `Alternate<1>`.

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -14,6 +14,9 @@ pub use partially_erased::PEPin;
 mod erased;
 pub use erased::EPin;
 
+/// A filler pin type
+pub struct NoPin;
+
 /// Extension trait to split a GPIO peripheral in independent pins and registers
 pub trait GpioExt {
     /// The parts to split the GPIO into

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -267,11 +267,12 @@ impl private::Sealed for I2C3 {}
 impl Instance for I2C3 {}
 
 #[cfg(feature = "fmpi2c1")]
-impl<PINS> FMPI2c<FMPI2C1, PINS>
+impl<SCL, SDA> FMPI2c<FMPI2C1, (SCL, SDA)>
 where
-    PINS: Pins<FMPI2C1>,
+    SCL: PinScl<FMPI2C1>,
+    SDA: PinSda<FMPI2C1>,
 {
-    pub fn new(i2c: FMPI2C1, pins: PINS, speed: KiloHertz) -> Self {
+    pub fn new(i2c: FMPI2C1, pins: (SCL, SDA), speed: KiloHertz) -> Self {
         unsafe {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.
             let rcc = &(*RCC::ptr());
@@ -289,12 +290,13 @@ where
     }
 }
 
-impl<I2C, PINS> I2c<I2C, PINS>
+impl<I2C, SCL, SDA> I2c<I2C, (SCL, SDA)>
 where
     I2C: Instance,
-    PINS: Pins<I2C>,
+    SCL: PinScl<I2C>,
+    SDA: PinSda<I2C>,
 {
-    pub fn new(i2c: I2C, pins: PINS, speed: KiloHertz, clocks: Clocks) -> Self {
+    pub fn new(i2c: I2C, pins: (SCL, SDA), speed: KiloHertz, clocks: Clocks) -> Self {
         unsafe {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.
             let rcc = &(*RCC::ptr());

--- a/src/i2s.rs
+++ b/src/i2s.rs
@@ -293,12 +293,15 @@ macro_rules! i2s {
             }
         }
 
-        impl<PINS> I2s<$SPIX, PINS>
+        impl<PWS, PCK, PMCLK, PSD> I2s<$SPIX, (PWS, PCK, PMCLK, PSD)>
         where
-            PINS: Pins<$SPIX>,
+            PWS: PinWs<$SPIX>,
+            PCK: PinCk<$SPIX>,
+            PMCLK: PinMck<$SPIX>,
+            PSD: PinSd<$SPIX>,
         {
             #[deprecated(since = "0.10.0", note = "Please use new instead")]
-            pub fn $i2sx(spi: $SPIX, pins: PINS, clocks: Clocks) -> Self {
+            pub fn $i2sx(spi: $SPIX, pins: (PWS, PCK, PMCLK, PSD), clocks: Clocks) -> Self {
                 Self::new(spi, pins, clocks)
             }
         }
@@ -309,10 +312,13 @@ macro_rules! i2s {
     };
 }
 
-impl<SPI, PINS> I2s<SPI, PINS>
+impl<SPI, PWS, PCK, PMCLK, PSD> I2s<SPI, (PWS, PCK, PMCLK, PSD)>
 where
     SPI: I2sFreq + rcc::Enable + rcc::Reset,
-    PINS: Pins<SPI>,
+    PWS: PinWs<SPI>,
+    PCK: PinCk<SPI>,
+    PMCLK: PinMck<SPI>,
+    PSD: PinSd<SPI>,
 {
     /// Creates an I2s object around an SPI peripheral and pins
     ///
@@ -325,7 +331,7 @@ where
     ///
     /// This function panics if the I2S clock input (from the I2S PLL or similar)
     /// is not configured.
-    pub fn new(spi: SPI, pins: PINS, clocks: Clocks) -> Self {
+    pub fn new(spi: SPI, pins: (PWS, PCK, PMCLK, PSD), clocks: Clocks) -> Self {
         let input_clock = SPI::i2s_freq(&clocks);
         unsafe {
             // NOTE(unsafe) this reference will only be used for atomic writes with no side effects.

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -56,7 +56,7 @@ use crate::pac::UART8;
 #[cfg(feature = "uart9")]
 use crate::pac::UART9;
 
-use crate::gpio::Alternate;
+use crate::gpio::{Alternate, NoPin};
 use crate::rcc::Clocks;
 
 use crate::dma::traits::PeriAddress;
@@ -192,13 +192,13 @@ where
 }
 
 /// A filler type for when the Tx pin is unnecessary
-pub struct NoTx;
+pub type NoTx = NoPin;
 /// A filler type for when the Rx pin is unnecessary
-pub struct NoRx;
+pub type NoRx = NoPin;
 
-impl PinTx<USART1> for NoTx {}
+impl<USART> PinTx<USART> for NoPin where USART: Instance {}
 
-impl PinRx<USART1> for NoRx {}
+impl<USART> PinRx<USART> for NoPin where USART: Instance {}
 
 impl PinTx<USART1> for gpioa::PA9<Alternate<7>> {}
 
@@ -223,10 +223,6 @@ impl PinRx<USART1> for gpiob::PB3<Alternate<7>> {}
 impl PinTx<USART1> for gpiob::PB6<Alternate<7>> {}
 
 impl PinRx<USART1> for gpiob::PB7<Alternate<7>> {}
-
-impl PinTx<USART2> for NoTx {}
-
-impl PinRx<USART2> for NoRx {}
 
 impl PinTx<USART2> for gpioa::PA2<Alternate<7>> {}
 
@@ -270,10 +266,6 @@ impl PinTx<USART2> for gpiod::PD5<Alternate<7>> {}
 ))]
 impl PinRx<USART2> for gpiod::PD6<Alternate<7>> {}
 
-#[cfg(feature = "usart3")]
-impl PinTx<USART3> for NoTx {}
-#[cfg(feature = "usart3")]
-impl PinRx<USART3> for NoRx {}
 #[cfg(feature = "usart3")]
 impl PinTx<USART3> for gpiob::PB10<Alternate<7>> {}
 #[cfg(feature = "usart3")]
@@ -355,10 +347,6 @@ impl PinTx<USART3> for gpiod::PD8<Alternate<7>> {}
 impl PinRx<USART3> for gpiod::PD9<Alternate<7>> {}
 
 #[cfg(feature = "uart4")]
-impl PinTx<UART4> for NoTx {}
-#[cfg(feature = "uart4")]
-impl PinRx<UART4> for NoRx {}
-#[cfg(feature = "uart4")]
 impl PinTx<UART4> for gpioa::PA0<Alternate<8>> {}
 #[cfg(feature = "uart4")]
 impl PinRx<UART4> for gpioa::PA1<Alternate<8>> {}
@@ -403,10 +391,6 @@ impl PinTx<UART4> for gpiod::PD10<Alternate<8>> {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
 impl PinRx<UART4> for gpioc::PC11<Alternate<8>> {}
 
-#[cfg(feature = "uart5")]
-impl PinTx<UART5> for NoTx {}
-#[cfg(feature = "uart5")]
-impl PinRx<UART5> for NoRx {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
 impl PinTx<UART5> for gpiob::PB6<Alternate<11>> {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
@@ -428,9 +412,6 @@ impl PinTx<UART5> for gpioe::PE8<Alternate<8>> {}
 #[cfg(any(feature = "stm32f446"))]
 impl PinRx<UART5> for gpioe::PE7<Alternate<8>> {}
 
-impl PinTx<USART6> for NoTx {}
-
-impl PinRx<USART6> for NoRx {}
 #[cfg(any(
     feature = "stm32f401",
     feature = "stm32f410",
@@ -488,10 +469,6 @@ impl PinTx<USART6> for gpiog::PG14<Alternate<8>> {}
 ))]
 impl PinRx<USART6> for gpiog::PG9<Alternate<8>> {}
 
-#[cfg(feature = "uart7")]
-impl PinTx<UART7> for NoTx {}
-#[cfg(feature = "uart7")]
-impl PinRx<UART7> for NoRx {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
 impl PinTx<UART7> for gpioa::PA15<Alternate<8>> {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
@@ -509,10 +486,6 @@ impl PinTx<UART7> for gpiof::PF7<Alternate<8>> {}
 #[cfg(all(feature = "uart7", feature = "gpiof"))]
 impl PinRx<UART7> for gpiof::PF6<Alternate<8>> {}
 
-#[cfg(feature = "uart8")]
-impl PinTx<UART8> for NoTx {}
-#[cfg(feature = "uart8")]
-impl PinRx<UART8> for NoRx {}
 #[cfg(all(feature = "uart8", feature = "gpioe"))]
 impl PinTx<UART8> for gpioe::PE1<Alternate<8>> {}
 #[cfg(all(feature = "uart8", feature = "gpioe"))]
@@ -522,10 +495,6 @@ impl PinTx<UART8> for gpiof::PF9<Alternate<8>> {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
 impl PinRx<UART8> for gpiof::PF8<Alternate<8>> {}
 
-#[cfg(feature = "uart9")]
-impl PinTx<UART9> for NoTx {}
-#[cfg(feature = "uart9")]
-impl PinRx<UART9> for NoRx {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
 impl PinTx<UART9> for gpiod::PD15<Alternate<11>> {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
@@ -535,10 +504,6 @@ impl PinTx<UART9> for gpiog::PG1<Alternate<11>> {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
 impl PinRx<UART9> for gpiog::PG0<Alternate<11>> {}
 
-#[cfg(feature = "uart10")]
-impl PinTx<UART10> for NoTx {}
-#[cfg(feature = "uart10")]
-impl PinRx<UART10> for NoRx {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
 impl PinTx<UART10> for gpioe::PE3<Alternate<11>> {}
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
@@ -567,9 +532,10 @@ pub struct Tx<USART, WORD = u8> {
     _word: PhantomData<WORD>,
 }
 
-impl<USART, PINS, WORD> Serial<USART, PINS, WORD>
+impl<USART, TX, RX, WORD> Serial<USART, (TX, RX), WORD>
 where
-    PINS: Pins<USART>,
+    TX: PinTx<USART>,
+    RX: PinRx<USART>,
     USART: Instance,
 {
     /*
@@ -579,7 +545,7 @@ where
     */
     pub fn new(
         usart: USART,
-        pins: PINS,
+        pins: (TX, RX),
         config: config::Config,
         clocks: Clocks,
     ) -> Result<Self, config::InvalidConfig> {
@@ -696,9 +662,9 @@ where
     }
 }
 
-impl<USART, TX, WORD> Serial<USART, (TX, NoRx), WORD>
+impl<USART, TX, WORD> Serial<USART, (TX, NoPin), WORD>
 where
-    (TX, NoRx): Pins<USART>,
+    TX: PinTx<USART>,
     USART: Instance,
 {
     pub fn tx(
@@ -707,13 +673,13 @@ where
         config: config::Config,
         clocks: Clocks,
     ) -> Result<Tx<USART, WORD>, config::InvalidConfig> {
-        Self::new(usart, (tx_pin, NoRx), config, clocks).map(|s| s.split().0)
+        Self::new(usart, (tx_pin, NoPin), config, clocks).map(|s| s.split().0)
     }
 }
 
-impl<USART, RX, WORD> Serial<USART, (NoTx, RX), WORD>
+impl<USART, RX, WORD> Serial<USART, (NoPin, RX), WORD>
 where
-    (NoTx, RX): Pins<USART>,
+    RX: PinRx<USART>,
     USART: Instance,
 {
     pub fn rx(
@@ -722,7 +688,7 @@ where
         config: config::Config,
         clocks: Clocks,
     ) -> Result<Rx<USART, WORD>, config::InvalidConfig> {
-        Self::new(usart, (NoTx, rx_pin), config, clocks).map(|s| s.split().1)
+        Self::new(usart, (NoPin, rx_pin), config, clocks).map(|s| s.split().1)
     }
 }
 
@@ -1220,15 +1186,16 @@ macro_rules! halUsart {
             }
         }
 
-        impl<USART, PINS> Serial<USART, PINS>
+        impl<USART, TX, RX> Serial<USART, (TX, RX)>
         where
-            PINS: Pins<USART>,
+            TX: PinTx<USART>,
+            RX: PinRx<USART>,
             USART: Instance,
         {
             #[deprecated(since = "0.10.0")]
             pub fn $usartX(
                 usart: USART,
-                pins: PINS,
+                pins: (TX, RX),
                 config: config::Config,
                 clocks: Clocks,
             ) -> Result<Self, config::InvalidConfig> {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1242,15 +1242,16 @@ macro_rules! halUart {
             }
         }
 
-        impl<USART, PINS> Serial<USART, PINS>
+        impl<USART, TX, RX> Serial<USART, (TX, RX)>
         where
-            PINS: Pins<USART>,
+            TX: PinTx<USART>,
+            RX: PinRx<USART>,
             USART: Instance,
         {
             #[deprecated(since = "0.10.0")]
             pub fn $usartX(
                 usart: USART,
-                pins: PINS,
+                pins: (TX, RX),
                 config: config::Config,
                 clocks: Clocks,
             ) -> Result<Self, config::InvalidConfig> {


### PR DESCRIPTION
One `NoPin` type and `NoTx`, `NoSck etc. are aliases for it.

Use `(TX, RX)` directly in constructors instead of `Pins`. Better for docs:
![изображение](https://user-images.githubusercontent.com/3072754/125181418-3bc2b380-e20d-11eb-8b71-176e9f8d6d31.png)

vs

![изображение](https://user-images.githubusercontent.com/3072754/125181423-4715df00-e20d-11eb-86d0-bfdcb51eec35.png)
