### PR TITLE
Add listen/unlisten for RX/TX-only USART

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added PWM input capability to all compatable timers [#271]
 - [breaking-change] `gpio::Edge::{RISING, FALLING, RISING_FALLING}` are renamed to `Rising`, `Falling`, `RisingFalling`, respectively.
 - Bidi mode support for SPI [#349]
-- Added `listen` and `unlisten` for RX- and TX-only USART
-- Added function for clearing the idle line interrupt in USART
+- Added `listen` and `unlisten` for RX- and TX-only USART [#357]
+- Added function for clearing the idle line interrupt in USART [#357]
 
 [#265]: https://github.com/stm32-rs/stm32f4xx-hal/pull/265
 [#271] https://github.com/stm32-rs/stm32f4xx-hal/pull/271
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#313]: https://github.com/stm32-rs/stm32f4xx-hal/pull/313
 [#318]: https://github.com/stm32-rs/stm32f4xx-hal/pull/318
 [#349]: https://github.com/stm32-rs/stm32f4xx-hal/pull/349
+[#357]: https://github.com/stm32-rs/stm32f4xx-hal/pull/357
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added PWM input capability to all compatable timers [#271]
 - [breaking-change] `gpio::Edge::{RISING, FALLING, RISING_FALLING}` are renamed to `Rising`, `Falling`, `RisingFalling`, respectively.
 - Bidi mode support for SPI [#349]
+- Added `listen` and `unlisten` for RX- and TX-only USART
+- Added function for clearing the idle line interrupt in USART
 
 [#265]: https://github.com/stm32-rs/stm32f4xx-hal/pull/265
 [#271] https://github.com/stm32-rs/stm32f4xx-hal/pull/271

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -543,25 +543,30 @@ where
         }
     }
 
-    /// Start listening for an interrupt event
+    /// Start listening for an rx not empty interrupt event
     ///
     /// Note, you will also have to enable the corresponding interrupt
     /// in the NVIC to start receiving events.
-    pub fn listen(&mut self, event: Event) {
-        match event {
-            Event::Rxne => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) },
-            Event::Txe => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) },
-            Event::Idle => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) },
-        }
+    pub fn listen(&mut self) {
+        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) }
     }
 
-    /// Stop listening for an interrupt event
-    pub fn unlisten(&mut self, event: Event) {
-        match event {
-            Event::Rxne => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) },
-            Event::Txe => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) },
-            Event::Idle => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) },
-        }
+    /// Stop listening for the rx not empty interrupt event
+    pub fn unlisten(&mut self) {
+        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) }
+    }
+
+    /// Start listening for a line idle interrupt event
+    ///
+    /// Note, you will also have to enable the corresponding interrupt
+    /// in the NVIC to start receiving events.
+    pub fn listen_idle(&mut self) {
+        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) }
+    }
+
+    /// Stop listening for the line idle interrupt event
+    pub fn unlisten_idle(&mut self) {
+        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) }
     }
 
     /// Return true if the line idle status is set
@@ -594,25 +599,17 @@ where
         }
     }
 
-    /// Start listening for an interrupt event
+    /// Start listening for a tx empty interrupt event
     ///
     /// Note, you will also have to enable the corresponding interrupt
     /// in the NVIC to start receiving events.
-    pub fn listen(&mut self, event: Event) {
-        match event {
-            Event::Rxne => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) },
-            Event::Txe => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) },
-            Event::Idle => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) },
-        }
+    pub fn listen(&mut self) {
+        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) }
     }
 
-    /// Stop listening for an interrupt event
-    pub fn unlisten(&mut self, event: Event) {
-        match event {
-            Event::Rxne => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) },
-            Event::Txe => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) },
-            Event::Idle => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) },
-        }
+    /// Stop listening for the tx empty interrupt event
+    pub fn unlisten(&mut self) {
+        unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) }
     }
 
     /// Return true if the tx register is empty (and can accept data)

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -575,15 +575,15 @@ where
     }
 
     /// Return true if the rx register is not empty (and can be read)
-    pub fn is_rxne(&self) -> bool {
+    pub fn is_rx_not_empty(&self) -> bool {
         unsafe { (*USART::ptr()).sr.read().rxne().bit_is_set() }
     }
 
     // Clear idle line interrupt flag
     pub fn clear_idle_interrupt(&self) {
         unsafe {
-            let _ = (*USART::ptr()).sr.read().idle();
-            let _ = (*USART::ptr()).dr.read().bits();
+            let _ = (*USART::ptr()).sr.read();
+            let _ = (*USART::ptr()).dr.read();
         }
     }
 }
@@ -613,7 +613,7 @@ where
     }
 
     /// Return true if the tx register is empty (and can accept data)
-    pub fn is_txe(&self) -> bool {
+    pub fn is_tx_empty(&self) -> bool {
         unsafe { (*USART::ptr()).sr.read().txe().bit_is_set() }
     }
 }
