### PR TITLE
Add missing CAN1 pin mapping for stm32f446

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - VSCode setting file
+- Add CAN1 PB8/PB9 and SPI3 MOSI PC1 pin mappings for F446 [#421]
+
+[#421]: https://github.com/stm32-rs/stm32f4xx-hal/pull/421
 
 ### Changed
 

--- a/src/gpio/alt.rs
+++ b/src/gpio/alt.rs
@@ -108,6 +108,7 @@ mod can {
         feature = "stm32f429",
         feature = "stm32f437",
         feature = "stm32f439",
+        feature = "stm32f446",
         feature = "stm32f469",
         feature = "stm32f479"
     ))]
@@ -448,7 +449,7 @@ pin! {
     <spi::Mosi, SPI2> for [gpioc::PC1<7>],
     <spi::Nss,  SPI2> for [gpiob::PB4<7>, gpiod::PD1<7>],
 
-    <spi::Mosi, SPI3> for [gpiob::PB0<7>, gpiob::PB2<7>, gpiod::PD0<6>],
+    <spi::Mosi, SPI3> for [gpiob::PB0<7>, gpiob::PB2<7>, gpioc::PC1<5>, gpiod::PD0<6>],
 
     <spi::Sck,  SPI4> for [gpiog::PG11<6>],
     <spi::Miso, SPI4> for [gpiog::PG12<6>, gpiod::PD0<5>],


### PR DESCRIPTION
Reference [stm32f446 datasheet](https://www.st.com/resource/en/datasheet/stm32f446re.pdf) pages 55 and 58.