### PR TITLE
Change rtic-tick example system clock to fix assert.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `Into<serial::Config>` for `Bps` [#387]
 - `count_down` constructor for `Timer` -> `CountDownTimer` without start [#382]
-- Implementation of RTIC Monotonic for TIM2 & TIM5 under `rtic` feature [#380]
+- Implementation of RTIC Monotonic for TIM2 & TIM5 under `rtic` feature [#380] [#390]
 - `IoPin` for `Output<OpenDrain>> <-> Input<Floating>>` [#374]
 - `IoPin` for `Output<PushPull>> <-> Input<PullUp>> and Input<PullDown>>` [#389]
 
+[#390]: https://github.com/stm32-rs/stm32f4xx-hal/pull/390
 [#382]: https://github.com/stm32-rs/stm32f4xx-hal/pull/382
 [#380]: https://github.com/stm32-rs/stm32f4xx-hal/pull/380
 [#374]: https://github.com/stm32-rs/stm32f4xx-hal/pull/374

--- a/examples/rtic-tick.rs
+++ b/examples/rtic-tick.rs
@@ -27,7 +27,7 @@ mod app {
     #[init]
     fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         let rcc = ctx.device.RCC.constrain();
-        let clocks = rcc.cfgr.sysclk(8.mhz()).freeze();
+        let clocks = rcc.cfgr.sysclk(48.mhz()).freeze();
 
         let gpioc = ctx.device.GPIOC.split();
         let led = gpioc.pc13.into_push_pull_output();


### PR DESCRIPTION
The rtic-tick example asserts during clock setup because the code attempts to configure a clock of 8 MHz, which is below the lowest `SYSCLK_MIN` defined in `src/rcc/mod.rs` (12.5 MHz).  Change requested clock to 48 MHz (above the highest `SYSCLK_MIN` of 24 MHz).