### PR TITLE
Fix defmt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Move pin mode at the end of generics, add defaults for modes,
   bump MSRV to 1.59 [#418]
 
+### Fixed
+- Enable the defmt feature on fugit when the defmt feature on the
+  crate is enabled
+
 ### Added
 
 - Support eMMC peripherals using SDIO module [#458]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Move pin mode at the end of generics, add defaults for modes,
   bump MSRV to 1.59 [#418]
+- Move hd44780-driver to dev-dependencies
 
 ### Fixed
 - Enable the defmt feature on fugit when the defmt feature on the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = ["stm32f429", "rt", "usb_fs", "can", "i2s", "fsmc_lcd"]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
-defmt = { version = "0.3.0", optional = true }
+defmt_ = { package = "defmt", version = "0.3.0", optional = true }
 bxcan = { version = "0.6", optional = true }
 cortex-m = "0.7.4"
 cortex-m-rt = "0.7"
@@ -323,6 +323,8 @@ can = ["bxcan"]
 i2s = ["stm32_i2s_v12x"]
 
 fsmc_lcd = ["display-interface"]
+
+defmt = ["defmt_", "fugit/defmt"]
 
 adc2 = []
 adc3 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ fugit-timer = "0.1.3"
 rtic-monotonic = { version = "1.0", optional = true }
 bitflags = "1.3.2"
 embedded-storage = "0.2"
-hd44780-driver = "0.4.0"
 
 [dependencies.time]
 version = "0.3"
@@ -80,6 +79,7 @@ display-interface-spi = "0.4"
 ist7920 = "0.1.0"
 smart-leds = "0.3.0"
 ws2812-spi = { version = "0.4.0", features = [] }
+hd44780-driver = "0.4.0"
 
 [dev-dependencies.time]
 version = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 #![allow(non_camel_case_types)]
 
+#[cfg(feature = "defmt")]
+extern crate defmt_ as defmt;
+
 #[cfg(not(feature = "device-selected"))]
 compile_error!(
     "This crate requires one of the following device features enabled:


### PR DESCRIPTION
Right now on relase 0.12 (and master) this:
```
DEFMT_LOG=debug cargo build --release --features=rt,stm32f405,defmt --examples
```
fails to compile due to `defmt` support in fugit not being enabled.

This workaround fixes that, but feels like a hack.
It's described here: https://blog.turbo.fish/cargo-features/

The other option is to rename the fugit feature under a different name, but this fix could be used until then.

Let me know if you want this to be merged and I can write a Changelog entry.

