### PR TITLE
Add missing implementation for `IoPin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `IoPin` for `Output<OpenDrain>> <-> Input<Floating>>` [#374]
+
+[#374]: https://github.com/stm32-rs/stm32f4xx-hal/pull/374
+
 ### Changed
 
 - [breaking-change] Remove all deprecated
@@ -121,7 +127,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Remove unsafe code from ADC DMA example [#301]
 - [breaking-change] DMA: Memory to peripheral transfers now only require `StaticReadBuffer` [#257].
 - Rename erased `Pin` to `EPin`, partially erased `PXx` to `PEPin`, `PX` to `Pin` [#339]
-- [breaking-change] `gpio::Edge::{RISING, FALLING, RISING_FALLING}` are renamed to `Rising`, `Falling`, `RisingFalling`, respectively [#343] 
+- [breaking-change] `gpio::Edge::{RISING, FALLING, RISING_FALLING}` are renamed to `Rising`, `Falling`, `RisingFalling`, respectively [#343]
 
 [#266]: https://github.com/stm32-rs/stm32f4xx-hal/pull/266
 [#293]: https://github.com/stm32-rs/stm32f4xx-hal/pull/293

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -557,6 +557,31 @@ impl<const P: char, const N: u8> IoPin<Self, Self> for Pin<Output<OpenDrain>, P,
 }
 
 impl<const P: char, const N: u8> IoPin<Pin<Input<Floating>, P, N>, Self>
+    for Pin<Output<OpenDrain>, P, N>
+{
+    type Error = Infallible;
+    fn into_input_pin(self) -> Result<Pin<Input<Floating>, P, N>, Self::Error> {
+        Ok(self.into_floating_input())
+    }
+    fn into_output_pin(mut self, state: PinState) -> Result<Self, Self::Error> {
+        self.set_state(state);
+        Ok(self)
+    }
+}
+
+impl<const P: char, const N: u8> IoPin<Self, Pin<Output<OpenDrain>, P, N>>
+    for Pin<Input<Floating>, P, N>
+{
+    type Error = Infallible;
+    fn into_input_pin(self) -> Result<Self, Self::Error> {
+        Ok(self)
+    }
+    fn into_output_pin(self, state: PinState) -> Result<Pin<Output<OpenDrain>, P, N>, Self::Error> {
+        Ok(self.into_open_drain_output_in_state(state))
+    }
+}
+
+impl<const P: char, const N: u8> IoPin<Pin<Input<Floating>, P, N>, Self>
     for Pin<Output<PushPull>, P, N>
 {
     type Error = Infallible;


### PR DESCRIPTION
`IoPin` is currently missing implementation for the combination of `Input<Floating>` and `Output<OpenDrain>`. This specific setup is required for certain devices I'm developing drivers for at the moment.