### PR TITLE
Support eMMC in SDIO module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support eMMC peripherals using SDIO module [#458]
+
 ## [v0.12.0] - 2022-02-23
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ nb = "1"
 rand_core = "0.6"
 stm32f4 = "0.14.0"
 synopsys-usb-otg = { version = "0.2.0", features = ["cortex-m"], optional = true }
-sdio-host = { version = "0.5.0", optional = true }
+sdio-host = { version = "0.6.0", optional = true }
 embedded-dma = "0.2.0"
 bare-metal = { version = "1" }
 void = { default-features = false, version = "1.0.2" }

--- a/examples/sd.rs
+++ b/examples/sd.rs
@@ -8,7 +8,7 @@ use panic_semihosting as _;
 use stm32f4xx_hal::{
     pac,
     prelude::*,
-    sdio::{ClockFreq, Sdio},
+    sdio::{ClockFreq, SdCard, Sdio},
 };
 
 #[entry]
@@ -40,13 +40,13 @@ fn main() -> ! {
     let d3 = gpioc.pc11.into_alternate().internal_pull_up(true);
     let clk = gpioc.pc12.into_alternate().internal_pull_up(false);
     let cmd = gpiod.pd2.into_alternate().internal_pull_up(true);
-    let mut sdio = Sdio::new(device.SDIO, (clk, cmd, d0, d1, d2, d3), &clocks);
+    let mut sdio: Sdio<SdCard> = Sdio::new(device.SDIO, (clk, cmd, d0, d1, d2, d3), &clocks);
 
     hprintln!("Waiting for card...").ok();
 
     // Wait for card to be ready
     loop {
-        match sdio.init_card(ClockFreq::F24Mhz) {
+        match sdio.init(ClockFreq::F24Mhz) {
             Ok(_) => break,
             Err(_err) => (),
         }

--- a/src/sdio.rs
+++ b/src/sdio.rs
@@ -16,9 +16,29 @@ pub trait PinD0 {}
 pub trait PinD1 {}
 pub trait PinD2 {}
 pub trait PinD3 {}
+pub trait PinD4 {}
+pub trait PinD5 {}
+pub trait PinD6 {}
+pub trait PinD7 {}
 
 pub trait Pins {
     const BUSWIDTH: Buswidth;
+}
+
+impl<CLK, CMD, D0, D1, D2, D3, D4, D5, D6, D7> Pins for (CLK, CMD, D0, D1, D2, D3, D4, D5, D6, D7)
+where
+    CLK: PinClk,
+    CMD: PinCmd,
+    D0: PinD0,
+    D1: PinD1,
+    D2: PinD2,
+    D3: PinD3,
+    D4: PinD4,
+    D5: PinD5,
+    D6: PinD6,
+    D7: PinD7,
+{
+    const BUSWIDTH: Buswidth = Buswidth::Buswidth8;
 }
 
 impl<CLK, CMD, D0, D1, D2, D3> Pins for (CLK, CMD, D0, D1, D2, D3)
@@ -43,7 +63,7 @@ where
 }
 
 macro_rules! pins {
-    ($(CLK: [$($CLK:ty),*] CMD: [$($CMD:ty),*] D0: [$($D0:ty),*] D1: [$($D1:ty),*] D2: [$($D2:ty),*] D3: [$($D3:ty),*])+) => {
+    ($(CLK: [$($CLK:ty),*] CMD: [$($CMD:ty),*] D0: [$($D0:ty),*] D1: [$($D1:ty),*] D2: [$($D2:ty),*] D3: [$($D3:ty),*] D4: [$($D4:ty),*] D5: [$($D5:ty),*] D6: [$($D6:ty),*] D7: [$($D7:ty),*])+) => {
         $(
             $(
                 impl PinClk for $CLK {}
@@ -62,6 +82,18 @@ macro_rules! pins {
             )*
             $(
                 impl PinD3 for $D3 {}
+            )*
+            $(
+                impl PinD4 for $D4 {}
+            )*
+            $(
+                impl PinD5 for $D5 {}
+            )*
+            $(
+                impl PinD6 for $D6 {}
+            )*
+            $(
+                impl PinD7 for $D7 {}
             )*
         )+
     }
@@ -92,6 +124,10 @@ pins! {
     D1: [gpio::PC9<Alternate<PushPull, 12>>]
     D2: [gpio::PC10<Alternate<PushPull, 12>>]
     D3: [gpio::PC11<Alternate<PushPull, 12>>]
+    D4: [gpio::PB8<Alternate<PushPull, 12>>]
+    D5: [gpio::PB9<Alternate<PushPull, 12>>]
+    D6: [gpio::PC6<Alternate<PushPull, 12>>]
+    D7: [gpio::PC7<Alternate<PushPull, 12>>]
 }
 
 #[cfg(any(feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
@@ -102,6 +138,10 @@ pins! {
     D1: [gpio::PA8<Alternate<PushPull, 12>>]
     D2: [gpio::PA9<Alternate<PushPull, 12>>]
     D3: [gpio::PB5<Alternate<PushPull, 12>>]
+    D4: []
+    D5: []
+    D6: [gpio::PB14<Alternate<PushPull, 12>>]
+    D7: [gpio::PB10<Alternate<PushPull, 12>>]
 }
 
 #[cfg(feature = "stm32f411")]
@@ -112,12 +152,17 @@ pins! {
     D1: [gpio::PA8<Alternate<PushPull, 12>>]
     D2: [gpio::PA9<Alternate<PushPull, 12>>]
     D3: [gpio::PB5<Alternate<PushPull, 12>>]
+    D4: []
+    D5: []
+    D6: [gpio::PB14<Alternate<PushPull, 12>>]
+    D7: [gpio::PB10<Alternate<PushPull, 12>>]
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Buswidth {
     Buswidth1 = 0,
     Buswidth4 = 1,
+    Buswidth8 = 2,
 }
 
 /// Clock frequency of a SDIO bus.


### PR DESCRIPTION
Followup to https://github.com/jkristell/sdio-host/pull/10, which will also be required before this PR can be merged (cc @jkristell)

This PR adds support for eMMC peripherals using the SDIO module. `Sdio` is now generic over an `SdioPeripheral`, which can either be a `SdCard` or `Emmc`. Many of the methods are generic enough to be shared between both, although some (like initialization) need to be specialized for each.