### PR TITLE
Fix `rcc` example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Move hd44780-driver to dev-dependencies
 
 ### Fixed
+- Fixed RCC example.
 - Enable the defmt feature on fugit when the defmt feature on the
   crate is enabled
 

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! ```
 //! let dp = pac::Peripherals::take().unwrap();
+//! let rcc = dp.RCC.constrain();
 //! let clocks = rcc
 //!     .cfgr
 //!     .use_hse(8.MHz())


### PR DESCRIPTION
Add missing `rcc` variable.