### PR TITLE
Add internal_pull_down() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implementation of RTIC Monotonic for TIM2 & TIM5 under `rtic` feature [#380] [#390]
 - `IoPin` for `Output<OpenDrain>> <-> Input<Floating>>` [#374]
 - `IoPin` for `Output<PushPull>> <-> Input<PullUp>> and Input<PullDown>>` [#389]
+- Add `internal_pull_down` to `Pin<Output<OpenDrain>>` and `Pin<Alternate<PushPull>>` for symmetry
+  with `internal_pull_up` [#399]
 
 [#390]: https://github.com/stm32-rs/stm32f4xx-hal/pull/390
 [#382]: https://github.com/stm32-rs/stm32f4xx-hal/pull/382
@@ -32,6 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [breaking-change] Bump `stm32f4` to 0.14. Update RTIC based examples to use `rtic` 0.6 [#367]
 - [breaking-change] Bump `bxcan` to 0.6 [#371]
 - fix #362: ADC voltage conversion might be incorrect [#397]
+- [breaking-change] Change `Pin<Output<OpenDrain>>::internal_pull_up` signature from `(&mut self, _: bool) -> ()`
+  to `(self, _: bool) -> Self`. [#399]
 
 [#367]: https://github.com/stm32-rs/stm32f4xx-hal/pull/397
 [#367]: https://github.com/stm32-rs/stm32f4xx-hal/pull/367

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -300,7 +300,7 @@ impl<MODE, const P: char, const N: u8> Pin<Output<MODE>, P, N> {
 
 impl<const P: char, const N: u8> Pin<Output<OpenDrain>, P, N> {
     /// Enables / disables the internal pull up
-    pub fn internal_pull_up(&mut self, on: bool) {
+    pub fn internal_pull_up(self, on: bool) -> Self {
         let offset = 2 * { N };
         let value = if on { 0b01 } else { 0b00 };
         unsafe {
@@ -308,6 +308,21 @@ impl<const P: char, const N: u8> Pin<Output<OpenDrain>, P, N> {
                 .pupdr
                 .modify(|r, w| w.bits((r.bits() & !(0b11 << offset)) | (value << offset)))
         };
+
+        self
+    }
+
+    /// Enables / disables the internal pull down
+    pub fn internal_pull_down(self, on: bool) -> Self {
+        let offset = 2 * { N };
+        let value = if on { 0b10 } else { 0b00 };
+        unsafe {
+            (*Gpio::<P>::ptr())
+                .pupdr
+                .modify(|r, w| w.bits((r.bits() & !(0b11 << offset)) | (value << offset)))
+        };
+
+        self
     }
 }
 
@@ -329,6 +344,19 @@ impl<const P: char, const N: u8, const A: u8> Pin<Alternate<PushPull, A>, P, N> 
     pub fn internal_pull_up(self, on: bool) -> Self {
         let offset = 2 * { N };
         let value = if on { 0b01 } else { 0b00 };
+        unsafe {
+            (*Gpio::<P>::ptr())
+                .pupdr
+                .modify(|r, w| w.bits((r.bits() & !(0b11 << offset)) | (value << offset)))
+        };
+
+        self
+    }
+
+    /// Enables / disables the internal pull down
+    pub fn internal_pull_down(self, on: bool) -> Self {
+        let offset = 2 * { N };
+        let value = if on { 0b10 } else { 0b00 };
         unsafe {
             (*Gpio::<P>::ptr())
                 .pupdr


### PR DESCRIPTION
PR #266 has added a `internal_pull_up()` function. This PR adds `internal_pull_down()` for symmetry reasons