### PR TITLE
WithPwm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Add channel events, make Event use bitflags (simplify interrupt handling) [#425]
 - reexport `digital::v2::PinState` again [#428]
 - Timer impls with time based on `fugit` moved to `fugit` module, added `Pwm` and `fugit-timer` impls [#423]
 
@@ -18,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `WithPwm` trait implemented for timers with channels (internals) [#425]
+- `Pwm` struct with `split` method and implementation of embedded-hal::Pwm (similar to f1xx-hal) [#425]
 - VSCode setting file
 - Add CAN1 PB8/PB9 and SPI3 MOSI PC1 pin mappings for F446 [#421]
 
@@ -25,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#422]: https://github.com/stm32-rs/stm32f4xx-hal/pull/422
 [#423]: https://github.com/stm32-rs/stm32f4xx-hal/pull/423
 [#428]: https://github.com/stm32-rs/stm32f4xx-hal/pull/428
+[#425]: https://github.com/stm32-rs/stm32f4xx-hal/pull/425
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ display-interface = { version = "0.4.1", optional = true }
 fugit = "0.3.3"
 fugit-timer = "0.1.3"
 rtic-monotonic = { version = "1.0", optional = true }
+bitflags = "1.3.2"
 
 [dependencies.stm32_i2s_v12x]
 version = "0.2.0"

--- a/examples/analog-stopwatch-with-spi-ssd1306.rs
+++ b/examples/analog-stopwatch-with-spi-ssd1306.rs
@@ -128,7 +128,7 @@ fn main() -> ! {
     // Create a 1ms periodic interrupt from TIM2
     let mut timer = Timer::new(dp.TIM2, &clocks).counter();
     timer.start(1.secs()).unwrap();
-    timer.listen(Event::TimeOut);
+    timer.listen(Event::Update);
 
     free(|cs| {
         TIMER_TIM2.borrow(cs).replace(Some(timer));
@@ -263,7 +263,7 @@ fn EXTI0() {
 fn TIM2() {
     free(|cs| {
         if let Some(ref mut tim2) = TIMER_TIM2.borrow(cs).borrow_mut().deref_mut() {
-            tim2.clear_interrupt(Event::TimeOut);
+            tim2.clear_interrupt(Event::Update);
         }
 
         let cell = ELAPSED_MS.borrow(cs);

--- a/examples/blinky-timer-irq.rs
+++ b/examples/blinky-timer-irq.rs
@@ -82,7 +82,7 @@ fn main() -> ! {
     timer.start(1.secs()).unwrap();
 
     // Generate an interrupt when the timer expires
-    timer.listen(Event::TimeOut);
+    timer.listen(Event::Update);
 
     // Move the timer into our global storage
     cortex_m::interrupt::free(|cs| *G_TIM.borrow(cs).borrow_mut() = Some(timer));

--- a/examples/delay-timer-blinky.rs
+++ b/examples/delay-timer-blinky.rs
@@ -31,11 +31,11 @@ fn main() -> ! {
         let mut delay = dp.TIM5.delay_us(&clocks);
 
         loop {
-            // On for 1s, off for 1s.
+            // On for 1s, off for 3s.
             led.set_high();
-            delay.delay_ms(1_000_u32);
+            delay.delay(1.secs()).unwrap();
             led.set_low();
-            delay.delay_us(1_000_000_u32);
+            delay.delay(3.secs()).unwrap();
         }
     }
 

--- a/examples/pwm-input.rs
+++ b/examples/pwm-input.rs
@@ -21,7 +21,7 @@ fn main() -> ! {
         let channels = (gpioa.pa8.into_alternate(), gpioa.pa9.into_alternate());
         // configure tim1 as a PWM output of known frequency.
         let pwm = Timer::new(dp.TIM1, &clocks).pwm(channels, 501u32.hz());
-        let (mut ch1, _ch2) = pwm;
+        let (mut ch1, _ch2) = pwm.split();
         let max_duty = ch1.get_max_duty();
         ch1.set_duty(max_duty / 2);
         ch1.enable();

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -18,7 +18,9 @@ fn main() -> ! {
         let gpioa = dp.GPIOA.split();
         let channels = (gpioa.pa8.into_alternate(), gpioa.pa9.into_alternate());
 
-        let pwm = Timer::new(dp.TIM1, &clocks).pwm(channels, 20u32.khz());
+        let pwm = Timer::new(dp.TIM1, &clocks)
+            .pwm(channels, 20u32.khz())
+            .split();
         let (mut ch1, _ch2) = pwm;
         let max_duty = ch1.get_max_duty();
         ch1.set_duty(max_duty / 2);

--- a/examples/stopwatch-with-ssd1306-and-interrupts.rs
+++ b/examples/stopwatch-with-ssd1306-and-interrupts.rs
@@ -94,7 +94,7 @@ fn main() -> ! {
         // Create a 1ms periodic interrupt from TIM2
         let mut timer = Timer::new(dp.TIM2, &clocks).counter();
         timer.start(1.secs()).unwrap();
-        timer.listen(Event::TimeOut);
+        timer.listen(Event::Update);
 
         free(|cs| {
             TIMER_TIM2.borrow(cs).replace(Some(timer));
@@ -155,7 +155,7 @@ fn main() -> ! {
 fn TIM2() {
     free(|cs| {
         if let Some(ref mut tim2) = TIMER_TIM2.borrow(cs).borrow_mut().deref_mut() {
-            tim2.clear_interrupt(Event::TimeOut);
+            tim2.clear_interrupt(Event::Update);
         }
 
         let cell = ELAPSED_MS.borrow(cs);

--- a/src/fugit/counter.rs
+++ b/src/fugit/counter.rs
@@ -1,4 +1,4 @@
-use super::{Error, Instance, Timer};
+use super::{Error, Event, Instance, Timer};
 
 use core::ops::{Deref, DerefMut};
 use fugit::{TimerDurationU32, TimerInstantU32};
@@ -57,11 +57,11 @@ impl<TIM: Instance, const FREQ: u32> Counter<TIM, FREQ> {
     }
 
     pub fn wait(&mut self) -> nb::Result<(), Error> {
-        if self.tim.get_update_interrupt_flag() {
-            Err(nb::Error::WouldBlock)
-        } else {
-            self.tim.clear_update_interrupt_flag();
+        if self.tim.get_interrupt_flag().contains(Event::Update) {
+            self.tim.clear_interrupt_flag(Event::Update);
             Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
         }
     }
 

--- a/src/fugit/mod.rs
+++ b/src/fugit/mod.rs
@@ -2,8 +2,8 @@
 
 use crate::pac::RCC;
 use crate::rcc::Clocks;
-use crate::timer::General;
-pub use crate::timer::{Error, Event, Instance};
+use crate::timer::WithPwm;
+pub use crate::timer::{Channel, Error, Event, Instance, Ocm, SysEvent};
 use cast::u16;
 
 pub mod delay;
@@ -128,12 +128,7 @@ impl<TIM: Instance, const FREQ: u32> Timer<TIM, FREQ> {
     /// Note, you will also have to enable the TIM2 interrupt in the NVIC to start
     /// receiving events.
     pub fn listen(&mut self, event: Event) {
-        match event {
-            Event::TimeOut => {
-                // Enable update event interrupt
-                self.tim.listen_update_interrupt(true);
-            }
-        }
+        self.tim.listen_interrupt(event, true);
     }
 
     /// Clears interrupt associated with `event`.
@@ -141,21 +136,15 @@ impl<TIM: Instance, const FREQ: u32> Timer<TIM, FREQ> {
     /// If the interrupt is not cleared, it will immediately retrigger after
     /// the ISR has finished.
     pub fn clear_interrupt(&mut self, event: Event) {
-        match event {
-            Event::TimeOut => {
-                // Clear interrupt flag
-                self.tim.clear_update_interrupt_flag();
-            }
-        }
+        self.tim.clear_interrupt_flag(event);
+    }
+
+    pub fn get_interrupt(&mut self) -> Event {
+        self.tim.get_interrupt_flag()
     }
 
     /// Stops listening for an `event`
     pub fn unlisten(&mut self, event: Event) {
-        match event {
-            Event::TimeOut => {
-                // Disable update event interrupt
-                self.tim.listen_update_interrupt(false);
-            }
-        }
+        self.tim.listen_interrupt(event, false);
     }
 }

--- a/src/fugit/syscounter.rs
+++ b/src/fugit/syscounter.rs
@@ -1,4 +1,4 @@
-use super::{Error, Event};
+use super::{Error, SysEvent};
 
 use crate::{pac::SYST, rcc::Clocks, time::Hertz};
 use fugit::{MicrosDurationU32, TimerInstantU32};
@@ -44,16 +44,16 @@ impl SysCounter {
     }
 
     /// Starts listening for an `event`
-    pub fn listen(&mut self, event: Event) {
+    pub fn listen(&mut self, event: SysEvent) {
         match event {
-            Event::TimeOut => self.tim.enable_interrupt(),
+            SysEvent::Update => self.tim.enable_interrupt(),
         }
     }
 
     /// Stops listening for an `event`
-    pub fn unlisten(&mut self, event: Event) {
+    pub fn unlisten(&mut self, event: SysEvent) {
         match event {
-            Event::TimeOut => self.tim.disable_interrupt(),
+            SysEvent::Update => self.tim.disable_interrupt(),
         }
     }
 


### PR DESCRIPTION
add support `WithPwm` trait implemented for timers with channels.
Add `Pwm` struct with split method and implementation of `embedded-hal::Pwm` (similar to `f1xx-hal`)
Add channel events, make `Event` use `bitflags` (simplify interrupt handling)
