### PR TITLE
try to use fugit::Duraction for CountDown::Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added `Counter` with `CountDown<Time=fugit::TimerDuration>` and `atat::Clock` implementations [#381]
 - `Into<serial::Config>` for `Bps` [#387]
 - Added the missing DMA implementations for USART3 [#373]
 - `count_down` constructor for `Timer` -> `CountDownTimer` without start [#382]
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#382]: https://github.com/stm32-rs/stm32f4xx-hal/pull/382
 [#380]: https://github.com/stm32-rs/stm32f4xx-hal/pull/380
 [#374]: https://github.com/stm32-rs/stm32f4xx-hal/pull/374
+[#381]: https://github.com/stm32-rs/stm32f4xx-hal/pull/381
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,9 @@ cast = { default-features = false, version = "0.3.0" }
 void = { default-features = false, version = "1.0.2" }
 embedded-hal = { features = ["unproven"], version = "0.2.6" }
 display-interface = { version = "0.4.1", optional = true }
-fugit = "0.3.0"
+fugit = "0.3.3"
 rtic-monotonic = { version = "1.0", optional = true }
+atat = { version = "0.14.0", optional = true }
 
 [dependencies.stm32_i2s_v12x]
 version = "0.2.0"

--- a/examples/adc_dma_rtic.rs
+++ b/examples/adc_dma_rtic.rs
@@ -7,7 +7,6 @@ use panic_semihosting as _;
 mod app {
     use cortex_m_semihosting::hprintln;
     use dwt_systick_monotonic::DwtSystick;
-    pub use fugit::ExtU32;
 
     use stm32f4xx_hal::{
         adc::{

--- a/examples/analog-stopwatch-with-spi-ssd1306.rs
+++ b/examples/analog-stopwatch-with-spi-ssd1306.rs
@@ -16,7 +16,7 @@ use crate::hal::{
     prelude::*,
     rcc::{Clocks, Rcc},
     spi::Spi,
-    timer::{CountDownTimer, Event, Timer},
+    timer::{CounterUs, Event, Timer},
 };
 
 use core::cell::{Cell, RefCell};
@@ -43,8 +43,7 @@ use ssd1306::{prelude::*, Ssd1306};
 // Set up global state. It's all mutexed up for concurrency safety.
 static ELAPSED_MS: Mutex<Cell<u32>> = Mutex::new(Cell::new(0u32));
 static ELAPSED_RESET_MS: Mutex<Cell<u32>> = Mutex::new(Cell::new(0u32));
-static TIMER_TIM2: Mutex<RefCell<Option<CountDownTimer<pac::TIM2>>>> =
-    Mutex::new(RefCell::new(None));
+static TIMER_TIM2: Mutex<RefCell<Option<CounterUs<pac::TIM2>>>> = Mutex::new(RefCell::new(None));
 static STATE: Mutex<Cell<StopwatchState>> = Mutex::new(Cell::new(StopwatchState::Ready));
 static BUTTON: Mutex<RefCell<Option<PA0<Input<PullDown>>>>> = Mutex::new(RefCell::new(None));
 
@@ -127,8 +126,8 @@ fn main() -> ! {
     disp.flush().unwrap();
 
     // Create a 1ms periodic interrupt from TIM2
-    let mut timer = Timer::new(dp.TIM2, &clocks).count_down();
-    timer.start(1.hz());
+    let mut timer = Timer::new(dp.TIM2, &clocks).counter();
+    timer.start(1.secs()).unwrap();
     timer.listen(Event::TimeOut);
 
     free(|cs| {

--- a/examples/rtic-tick.rs
+++ b/examples/rtic-tick.rs
@@ -5,7 +5,6 @@ use panic_halt as _;
 
 #[rtic::app(device = stm32f4xx_hal::pac, dispatchers = [USART1])]
 mod app {
-    use fugit::ExtU32;
     use stm32f4xx_hal::{
         gpio::{gpioc::PC13, Output, PushPull},
         pac,

--- a/examples/stopwatch-with-ssd1306-and-interrupts.rs
+++ b/examples/stopwatch-with-ssd1306-and-interrupts.rs
@@ -28,7 +28,7 @@ use crate::hal::{
     interrupt, pac,
     prelude::*,
     rcc::{Clocks, Rcc},
-    timer::{CountDownTimer, Event, Timer},
+    timer::{CounterUs, Event, Timer},
 };
 use core::cell::{Cell, RefCell};
 use core::fmt::Write;
@@ -49,8 +49,7 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 
 // Set up global state. It's all mutexed up for concurrency safety.
 static ELAPSED_MS: Mutex<Cell<u32>> = Mutex::new(Cell::new(0u32));
-static TIMER_TIM2: Mutex<RefCell<Option<CountDownTimer<pac::TIM2>>>> =
-    Mutex::new(RefCell::new(None));
+static TIMER_TIM2: Mutex<RefCell<Option<CounterUs<pac::TIM2>>>> = Mutex::new(RefCell::new(None));
 static STATE: Mutex<Cell<StopwatchState>> = Mutex::new(Cell::new(StopwatchState::Ready));
 static BUTTON: Mutex<RefCell<Option<PC13<Input<PullUp>>>>> = Mutex::new(RefCell::new(None));
 
@@ -93,8 +92,8 @@ fn main() -> ! {
         disp.flush().unwrap();
 
         // Create a 1ms periodic interrupt from TIM2
-        let mut timer = Timer::new(dp.TIM2, &clocks).count_down();
-        timer.start(1.hz());
+        let mut timer = Timer::new(dp.TIM2, &clocks).counter();
+        timer.start(1.secs()).unwrap();
         timer.listen(Event::TimeOut);
 
         free(|cs| {

--- a/examples/timer-periph.rs
+++ b/examples/timer-periph.rs
@@ -15,7 +15,6 @@ use panic_halt as _;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::hprintln;
 
-use embedded_hal::timer::Cancel;
 use hal::timer;
 use hal::timer::Timer;
 use stm32f4xx_hal as hal;
@@ -29,8 +28,8 @@ fn main() -> ! {
     let clocks = rcc.cfgr.sysclk(24.mhz()).freeze();
 
     // Create a timer based on SysTick
-    let mut timer = Timer::new(dp.TIM1, &clocks).count_down();
-    timer.start(1.hz());
+    let mut timer = Timer::new(dp.TIM1, &clocks).counter_ms();
+    timer.start(1.secs()).unwrap();
 
     hprintln!("hello!").unwrap();
     // wait until timer expires
@@ -46,8 +45,7 @@ fn main() -> ! {
     timer.cancel().unwrap();
 
     // start it again
-    timer.start(1.hz());
-    nb::block!(timer.wait()).unwrap();
+    timer.delay(1.secs()).unwrap();
     hprintln!("timer expired 3").unwrap();
 
     timer.cancel().unwrap();

--- a/examples/timer-syst.rs
+++ b/examples/timer-syst.rs
@@ -15,7 +15,6 @@ use panic_halt as _;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::hprintln;
 
-use embedded_hal::timer::Cancel;
 use hal::timer;
 use hal::timer::Timer;
 use stm32f4xx_hal as hal;
@@ -30,8 +29,8 @@ fn main() -> ! {
     let clocks = rcc.cfgr.sysclk(24.mhz()).freeze();
 
     // Create a timer based on SysTick
-    let mut timer = Timer::syst(cp.SYST, &clocks).count_down();
-    timer.start(24.hz());
+    let mut timer = Timer::syst(cp.SYST, &clocks).counter();
+    timer.start(42.millis()).unwrap();
 
     hprintln!("hello!").unwrap();
     // wait until timer expires
@@ -47,8 +46,7 @@ fn main() -> ! {
     timer.cancel().unwrap();
 
     // start it again
-    timer.start(24.hz());
-    nb::block!(timer.wait()).unwrap();
+    timer.delay(42.millis()).unwrap();
     hprintln!("timer expired 3").unwrap();
 
     timer.cancel().unwrap();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -57,6 +57,7 @@ pub use embedded_hal::watchdog::WatchdogEnable as _embedded_hal_watchdog_Watchdo
 pub use embedded_hal::Capture as _embedded_hal_Capture;
 pub use embedded_hal::Pwm as _embedded_hal_Pwm;
 pub use embedded_hal::Qei as _embedded_hal_Qei;
+pub use fugit::ExtU32 as _fugit_ExtU32;
 
 #[cfg(all(feature = "device-selected", feature = "dac"))]
 pub use crate::dac::DacExt as _stm32f4xx_hal_dac_DacExt;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -18,6 +18,9 @@ use crate::time::Hertz;
 #[cfg(not(feature = "stm32f410"))]
 pub mod monotonic;
 
+mod counter;
+pub use counter::*;
+
 /// Timer wrapper
 pub struct Timer<TIM> {
     pub(crate) tim: TIM,

--- a/src/timer/counter.rs
+++ b/src/timer/counter.rs
@@ -1,0 +1,311 @@
+use super::*;
+
+use cast::u16;
+use embedded_hal::timer::{Cancel, CountDown, Periodic};
+use fugit::{MicrosDurationU32, TimerDurationU32, TimerInstantU32};
+use void::Void;
+
+/// Timer that waits given time
+pub struct Counter<TIM, const FREQ: u32> {
+    tim: TIM,
+}
+
+/// `Counter` with sampling of 1 MHz
+pub type CounterUs<TIM> = Counter<TIM, 1_000_000>;
+
+/// `Counter` with sampling of 1 kHz
+///
+/// NOTE: don't use this if your system frequency more than 65 MHz
+pub type CounterMs<TIM> = Counter<TIM, 1_000>;
+
+impl<TIM> Timer<TIM>
+where
+    TIM: Instance,
+{
+    /// Creates `Counter` with custom sampling
+    pub fn counter<const FREQ: u32>(self) -> Counter<TIM, FREQ> {
+        let Self { tim, clk } = self;
+        Counter::<TIM, FREQ>::new(tim, clk)
+    }
+    /// Creates `Counter` with sampling of 1 MHz
+    pub fn counter_us(self) -> CounterUs<TIM> {
+        self.counter::<1_000_000>()
+    }
+
+    /// Creates `Counter` with sampling of 1 kHz
+    ///
+    /// NOTE: don't use this if your system frequency more than 65 MHz
+    pub fn counter_ms(self) -> CounterMs<TIM> {
+        self.counter::<1_000>()
+    }
+}
+
+impl<TIM, const FREQ: u32> Periodic for Counter<TIM, FREQ> {}
+
+impl Timer<SYST> {
+    /// Creates SysCounter
+    pub fn counter(self) -> SysCounter {
+        let Self { tim, clk } = self;
+        SysCounter::new(tim, clk)
+    }
+}
+
+pub struct SysCounter {
+    tim: SYST,
+    mhz: u32,
+}
+
+impl SysCounter {
+    fn new(tim: SYST, clk: Hertz) -> Self {
+        Self {
+            tim,
+            mhz: clk.0 / 1_000_000,
+        }
+    }
+
+    /// Starts listening for an `event`
+    pub fn listen(&mut self, event: Event) {
+        match event {
+            Event::TimeOut => self.tim.enable_interrupt(),
+        }
+    }
+
+    /// Stops listening for an `event`
+    pub fn unlisten(&mut self, event: Event) {
+        match event {
+            Event::TimeOut => self.tim.disable_interrupt(),
+        }
+    }
+
+    pub fn now(&self) -> TimerInstantU32<1_000_000> {
+        TimerInstantU32::from_ticks(SYST::get_current() / self.mhz)
+    }
+
+    pub fn start(&mut self, timeout: MicrosDurationU32) -> Result<(), Error> {
+        let rvr = timeout.ticks() * self.mhz - 1;
+
+        assert!(rvr < (1 << 24));
+
+        self.tim.set_reload(rvr);
+        self.tim.clear_current();
+        self.tim.enable_counter();
+        Ok(())
+    }
+
+    pub fn wait(&mut self) -> nb::Result<(), Error> {
+        if self.tim.has_wrapped() {
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    pub fn delay(&mut self, timeout: MicrosDurationU32) -> Result<(), Error> {
+        self.start(timeout)?;
+        nb::block!(self.wait())
+    }
+
+    pub fn cancel(&mut self) -> Result<(), Error> {
+        if !self.tim.is_counter_enabled() {
+            return Err(Error::Disabled);
+        }
+
+        self.tim.disable_counter();
+        Ok(())
+    }
+}
+
+impl CountDown for SysCounter {
+    type Time = MicrosDurationU32;
+
+    fn start<T>(&mut self, timeout: T)
+    where
+        T: Into<Self::Time>,
+    {
+        self.start(timeout.into()).unwrap()
+    }
+
+    fn wait(&mut self) -> nb::Result<(), Void> {
+        match self.wait() {
+            Err(nb::Error::WouldBlock) => Err(nb::Error::WouldBlock),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl Cancel for SysCounter {
+    type Error = Error;
+
+    fn cancel(&mut self) -> Result<(), Self::Error> {
+        self.cancel()
+    }
+}
+
+impl<TIM, const FREQ: u32> Counter<TIM, FREQ>
+where
+    TIM: General,
+{
+    fn new(mut tim: TIM, clk: Hertz) -> Self {
+        let psc = clk.0 / FREQ - 1;
+        tim.set_prescaler(u16(psc).unwrap());
+        Self { tim }
+    }
+
+    /// Starts listening for an `event`
+    ///
+    /// Note, you will also have to enable the TIM2 interrupt in the NVIC to start
+    /// receiving events.
+    pub fn listen(&mut self, event: Event) {
+        match event {
+            Event::TimeOut => {
+                // Enable update event interrupt
+                self.tim.listen_update_interrupt(true);
+            }
+        }
+    }
+
+    /// Clears interrupt associated with `event`.
+    ///
+    /// If the interrupt is not cleared, it will immediately retrigger after
+    /// the ISR has finished.
+    pub fn clear_interrupt(&mut self, event: Event) {
+        match event {
+            Event::TimeOut => {
+                // Clear interrupt flag
+                self.tim.clear_update_interrupt_flag();
+            }
+        }
+    }
+
+    /// Stops listening for an `event`
+    pub fn unlisten(&mut self, event: Event) {
+        match event {
+            Event::TimeOut => {
+                // Disable update event interrupt
+                self.tim.listen_update_interrupt(false);
+            }
+        }
+    }
+
+    /// Releases the TIM peripheral
+    pub fn release(mut self) -> TIM {
+        // pause counter
+        self.tim.disable_counter();
+        self.tim
+    }
+
+    pub fn now(&self) -> TimerInstantU32<FREQ> {
+        TimerInstantU32::from_ticks(self.tim.read_count().into())
+    }
+
+    pub fn start(&mut self, timeout: TimerDurationU32<FREQ>) -> Result<(), Error> {
+        // pause
+        self.tim.disable_counter();
+        // reset counter
+        self.tim.reset_counter();
+
+        let arr = timeout.ticks() - 1;
+        self.tim.set_auto_reload(arr)?;
+
+        // Trigger update event to load the registers
+        self.tim.trigger_update();
+
+        // start counter
+        self.tim.enable_counter();
+
+        Ok(())
+    }
+
+    pub fn wait(&mut self) -> nb::Result<(), Error> {
+        if self.tim.get_update_interrupt_flag() {
+            Err(nb::Error::WouldBlock)
+        } else {
+            self.tim.clear_update_interrupt_flag();
+            Ok(())
+        }
+    }
+
+    pub fn delay(&mut self, timeout: TimerDurationU32<FREQ>) -> Result<(), Error> {
+        self.start(timeout)?;
+        nb::block!(self.wait())
+    }
+
+    pub fn cancel(&mut self) -> Result<(), Error> {
+        if !self.tim.is_counter_enabled() {
+            return Err(Error::Disabled);
+        }
+
+        // disable counter
+        self.tim.disable_counter();
+        Ok(())
+    }
+}
+
+impl<TIM, const FREQ: u32> CountDown for Counter<TIM, FREQ>
+where
+    TIM: General,
+{
+    type Time = TimerDurationU32<FREQ>;
+
+    fn start<T>(&mut self, timeout: T)
+    where
+        T: Into<Self::Time>,
+    {
+        self.start(timeout.into()).unwrap()
+    }
+
+    fn wait(&mut self) -> nb::Result<(), Void> {
+        match self.wait() {
+            Err(nb::Error::WouldBlock) => Err(nb::Error::WouldBlock),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl<TIM, const FREQ: u32> Cancel for Counter<TIM, FREQ>
+where
+    TIM: General,
+{
+    type Error = Error;
+
+    fn cancel(&mut self) -> Result<(), Self::Error> {
+        self.cancel()
+    }
+}
+
+#[cfg(feature = "atat")]
+impl atat::Clock<1_000_000> for SysCounter {
+    type Error = Error;
+
+    fn now(&mut self) -> TimerInstantU32<1_000_000> {
+        Self::now(self)
+    }
+
+    fn start(&mut self, duration: MicrosDurationU32) -> Result<(), Self::Error> {
+        self.start(duration)
+    }
+
+    fn wait(&mut self) -> nb::Result<(), Self::Error> {
+        self.wait()
+    }
+}
+
+#[cfg(feature = "atat")]
+impl<TIM, const FREQ: u32> atat::Clock<FREQ> for Counter<TIM, FREQ>
+where
+    TIM: General,
+{
+    type Error = Error;
+
+    fn now(&mut self) -> TimerInstantU32<FREQ> {
+        Self::now(self)
+    }
+
+    fn start(&mut self, duration: TimerDurationU32<FREQ>) -> Result<(), Self::Error> {
+        self.start(duration)
+    }
+
+    fn wait(&mut self) -> nb::Result<(), Self::Error> {
+        self.wait()
+    }
+}


### PR DESCRIPTION
~~Not for SysTick for now~~ Use 1 microsecond as minimal timeout for SysTick `Counter`

This PR lets to use `fugit` units for timer including values bigger then 1 second.
Sampling of timer (time of 1 tick) now can be set in by FREQ generic constant.