### PR TITLE
Remove the defmt feature/crate naming workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Remove the defmt feature/dependency name workaround
+
 ## [v0.13.0] - 2022-04-04
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
 categories = [
@@ -27,7 +27,7 @@ features = ["stm32f429", "usb_fs", "can", "i2s", "fsmc_lcd"]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
-defmt_ = { package = "defmt", version = "0.3.0", optional = true }
+defmt = { version = "0.3.0", optional = true }
 bxcan = { version = "0.6", optional = true }
 cortex-m = "0.7.4"
 cortex-m-rt = "0.7"
@@ -318,7 +318,7 @@ i2s = ["stm32_i2s_v12x"]
 
 fsmc_lcd = ["display-interface"]
 
-defmt = ["defmt_", "fugit/defmt"]
+defmt = ["dep:defmt", "fugit/defmt"]
 
 adc2 = []
 adc3 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #![no_std]
 #![allow(non_camel_case_types)]
 
-#[cfg(feature = "defmt")]
-extern crate defmt_ as defmt;
-
 #[cfg(not(feature = "device-selected"))]
 compile_error!(
     "This crate requires one of the following device features enabled:


### PR DESCRIPTION
Requires Rust 1.60