### PR TITLE
SetAlternate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update examples with `embedded-graphics`,
   remove deprecated `I2s::i2sx` [#358]
+- `into_alternate()` may be omitted now for `Serial`, `Spi`, `I2s`, `I2c` [#355]
 - [breaking-change] 115_200 bps for Serial by default [#355]
 - Move `Tx`, `Rx` structures into `Serial` [#355]
 - Update `embedded-hal` dependendency [#356]
@@ -125,7 +126,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#351]: https://github.com/stm32-rs/stm32f4xx-hal/pull/351
 [#355]: https://github.com/stm32-rs/stm32f4xx-hal/pull/355
 [#356]: https://github.com/stm32-rs/stm32f4xx-hal/pull/356
+<<<<<<< HEAD
 [#358]: https://github.com/stm32-rs/stm32f4xx-hal/pull/358
+=======
+[#359]: https://github.com/stm32-rs/stm32f4xx-hal/pull/359
+>>>>>>> 162df0e... SetAlternate
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,11 +126,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#351]: https://github.com/stm32-rs/stm32f4xx-hal/pull/351
 [#355]: https://github.com/stm32-rs/stm32f4xx-hal/pull/355
 [#356]: https://github.com/stm32-rs/stm32f4xx-hal/pull/356
-<<<<<<< HEAD
 [#358]: https://github.com/stm32-rs/stm32f4xx-hal/pull/358
-=======
 [#359]: https://github.com/stm32-rs/stm32f4xx-hal/pull/359
->>>>>>> 162df0e... SetAlternate
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update examples with `embedded-graphics`,
   remove deprecated `I2s::i2sx` [#358]
-- `into_alternate()` may be omitted now for `Serial`, `Spi`, `I2s`, `I2c` [#355]
+- `into_alternate()` may be omitted now for `Serial`, `Spi`, `I2s`, `I2c` [#359]
 - [breaking-change] 115_200 bps for Serial by default [#355]
 - Move `Tx`, `Rx` structures into `Serial` [#355]
 - Update `embedded-hal` dependendency [#356]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -56,6 +56,7 @@ use crate::pac::EXTI;
 use crate::syscfg::SysCfg;
 
 mod convert;
+pub(crate) use convert::{Const, SetAlternate, SetAlternateOD};
 mod partially_erased;
 pub use partially_erased::{PEPin, PartiallyErasedPin};
 mod erased;


### PR DESCRIPTION
With this PR passing `into_alternate()` is not necessary (but still can be used) when you work with `Serial`, `Spi`, `I2c` or `I2s`.
Pins will be internally switched in alternated mode and restored on `release`.