### PR TITLE
Update stm32f4xx-hal version to latest in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cortex-m-rt = "0.7"
 panic-halt = "0.2"
 
 [dependencies.stm32f4xx-hal]
-version = "0.10"
+version = "0.12"
 features = ["rt", "stm32f407"] # replace the model of your microcontroller here
 ```
 


### PR DESCRIPTION
Having latest version of crate in the readme should make it easier to get up and running.