### PR TITLE
adc improvements for dma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `IoPin` for `Output<PushPull>> <-> Input<PullUp>> and Input<PullDown>>` [#389]
 - Add `internal_pull_down` to `Pin<Output<OpenDrain>>` and `Pin<Alternate<PushPull>>` for symmetry
   with `internal_pull_up` [#399]
+- Added `peripheral` for DMA read access to peripheral [#396]
+- Added ADC2+ADC3 implementations to DMA Transfer [#396]
+- Added `reference_voltage` to Adc [#396]
 
 [#373]: https://github.com/stm32-rs/stm32f4xx-hal/pull/373
+[#396]: https://github.com/stm32-rs/stm32f4xx-hal/pull/396
 [#374]: https://github.com/stm32-rs/stm32f4xx-hal/pull/374
 [#380]: https://github.com/stm32-rs/stm32f4xx-hal/pull/380
 [#381]: https://github.com/stm32-rs/stm32f4xx-hal/pull/381

--- a/src/dma/mod.rs
+++ b/src/dma/mod.rs
@@ -23,7 +23,7 @@ use crate::{pac, rcc};
 pub mod traits;
 use traits::{
     sealed::{Bits, Sealed},
-    Channel, DMASet, Direction, Instance, PeriAddress, Stream, StreamISR,
+    Channel, DMASet, Direction, Instance, PeriAddress, SafePeripheralRead, Stream, StreamISR,
 };
 
 /// Errors.
@@ -1011,6 +1011,20 @@ where
         };
         self.next_transfer_with_common(new_buf, ptr_and_len, false, CurrentBuffer::FirstBuffer);
         Ok(r.1)
+    }
+}
+
+impl<STREAM, PERIPHERAL, BUF, const CHANNEL: u8>
+    Transfer<STREAM, PERIPHERAL, PeripheralToMemory, BUF, CHANNEL>
+where
+    STREAM: Stream,
+    ChannelX<CHANNEL>: Channel,
+    PERIPHERAL: PeriAddress + DMASet<STREAM, PeripheralToMemory, CHANNEL> + SafePeripheralRead,
+    BUF: StaticWriteBuffer<Word = <PERIPHERAL as PeriAddress>::MemSize>,
+{
+    /// Access the owned peripheral for reading
+    pub fn peripheral(&self) -> &PERIPHERAL {
+        &self.peripheral
     }
 }
 

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -16,6 +16,9 @@ pub(crate) mod sealed {
 }
 use sealed::{Bits, Sealed};
 
+/// Marker trait for structs which can be safely accessed with shared reference
+pub trait SafePeripheralRead {}
+
 /// Trait for DMA stream interrupt handling.
 pub trait StreamISR: Sealed {
     /// Clear all interrupts for the DMA stream.
@@ -931,6 +934,10 @@ dma_map!(
     (Stream2<DMA2>, 1, pac::ADC2, PeripheralToMemory),  //ADC2
     (Stream3<DMA2>, 1, pac::ADC2, PeripheralToMemory),  //ADC2
     (Stream7<DMA2>, 1, pac::DCMI, PeripheralToMemory),  //DCMI
+    (Stream2<DMA2>, 1, Adc<pac::ADC3>, PeripheralToMemory), //ADC2
+    (Stream3<DMA2>, 1, Adc<pac::ADC3>, PeripheralToMemory), //ADC2
+    (Stream0<DMA2>, 2, Adc<pac::ADC3>, PeripheralToMemory), //ADC3
+    (Stream1<DMA2>, 2, Adc<pac::ADC3>, PeripheralToMemory), //ADC3
 );
 #[cfg(any(
     feature = "stm32f417",


### PR DESCRIPTION
This PR should fix adc with dma issues as mentioned in #282: "DMA Transfer consumes peripheral".

Changes:
- DMA Transfer exposes a reference to the peripheral, currently only for PeripheralToMemory
- the ADC provides a closure similar to sample_to_millivolts
- a demonstration of its use in the adc_dma_rtic example.

As of now this PR is not complete; I kindly ask to review the concept before I complete the implementation, documentation and squashing.

