### PR TITLE
Wait for SDIO transmission to finish before polling card status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Finish SDIO data transmission before querying card status in `write_block` [#395]
 - Unify alternate pin constraints [#393]
 - [breaking-change] Use `&Clocks` instead of `Clocks` [#387]
 - Split and rename `GetBusFreq` -> `BusClock`, `BusTimerClock` [#386]
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#386]: https://github.com/stm32-rs/stm32f4xx-hal/pull/386
 [#387]: https://github.com/stm32-rs/stm32f4xx-hal/pull/387
 [#393]: https://github.com/stm32-rs/stm32f4xx-hal/pull/393
+[#395]: https://github.com/stm32-rs/stm32f4xx-hal/pull/395
 
 ## [v0.10.1] - 2021-10-26
 

--- a/src/sdio.rs
+++ b/src/sdio.rs
@@ -404,6 +404,14 @@ impl Sdio {
 
         status_to_error(sta)?;
 
+        // Wait for SDIO module to finish transmitting data
+        loop {
+            sta = self.sdio.sta.read();
+            if !sta.txact().bit_is_set() {
+                break;
+            }
+        }
+
         // Wait for card to finish writing data
         while !self.card_ready()? {}
 


### PR DESCRIPTION
When testing with an eMMC module driven at frequencies above 12MHz, I found that `write_block` would consistently fail with either `Crc`, `DataCrcFail`, or `Timeout` errors.

Here's a sample probe output collected on the CLK and D0 lines at 24MHz. D0 has a relatively clean data block and corresponding CRC, but the very end of the transmission spends a clock cycle at ~1V (when powered by 3V3) and has large rippling peaks at nearby level transitions.

![24MHz_clkdata_01_zm](https://user-images.githubusercontent.com/22821309/144735274-389555f4-da6a-4981-956a-0b8bee0e27ee.png)

As it turns out, the code in `write_block` is polling the eMMC (or SD card) status even while still transmitting on the data lines. Preventing the status commands from being sent until the transmission is complete (TXACT low) prevents the interference and allows writes to consistently succeed at any speed/bus width. It's unclear why the combination is problematic since the data transfer uses the data lines exclusively and the status command uses the CMD line exclusively. Regardless, there's no reason to ask for the card's status before transmission is complete, since it's guaranteed to still be busy receiving data.