### PR TITLE
Prevent overflows optimizing SAI PLL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Finish SDIO data transmission before querying card status in `write_block` [#395]
 - SDIO: Rewrite loop conditions to silence clippy
 - Unify alternate pin constraints [#393]
+- Prevent overflow when optimizing SAI PLL [#419]
 - [breaking-change] Use `&Clocks` instead of `Clocks` [#387]
 - Split and rename `GetBusFreq` -> `BusClock`, `BusTimerClock` [#386]
 - [breaking-change] Remove `Can::new_unchecked`. Add `Can::tx` and `Can::rx` [#384]
@@ -86,6 +87,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#403]: https://github.com/stm32-rs/stm32f4xx-hal/pull/403
 [#404]: https://github.com/stm32-rs/stm32f4xx-hal/pull/404
 [#405]: https://github.com/stm32-rs/stm32f4xx-hal/pull/405
+[#419]: https://github.com/stm32-rs/stm32f4xx-hal/pull/419
 
 ## [v0.10.1] - 2021-10-26
 

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -490,7 +490,10 @@ impl SingleOutputPll {
         // through all possible "N" values would result in more iterations.
         let (n, outdiv, output, error) = (min_div..=max_div)
             .filter_map(|outdiv| {
-                let target_vco_out = target * outdiv;
+                let target_vco_out = match target.checked_mul(outdiv) {
+                    Some(x) => x,
+                    None => return None,
+                };
                 let n = (target_vco_out + (vco_in >> 1)) / vco_in;
                 let vco_out = vco_in * n;
                 if !(100_000_000..=432_000_000).contains(&vco_out) {


### PR DESCRIPTION
Setting the common target PLL freq of 49.152 MHz for the SAI clock (192kHz * 256) results in an overflow during multiplication. This patch catches the overflow, though I'm sure there's a better approach to optimizing the PLL settings that could avoid this.