@@ -809,11 +809,23 @@ where
     }
 
     /// Return true if the tx register is empty (and can accept data)
+    pub fn is_tx_empty(&self) -> bool {
+        unsafe { (*USART::ptr()).sr.read().txe().bit_is_set() }
+    }
+
+    /// Return true if the tx register is empty (and can accept data)
+    #[deprecated(since = "0.10.0")]
     pub fn is_txe(&self) -> bool {
         unsafe { (*USART::ptr()).sr.read().txe().bit_is_set() }
     }
 
     /// Return true if the rx register is not empty (and can be read)
+    pub fn is_rx_not_empty(&self) -> bool {
+        unsafe { (*USART::ptr()).sr.read().rxne().bit_is_set() }
+    }
+
+    /// Return true if the rx register is not empty (and can be read)
+    #[deprecated(since = "0.10.0")]
     pub fn is_rxne(&self) -> bool {
         unsafe { (*USART::ptr()).sr.read().rxne().bit_is_set() }
     }
@@ -821,8 +833,8 @@ where
     // Clear idle line interrupt flag
     pub fn clear_idle_interrupt(&self) {
         unsafe {
-            let _ = (*USART::ptr()).sr.read().idle();
-            let _ = (*USART::ptr()).dr.read().bits();
+            let _ = (*USART::ptr()).sr.read();
+            let _ = (*USART::ptr()).dr.read();
         }
     }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -532,21 +532,92 @@ pub struct Tx<USART, WORD = u8> {
     _word: PhantomData<WORD>,
 }
 
-impl<USART, WORD> Rx<USART, WORD> {
+impl<USART, WORD> Rx<USART, WORD>
+where
+    USART: Instance,
+{
     fn new() -> Self {
         Self {
             _usart: PhantomData,
             _word: PhantomData,
         }
     }
+
+    /// Start listening for an interrupt event
+    ///
+    /// Note, you will also have to enable the corresponding interrupt
+    /// in the NVIC to start receiving events.
+    pub fn listen(&mut self, event: Event) {
+        match event {
+            Event::Rxne => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) },
+            Event::Txe => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) },
+            Event::Idle => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) },
+        }
+    }
+
+    /// Stop listening for an interrupt event
+    pub fn unlisten(&mut self, event: Event) {
+        match event {
+            Event::Rxne => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) },
+            Event::Txe => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) },
+            Event::Idle => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) },
+        }
+    }
+
+    /// Return true if the line idle status is set
+    pub fn is_idle(&self) -> bool {
+        unsafe { (*USART::ptr()).sr.read().idle().bit_is_set() }
+    }
+
+    /// Return true if the rx register is not empty (and can be read)
+    pub fn is_rxne(&self) -> bool {
+        unsafe { (*USART::ptr()).sr.read().rxne().bit_is_set() }
+    }
+
+    // Clear idle line interrupt flag
+    pub fn clear_idle_interrupt(&self) {
+        unsafe {
+            let _ = (*USART::ptr()).sr.read().idle();
+            let _ = (*USART::ptr()).dr.read().bits();
+        }
+    }
 }
 
-impl<USART, WORD> Tx<USART, WORD> {
+impl<USART, WORD> Tx<USART, WORD>
+where
+    USART: Instance,
+{
     fn new() -> Self {
         Self {
             _usart: PhantomData,
             _word: PhantomData,
         }
+    }
+
+    /// Start listening for an interrupt event
+    ///
+    /// Note, you will also have to enable the corresponding interrupt
+    /// in the NVIC to start receiving events.
+    pub fn listen(&mut self, event: Event) {
+        match event {
+            Event::Rxne => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) },
+            Event::Txe => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) },
+            Event::Idle => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) },
+        }
+    }
+
+    /// Stop listening for an interrupt event
+    pub fn unlisten(&mut self, event: Event) {
+        match event {
+            Event::Rxne => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) },
+            Event::Txe => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) },
+            Event::Idle => unsafe { (*USART::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) },
+        }
+    }
+
+    /// Return true if the tx register is empty (and can accept data)
+    pub fn is_txe(&self) -> bool {
+        unsafe { (*USART::ptr()).sr.read().txe().bit_is_set() }
     }
 }
 
@@ -748,6 +819,14 @@ where
     /// Return true if the rx register is not empty (and can be read)
     pub fn is_rxne(&self) -> bool {
         unsafe { (*USART::ptr()).sr.read().rxne().bit_is_set() }
+    }
+
+    // Clear idle line interrupt flag
+    pub fn clear_idle_interrupt(&self) {
+        unsafe {
+            let _ = (*USART::ptr()).sr.read().idle();
+            let _ = (*USART::ptr()).dr.read().bits();
+        }
     }
 
     pub fn split(self) -> (Tx<USART, WORD>, Rx<USART, WORD>) {


### PR DESCRIPTION
This PR adds `listen` and `unlisten` functions for the RX and TX only USART modes.
It also adds functions for checking the relevant interrupt flags and for clearing the idle line interrupt flag.