### PR TITLE
[DRAFT] Ensure all UARTs are defined as UARTs (not USARTs).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
+ - update `stm32f4` to 0.15.1
  - use `stm32_i2s_v12x` version 0.3, reexport it, and implements requirement for it
  - i2s module don't reuse marker from spi module and define its own.
  - `i2s-audio-out` example updated and now use pcm5102 dac module instead one from discovery board.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cortex-m = "0.7.4"
 cortex-m-rt = "0.7"
 nb = "1"
 rand_core = "0.6"
-stm32f4 = "0.14.0"
+stm32f4 = "0.15.1"
 synopsys-usb-otg = { version = "0.2.0", features = ["cortex-m"], optional = true }
 sdio-host = { version = "0.6.0", optional = true }
 embedded-dma = "0.2.0"

--- a/examples/blinky-timer-irq.rs
+++ b/examples/blinky-timer-irq.rs
@@ -58,7 +58,7 @@ fn TIM2() {
         })
     });
 
-    let _ = led.toggle();
+    led.toggle();
     let _ = tim.wait();
 }
 
@@ -72,7 +72,7 @@ fn main() -> ! {
     // Configure PA5 pin to blink LED
     let gpioa = dp.GPIOA.split();
     let mut led = gpioa.pa5.into_push_pull_output();
-    let _ = led.set_high(); // Turn off
+    led.set_high(); // Turn off
 
     // Move the pin into our global storage
     cortex_m::interrupt::free(|cs| *G_LED.borrow(cs).borrow_mut() = Some(led));

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -841,10 +841,24 @@ macro_rules! adc {
                 /// Sets which external trigger to use and if it is disabled, rising, falling or both
                 pub fn set_external_trigger(&mut self, (edge, extsel): (config::TriggerMode, config::ExternalTrigger)) {
                     self.config.external_trigger = (edge, extsel);
+                    #[cfg(any(
+                        feature = "stm32f401",
+                        feature = "stm32f410",
+                        feature = "stm32f411",
+                    ))] // TODO: fix pac
                     self.adc_reg.cr2.modify(|_, w| unsafe { w
                         .extsel().bits(extsel.into())
                         .exten().bits(edge.into())
                     });
+                    #[cfg(not(any(
+                        feature = "stm32f401",
+                        feature = "stm32f410",
+                        feature = "stm32f411",
+                    )))]
+                    self.adc_reg.cr2.modify(|_, w| w
+                        .extsel().bits(extsel.into())
+                        .exten().bits(edge.into())
+                    );
                 }
 
                 /// Enables and disables continuous mode

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -47,7 +47,7 @@ impl Crc32 {
     pub fn update(&mut self, data: &[u32]) -> u32 {
         // Feed each word into the engine
         for word in data {
-            self.periph.dr.write(|w| unsafe { w.bits(*word) });
+            self.periph.dr.write(|w| w.bits(*word));
         }
         // Retrieve the resulting CRC
         self.periph.dr.read().bits()
@@ -112,7 +112,7 @@ impl Crc32 {
             scratch[..remainder.len()].copy_from_slice(remainder);
             self.periph
                 .dr
-                .write(|w| unsafe { w.bits(u32::from_ne_bytes(scratch)) });
+                .write(|w| w.bits(u32::from_ne_bytes(scratch)));
         }
 
         self.periph.dr.read().bits()

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{
     adc::Adc,
     pac::{self, DMA1, DMA2},
-    serial, spi,
+    serial, spi, timer,
 };
 use core::ops::Deref;
 
@@ -265,24 +265,6 @@ impl Instance for DMA2 {
     }
 }
 
-macro_rules! tim_channels {
-    ($($name:ident),+ $(,)*) => {
-        $(
-            /// Wrapper type that indicates which register of the contained timer to use for DMA.
-            pub struct $name<T> (pub T);
-
-            impl<T> Deref for $name<T> {
-                type Target = T;
-
-                #[inline(always)]
-                fn deref(&self) -> &T {
-                    &self.0
-                }
-            }
-        )+
-    };
-}
-
 /// A channel that can be configured on a DMA stream.
 pub trait Channel {}
 
@@ -292,8 +274,6 @@ pub trait Channel {}
 ///
 /// Memory corruption might occur if this trait is implemented for an invalid combination.
 pub unsafe trait DMASet<STREAM, const CHANNEL: u8, DIRECTION> {}
-
-tim_channels!(CCR1, CCR2, CCR3, CCR4, DMAR, ARR);
 
 macro_rules! dma_map {
     ($(($Stream:ty, $C:literal, $Peripheral:ty, $Dir:ty)),+ $(,)*) => {
@@ -322,32 +302,32 @@ macro_rules! dma_map {
     feature = "stm32f479",
 ))]
 dma_map!(
-    (Stream0<DMA1>, 2, CCR1<pac::TIM4>, MemoryToPeripheral), //TIM4_CH1
-    (Stream0<DMA1>, 2, CCR1<pac::TIM4>, PeripheralToMemory), //TIM4_CH1
-    (Stream2<DMA1>, 5, CCR4<pac::TIM3>, MemoryToPeripheral), //TIM3_CH4
-    (Stream2<DMA1>, 5, CCR4<pac::TIM3>, PeripheralToMemory), //TIM3_CH4
-    (Stream2<DMA1>, 5, DMAR<pac::TIM3>, MemoryToPeripheral), //TIM3_UP
-    (Stream2<DMA1>, 5, DMAR<pac::TIM3>, PeripheralToMemory), //TIM3_UP
-    (Stream3<DMA1>, 2, CCR2<pac::TIM4>, MemoryToPeripheral), //TIM4_CH2
-    (Stream3<DMA1>, 2, CCR2<pac::TIM4>, PeripheralToMemory), //TIM4_CH2
-    (Stream4<DMA1>, 5, CCR1<pac::TIM3>, MemoryToPeripheral), //TIM3_CH1
-    (Stream4<DMA1>, 5, CCR1<pac::TIM3>, PeripheralToMemory), //TIM3_CH1
-    (Stream4<DMA1>, 5, DMAR<pac::TIM3>, MemoryToPeripheral), //TIM3_TRIG
-    (Stream4<DMA1>, 5, DMAR<pac::TIM3>, PeripheralToMemory), //TIM3_TRIG
-    (Stream5<DMA1>, 3, CCR1<pac::TIM2>, MemoryToPeripheral), //TIM2_CH1
-    (Stream5<DMA1>, 3, CCR1<pac::TIM2>, PeripheralToMemory), //TIM2_CH1
-    (Stream5<DMA1>, 5, CCR2<pac::TIM3>, MemoryToPeripheral), //TIM3_CH2
-    (Stream5<DMA1>, 5, CCR2<pac::TIM3>, PeripheralToMemory), //TIM3_CH2
-    (Stream6<DMA1>, 2, DMAR<pac::TIM4>, MemoryToPeripheral), //TIM4_UP
-    (Stream6<DMA1>, 2, DMAR<pac::TIM4>, PeripheralToMemory), //TIM4_UP
-    (Stream6<DMA1>, 3, CCR2<pac::TIM2>, MemoryToPeripheral), //TIM2_CH2
-    (Stream6<DMA1>, 3, CCR2<pac::TIM2>, PeripheralToMemory), //TIM2_CH2
-    (Stream6<DMA1>, 3, CCR4<pac::TIM2>, MemoryToPeripheral), //TIM2_CH4
-    (Stream6<DMA1>, 3, CCR4<pac::TIM2>, PeripheralToMemory), //TIM2_CH4
-    (Stream7<DMA1>, 2, CCR3<pac::TIM4>, MemoryToPeripheral), //TIM4_CH3
-    (Stream7<DMA1>, 2, CCR3<pac::TIM4>, PeripheralToMemory), //TIM4_CH3
-    (Stream7<DMA1>, 5, CCR3<pac::TIM3>, MemoryToPeripheral), //TIM3_CH3
-    (Stream7<DMA1>, 5, CCR3<pac::TIM3>, PeripheralToMemory), //TIM3_CH3
+    (Stream0<DMA1>, 2, timer::CCR1<pac::TIM4>, MemoryToPeripheral), //TIM4_CH1
+    (Stream0<DMA1>, 2, timer::CCR1<pac::TIM4>, PeripheralToMemory), //TIM4_CH1
+    (Stream2<DMA1>, 5, timer::CCR4<pac::TIM3>, MemoryToPeripheral), //TIM3_CH4
+    (Stream2<DMA1>, 5, timer::CCR4<pac::TIM3>, PeripheralToMemory), //TIM3_CH4
+    (Stream2<DMA1>, 5, timer::DMAR<pac::TIM3>, MemoryToPeripheral), //TIM3_UP
+    (Stream2<DMA1>, 5, timer::DMAR<pac::TIM3>, PeripheralToMemory), //TIM3_UP
+    (Stream3<DMA1>, 2, timer::CCR2<pac::TIM4>, MemoryToPeripheral), //TIM4_CH2
+    (Stream3<DMA1>, 2, timer::CCR2<pac::TIM4>, PeripheralToMemory), //TIM4_CH2
+    (Stream4<DMA1>, 5, timer::CCR1<pac::TIM3>, MemoryToPeripheral), //TIM3_CH1
+    (Stream4<DMA1>, 5, timer::CCR1<pac::TIM3>, PeripheralToMemory), //TIM3_CH1
+    (Stream4<DMA1>, 5, timer::DMAR<pac::TIM3>, MemoryToPeripheral), //TIM3_TRIG
+    (Stream4<DMA1>, 5, timer::DMAR<pac::TIM3>, PeripheralToMemory), //TIM3_TRIG
+    (Stream5<DMA1>, 3, timer::CCR1<pac::TIM2>, MemoryToPeripheral), //TIM2_CH1
+    (Stream5<DMA1>, 3, timer::CCR1<pac::TIM2>, PeripheralToMemory), //TIM2_CH1
+    (Stream5<DMA1>, 5, timer::CCR2<pac::TIM3>, MemoryToPeripheral), //TIM3_CH2
+    (Stream5<DMA1>, 5, timer::CCR2<pac::TIM3>, PeripheralToMemory), //TIM3_CH2
+    (Stream6<DMA1>, 2, timer::DMAR<pac::TIM4>, MemoryToPeripheral), //TIM4_UP
+    (Stream6<DMA1>, 2, timer::DMAR<pac::TIM4>, PeripheralToMemory), //TIM4_UP
+    (Stream6<DMA1>, 3, timer::CCR2<pac::TIM2>, MemoryToPeripheral), //TIM2_CH2
+    (Stream6<DMA1>, 3, timer::CCR2<pac::TIM2>, PeripheralToMemory), //TIM2_CH2
+    (Stream6<DMA1>, 3, timer::CCR4<pac::TIM2>, MemoryToPeripheral), //TIM2_CH4
+    (Stream6<DMA1>, 3, timer::CCR4<pac::TIM2>, PeripheralToMemory), //TIM2_CH4
+    (Stream7<DMA1>, 2, timer::CCR3<pac::TIM4>, MemoryToPeripheral), //TIM4_CH3
+    (Stream7<DMA1>, 2, timer::CCR3<pac::TIM4>, PeripheralToMemory), //TIM4_CH3
+    (Stream7<DMA1>, 5, timer::CCR3<pac::TIM3>, MemoryToPeripheral), //TIM3_CH3
+    (Stream7<DMA1>, 5, timer::CCR3<pac::TIM3>, PeripheralToMemory), //TIM3_CH3
     (Stream0<DMA1>, 0, pac::SPI3, PeripheralToMemory),       //SPI3_RX
     (Stream0<DMA1>, 0, spi::Rx<pac::SPI3>, PeripheralToMemory), //SPI3_RX
     (Stream2<DMA1>, 0, pac::SPI3, PeripheralToMemory),       //SPI3_RX
@@ -377,22 +357,7 @@ dma_map!(
     feature = "stm32f469",
     feature = "stm32f479",
 ))]
-address!(
-    (CCR1<pac::TIM4>, ccr1, u16),
-    (CCR4<pac::TIM3>, ccr4, u16),
-    (CCR1<pac::TIM2>, ccr1, u16),
-    (CCR1<pac::TIM3>, ccr1, u16),
-    (CCR2<pac::TIM2>, ccr2, u16),
-    (CCR2<pac::TIM3>, ccr2, u16),
-    (CCR2<pac::TIM4>, ccr2, u16),
-    (CCR3<pac::TIM3>, ccr3, u16),
-    (CCR3<pac::TIM4>, ccr3, u16),
-    (CCR4<pac::TIM2>, ccr4, u16),
-    (DMAR<pac::TIM3>, dmar, u16),
-    (DMAR<pac::TIM4>, dmar, u16),
-    (pac::SPI3, dr, u8),
-    (pac::I2C3, dr, u8),
-);
+address!((pac::SPI3, dr, u8), (pac::I2C3, dr, u8),);
 
 #[cfg(not(any(feature = "stm32f410")))]
 dma_map!(
@@ -425,46 +390,46 @@ address!((pac::SDIO, fifo, u32),);
     feature = "stm32f479",
 ))]
 dma_map!(
-    (Stream0<DMA1>, 6, CCR3<pac::TIM5>, MemoryToPeripheral), //TIM5_CH3
-    (Stream0<DMA1>, 6, CCR3<pac::TIM5>, PeripheralToMemory), //TIM5_CH3
-    (Stream0<DMA1>, 6, DMAR<pac::TIM5>, MemoryToPeripheral), //TIM5_UP
-    (Stream0<DMA1>, 6, DMAR<pac::TIM5>, PeripheralToMemory), //TIM5_UP
-    (Stream1<DMA1>, 6, CCR4<pac::TIM5>, MemoryToPeripheral), //TIM5_CH4
-    (Stream1<DMA1>, 6, CCR4<pac::TIM5>, PeripheralToMemory), //TIM5_CH4
-    (Stream1<DMA1>, 6, DMAR<pac::TIM5>, MemoryToPeripheral), //TIM5_TRIG
-    (Stream1<DMA1>, 6, DMAR<pac::TIM5>, PeripheralToMemory), //TIM5_TRIG
-    (Stream2<DMA1>, 6, CCR1<pac::TIM5>, MemoryToPeripheral), //TIM5_CH1
-    (Stream2<DMA1>, 6, CCR1<pac::TIM5>, PeripheralToMemory), //TIM5_CH1
-    (Stream3<DMA1>, 6, CCR4<pac::TIM5>, MemoryToPeripheral), //TIM5_CH4
-    (Stream3<DMA1>, 6, CCR4<pac::TIM5>, PeripheralToMemory), //TIM5_CH4
-    (Stream3<DMA1>, 6, DMAR<pac::TIM5>, MemoryToPeripheral), //TIM5_TRIG
-    (Stream3<DMA1>, 6, DMAR<pac::TIM5>, PeripheralToMemory), //TIM5_TRIG
-    (Stream4<DMA1>, 6, CCR2<pac::TIM5>, MemoryToPeripheral), //TIM5_CH2
-    (Stream4<DMA1>, 6, CCR2<pac::TIM5>, PeripheralToMemory), //TIM5_CH2
-    (Stream6<DMA1>, 6, DMAR<pac::TIM5>, MemoryToPeripheral), //TIM5_UP
-    (Stream6<DMA1>, 6, DMAR<pac::TIM5>, PeripheralToMemory), //TIM5_UP
-    (Stream0<DMA2>, 6, DMAR<pac::TIM1>, MemoryToPeripheral), //TIM1_TRIG
-    (Stream0<DMA2>, 6, DMAR<pac::TIM1>, PeripheralToMemory), //TIM1_TRIG
-    (Stream1<DMA2>, 6, CCR1<pac::TIM1>, MemoryToPeripheral), //TIM1_CH1
-    (Stream1<DMA2>, 6, CCR1<pac::TIM1>, PeripheralToMemory), //TIM1_CH1
-    (Stream2<DMA2>, 6, CCR2<pac::TIM1>, MemoryToPeripheral), //TIM1_CH2
-    (Stream2<DMA2>, 6, CCR2<pac::TIM1>, PeripheralToMemory), //TIM1_CH2
-    (Stream3<DMA2>, 6, CCR1<pac::TIM1>, MemoryToPeripheral), //TIM1_CH1
-    (Stream3<DMA2>, 6, CCR1<pac::TIM1>, PeripheralToMemory), //TIM1_CH1
-    (Stream4<DMA2>, 6, CCR4<pac::TIM1>, MemoryToPeripheral), //TIM1_CH4
-    (Stream4<DMA2>, 6, CCR4<pac::TIM1>, PeripheralToMemory), //TIM1_CH4
-    (Stream4<DMA2>, 6, DMAR<pac::TIM1>, MemoryToPeripheral), //TIM1_TRIG/COM
-    (Stream4<DMA2>, 6, DMAR<pac::TIM1>, PeripheralToMemory), //TIM1_TRIG/COM
-    (Stream5<DMA2>, 6, DMAR<pac::TIM1>, MemoryToPeripheral), //TIM1_UP
-    (Stream5<DMA2>, 6, DMAR<pac::TIM1>, PeripheralToMemory), //TIM1_UP
-    (Stream6<DMA2>, 0, CCR1<pac::TIM1>, MemoryToPeripheral), //TIM1_CH1
-    (Stream6<DMA2>, 0, CCR1<pac::TIM1>, PeripheralToMemory), //TIM1_CH1
-    (Stream6<DMA2>, 0, CCR2<pac::TIM1>, MemoryToPeripheral), //TIM1_CH2
-    (Stream6<DMA2>, 0, CCR2<pac::TIM1>, PeripheralToMemory), //TIM1_CH2
-    (Stream6<DMA2>, 0, CCR3<pac::TIM1>, MemoryToPeripheral), //TIM1_CH3
-    (Stream6<DMA2>, 0, CCR3<pac::TIM1>, PeripheralToMemory), //TIM1_CH3
-    (Stream6<DMA2>, 6, CCR3<pac::TIM1>, MemoryToPeripheral), //TIM1_CH3
-    (Stream6<DMA2>, 6, CCR3<pac::TIM1>, PeripheralToMemory), //TIM1_CH3
+    (Stream0<DMA1>, 6, timer::CCR3<pac::TIM5>, MemoryToPeripheral), //TIM5_CH3
+    (Stream0<DMA1>, 6, timer::CCR3<pac::TIM5>, PeripheralToMemory), //TIM5_CH3
+    (Stream0<DMA1>, 6, timer::DMAR<pac::TIM5>, MemoryToPeripheral), //TIM5_UP
+    (Stream0<DMA1>, 6, timer::DMAR<pac::TIM5>, PeripheralToMemory), //TIM5_UP
+    (Stream1<DMA1>, 6, timer::CCR4<pac::TIM5>, MemoryToPeripheral), //TIM5_CH4
+    (Stream1<DMA1>, 6, timer::CCR4<pac::TIM5>, PeripheralToMemory), //TIM5_CH4
+    (Stream1<DMA1>, 6, timer::DMAR<pac::TIM5>, MemoryToPeripheral), //TIM5_TRIG
+    (Stream1<DMA1>, 6, timer::DMAR<pac::TIM5>, PeripheralToMemory), //TIM5_TRIG
+    (Stream2<DMA1>, 6, timer::CCR1<pac::TIM5>, MemoryToPeripheral), //TIM5_CH1
+    (Stream2<DMA1>, 6, timer::CCR1<pac::TIM5>, PeripheralToMemory), //TIM5_CH1
+    (Stream3<DMA1>, 6, timer::CCR4<pac::TIM5>, MemoryToPeripheral), //TIM5_CH4
+    (Stream3<DMA1>, 6, timer::CCR4<pac::TIM5>, PeripheralToMemory), //TIM5_CH4
+    (Stream3<DMA1>, 6, timer::DMAR<pac::TIM5>, MemoryToPeripheral), //TIM5_TRIG
+    (Stream3<DMA1>, 6, timer::DMAR<pac::TIM5>, PeripheralToMemory), //TIM5_TRIG
+    (Stream4<DMA1>, 6, timer::CCR2<pac::TIM5>, MemoryToPeripheral), //TIM5_CH2
+    (Stream4<DMA1>, 6, timer::CCR2<pac::TIM5>, PeripheralToMemory), //TIM5_CH2
+    (Stream6<DMA1>, 6, timer::DMAR<pac::TIM5>, MemoryToPeripheral), //TIM5_UP
+    (Stream6<DMA1>, 6, timer::DMAR<pac::TIM5>, PeripheralToMemory), //TIM5_UP
+    (Stream0<DMA2>, 6, timer::DMAR<pac::TIM1>, MemoryToPeripheral), //TIM1_TRIG
+    (Stream0<DMA2>, 6, timer::DMAR<pac::TIM1>, PeripheralToMemory), //TIM1_TRIG
+    (Stream1<DMA2>, 6, timer::CCR1<pac::TIM1>, MemoryToPeripheral), //TIM1_CH1
+    (Stream1<DMA2>, 6, timer::CCR1<pac::TIM1>, PeripheralToMemory), //TIM1_CH1
+    (Stream2<DMA2>, 6, timer::CCR2<pac::TIM1>, MemoryToPeripheral), //TIM1_CH2
+    (Stream2<DMA2>, 6, timer::CCR2<pac::TIM1>, PeripheralToMemory), //TIM1_CH2
+    (Stream3<DMA2>, 6, timer::CCR1<pac::TIM1>, MemoryToPeripheral), //TIM1_CH1
+    (Stream3<DMA2>, 6, timer::CCR1<pac::TIM1>, PeripheralToMemory), //TIM1_CH1
+    (Stream4<DMA2>, 6, timer::CCR4<pac::TIM1>, MemoryToPeripheral), //TIM1_CH4
+    (Stream4<DMA2>, 6, timer::CCR4<pac::TIM1>, PeripheralToMemory), //TIM1_CH4
+    (Stream4<DMA2>, 6, timer::DMAR<pac::TIM1>, MemoryToPeripheral), //TIM1_TRIG/COM
+    (Stream4<DMA2>, 6, timer::DMAR<pac::TIM1>, PeripheralToMemory), //TIM1_TRIG/COM
+    (Stream5<DMA2>, 6, timer::DMAR<pac::TIM1>, MemoryToPeripheral), //TIM1_UP
+    (Stream5<DMA2>, 6, timer::DMAR<pac::TIM1>, PeripheralToMemory), //TIM1_UP
+    (Stream6<DMA2>, 0, timer::CCR1<pac::TIM1>, MemoryToPeripheral), //TIM1_CH1
+    (Stream6<DMA2>, 0, timer::CCR1<pac::TIM1>, PeripheralToMemory), //TIM1_CH1
+    (Stream6<DMA2>, 0, timer::CCR2<pac::TIM1>, MemoryToPeripheral), //TIM1_CH2
+    (Stream6<DMA2>, 0, timer::CCR2<pac::TIM1>, PeripheralToMemory), //TIM1_CH2
+    (Stream6<DMA2>, 0, timer::CCR3<pac::TIM1>, MemoryToPeripheral), //TIM1_CH3
+    (Stream6<DMA2>, 0, timer::CCR3<pac::TIM1>, PeripheralToMemory), //TIM1_CH3
+    (Stream6<DMA2>, 6, timer::CCR3<pac::TIM1>, MemoryToPeripheral), //TIM1_CH3
+    (Stream6<DMA2>, 6, timer::CCR3<pac::TIM1>, PeripheralToMemory), //TIM1_CH3
     (Stream0<DMA1>, 1, pac::I2C1, PeripheralToMemory),       //I2C1_RX
     (Stream2<DMA1>, 7, pac::I2C2, PeripheralToMemory),       //I2C2_RX
     (Stream3<DMA1>, 0, pac::SPI2, PeripheralToMemory),       //SPI2_RX
@@ -545,16 +510,6 @@ dma_map!(
     feature = "stm32f479",
 ))]
 address!(
-    (CCR1<pac::TIM1>, ccr1, u16),
-    (CCR2<pac::TIM1>, ccr2, u16),
-    (CCR3<pac::TIM1>, ccr3, u16),
-    (CCR4<pac::TIM1>, ccr4, u16),
-    (DMAR<pac::TIM1>, dmar, u16),
-    (CCR1<pac::TIM5>, ccr1, u16),
-    (CCR2<pac::TIM5>, ccr2, u16),
-    (CCR3<pac::TIM5>, ccr3, u16),
-    (CCR4<pac::TIM5>, ccr4, u16),
-    (DMAR<pac::TIM5>, dmar, u16),
     (pac::ADC1, dr, u16),
     (pac::I2C1, dr, u8),
     (pac::I2C2, dr, u8),
@@ -580,18 +535,15 @@ dma_map!(
 
 #[cfg(any(feature = "stm32f401", feature = "stm32f411",))]
 dma_map!(
-    (Stream1<DMA1>, 3, CCR3<pac::TIM2>, MemoryToPeripheral), //TIM2_CH3
-    (Stream1<DMA1>, 3, CCR3<pac::TIM2>, PeripheralToMemory), //TIM2_CH3
-    (Stream1<DMA1>, 3, DMAR<pac::TIM2>, MemoryToPeripheral), //TIM2_UP
-    (Stream1<DMA1>, 3, DMAR<pac::TIM2>, PeripheralToMemory), //TIM2_UP
-    (Stream7<DMA1>, 3, CCR4<pac::TIM2>, MemoryToPeripheral), //TIM2_CH4
-    (Stream7<DMA1>, 3, CCR4<pac::TIM2>, PeripheralToMemory), //TIM2_CH4
-    (Stream7<DMA1>, 3, DMAR<pac::TIM2>, MemoryToPeripheral), //TIM2_UP
-    (Stream7<DMA1>, 3, DMAR<pac::TIM2>, PeripheralToMemory), //TIM2_UP
+    (Stream1<DMA1>, 3, timer::CCR3<pac::TIM2>, MemoryToPeripheral), //TIM2_CH3
+    (Stream1<DMA1>, 3, timer::CCR3<pac::TIM2>, PeripheralToMemory), //TIM2_CH3
+    (Stream1<DMA1>, 3, timer::DMAR<pac::TIM2>, MemoryToPeripheral), //TIM2_UP
+    (Stream1<DMA1>, 3, timer::DMAR<pac::TIM2>, PeripheralToMemory), //TIM2_UP
+    (Stream7<DMA1>, 3, timer::CCR4<pac::TIM2>, MemoryToPeripheral), //TIM2_CH4
+    (Stream7<DMA1>, 3, timer::CCR4<pac::TIM2>, PeripheralToMemory), //TIM2_CH4
+    (Stream7<DMA1>, 3, timer::DMAR<pac::TIM2>, MemoryToPeripheral), //TIM2_UP
+    (Stream7<DMA1>, 3, timer::DMAR<pac::TIM2>, PeripheralToMemory), //TIM2_UP
 );
-
-#[cfg(any(feature = "stm32f401", feature = "stm32f411",))]
-address!((CCR3<pac::TIM2>, ccr3, u16), (DMAR<pac::TIM2>, dmar, u16),);
 
 #[cfg(any(
     feature = "stm32f401",
@@ -726,36 +678,36 @@ address!(
     feature = "stm32f479",
 ))]
 dma_map!(
-    (Stream1<DMA1>, 3, DMAR<pac::TIM2>, MemoryToPeripheral), //TIM2_UP
-    (Stream1<DMA1>, 3, DMAR<pac::TIM2>, PeripheralToMemory), //TIM2_UP
-    (Stream1<DMA1>, 3, CCR3<pac::TIM2>, MemoryToPeripheral), //TIM2_CH3
-    (Stream1<DMA1>, 3, CCR3<pac::TIM2>, PeripheralToMemory), //TIM2_CH3
-    //(pac::DMA1, Stream2, 1, DMAR<pac::TIM7>, MemoryToPeripheral), //TIM7_UP //dmar register appears to be missing
-    //(pac::DMA1, Stream2, 1, DMAR<pac::TIM7>, PeripheralToMemory), //TIM7_UP //dmar register appears to be missing
-    //(pac::DMA1, Stream4, 1, DMAR<pac::TIM7>, MemoryToPeripheral), //TIM7_UP //dmar register appears to be missing
-    //(pac::DMA1, Stream4, 1, DMAR<pac::TIM7>, PeripheralToMemory), //TIM7_UP //dmar register appears to be missing
-    (Stream7<DMA1>, 3, DMAR<pac::TIM2>, MemoryToPeripheral), //TIM2_UP
-    (Stream7<DMA1>, 3, DMAR<pac::TIM2>, PeripheralToMemory), //TIM2_UP
-    (Stream7<DMA1>, 3, CCR4<pac::TIM2>, MemoryToPeripheral), //TIM2_CH4
-    (Stream7<DMA1>, 3, CCR4<pac::TIM2>, PeripheralToMemory), //TIM2_CH4
-    (Stream1<DMA2>, 7, DMAR<pac::TIM8>, MemoryToPeripheral), //TIM8_UP
-    (Stream1<DMA2>, 7, DMAR<pac::TIM8>, PeripheralToMemory), //TIM8_UP
-    (Stream2<DMA2>, 0, CCR1<pac::TIM8>, MemoryToPeripheral), //TIM8_CH1
-    (Stream2<DMA2>, 0, CCR1<pac::TIM8>, PeripheralToMemory), //TIM8_CH1
-    (Stream2<DMA2>, 0, CCR2<pac::TIM8>, MemoryToPeripheral), //TIM8_CH2
-    (Stream2<DMA2>, 0, CCR2<pac::TIM8>, PeripheralToMemory), //TIM8_CH2
-    (Stream2<DMA2>, 0, CCR3<pac::TIM8>, MemoryToPeripheral), //TIM8_CH3
-    (Stream2<DMA2>, 0, CCR3<pac::TIM8>, PeripheralToMemory), //TIM8_CH3
-    (Stream2<DMA2>, 7, CCR1<pac::TIM8>, MemoryToPeripheral), //TIM8_CH1
-    (Stream2<DMA2>, 7, CCR1<pac::TIM8>, PeripheralToMemory), //TIM8_CH1
-    (Stream3<DMA2>, 7, CCR2<pac::TIM8>, MemoryToPeripheral), //TIM8_CH2
-    (Stream3<DMA2>, 7, CCR2<pac::TIM8>, PeripheralToMemory), //TIM8_CH2
-    (Stream4<DMA2>, 7, CCR3<pac::TIM8>, MemoryToPeripheral), //TIM8_CH3
-    (Stream4<DMA2>, 7, CCR3<pac::TIM8>, PeripheralToMemory), //TIM8_CH3
-    (Stream7<DMA2>, 7, CCR4<pac::TIM8>, MemoryToPeripheral), //TIM8_CH4
-    (Stream7<DMA2>, 7, CCR4<pac::TIM8>, PeripheralToMemory), //TIM8_CH4
-    (Stream7<DMA2>, 7, DMAR<pac::TIM8>, MemoryToPeripheral), //TIM8_COM/TRIG
-    (Stream7<DMA2>, 7, DMAR<pac::TIM8>, PeripheralToMemory), //TIM8_COM/TRIG
+    (Stream1<DMA1>, 3, timer::DMAR<pac::TIM2>, MemoryToPeripheral), //TIM2_UP
+    (Stream1<DMA1>, 3, timer::DMAR<pac::TIM2>, PeripheralToMemory), //TIM2_UP
+    (Stream1<DMA1>, 3, timer::CCR3<pac::TIM2>, MemoryToPeripheral), //TIM2_CH3
+    (Stream1<DMA1>, 3, timer::CCR3<pac::TIM2>, PeripheralToMemory), //TIM2_CH3
+    //(pac::DMA1, Stream2, 1, timer::DMAR<pac::TIM7>, MemoryToPeripheral), //TIM7_UP //dmar register appears to be missing
+    //(pac::DMA1, Stream2, 1, timer::DMAR<pac::TIM7>, PeripheralToMemory), //TIM7_UP //dmar register appears to be missing
+    //(pac::DMA1, Stream4, 1, timer::DMAR<pac::TIM7>, MemoryToPeripheral), //TIM7_UP //dmar register appears to be missing
+    //(pac::DMA1, Stream4, 1, timer::DMAR<pac::TIM7>, PeripheralToMemory), //TIM7_UP //dmar register appears to be missing
+    (Stream7<DMA1>, 3, timer::DMAR<pac::TIM2>, MemoryToPeripheral), //TIM2_UP
+    (Stream7<DMA1>, 3, timer::DMAR<pac::TIM2>, PeripheralToMemory), //TIM2_UP
+    (Stream7<DMA1>, 3, timer::CCR4<pac::TIM2>, MemoryToPeripheral), //TIM2_CH4
+    (Stream7<DMA1>, 3, timer::CCR4<pac::TIM2>, PeripheralToMemory), //TIM2_CH4
+    (Stream1<DMA2>, 7, timer::DMAR<pac::TIM8>, MemoryToPeripheral), //TIM8_UP
+    (Stream1<DMA2>, 7, timer::DMAR<pac::TIM8>, PeripheralToMemory), //TIM8_UP
+    (Stream2<DMA2>, 0, timer::CCR1<pac::TIM8>, MemoryToPeripheral), //TIM8_CH1
+    (Stream2<DMA2>, 0, timer::CCR1<pac::TIM8>, PeripheralToMemory), //TIM8_CH1
+    (Stream2<DMA2>, 0, timer::CCR2<pac::TIM8>, MemoryToPeripheral), //TIM8_CH2
+    (Stream2<DMA2>, 0, timer::CCR2<pac::TIM8>, PeripheralToMemory), //TIM8_CH2
+    (Stream2<DMA2>, 0, timer::CCR3<pac::TIM8>, MemoryToPeripheral), //TIM8_CH3
+    (Stream2<DMA2>, 0, timer::CCR3<pac::TIM8>, PeripheralToMemory), //TIM8_CH3
+    (Stream2<DMA2>, 7, timer::CCR1<pac::TIM8>, MemoryToPeripheral), //TIM8_CH1
+    (Stream2<DMA2>, 7, timer::CCR1<pac::TIM8>, PeripheralToMemory), //TIM8_CH1
+    (Stream3<DMA2>, 7, timer::CCR2<pac::TIM8>, MemoryToPeripheral), //TIM8_CH2
+    (Stream3<DMA2>, 7, timer::CCR2<pac::TIM8>, PeripheralToMemory), //TIM8_CH2
+    (Stream4<DMA2>, 7, timer::CCR3<pac::TIM8>, MemoryToPeripheral), //TIM8_CH3
+    (Stream4<DMA2>, 7, timer::CCR3<pac::TIM8>, PeripheralToMemory), //TIM8_CH3
+    (Stream7<DMA2>, 7, timer::CCR4<pac::TIM8>, MemoryToPeripheral), //TIM8_CH4
+    (Stream7<DMA2>, 7, timer::CCR4<pac::TIM8>, PeripheralToMemory), //TIM8_CH4
+    (Stream7<DMA2>, 7, timer::DMAR<pac::TIM8>, MemoryToPeripheral), //TIM8_COM/TRIG
+    (Stream7<DMA2>, 7, timer::DMAR<pac::TIM8>, PeripheralToMemory), //TIM8_COM/TRIG
     (Stream1<DMA1>, 4, pac::USART3, PeripheralToMemory),     //USART3_RX
     (Stream1<DMA1>, 4, serial::Rx<pac::USART3>, PeripheralToMemory), //USART3_RX
     (Stream3<DMA1>, 4, pac::USART3, MemoryToPeripheral),     //USART3_TX
@@ -780,17 +732,7 @@ dma_map!(
     feature = "stm32f469",
     feature = "stm32f479",
 ))]
-address!(
-    (CCR1<pac::TIM8>, ccr1, u16),
-    (CCR2<pac::TIM8>, ccr2, u16),
-    (CCR3<pac::TIM8>, ccr3, u16),
-    (CCR4<pac::TIM8>, ccr4, u16),
-    (DMAR<pac::TIM8>, dmar, u16),
-    (CCR3<pac::TIM2>, ccr3, u16),
-    (DMAR<pac::TIM2>, dmar, u16),
-    //(DMAR<pac::TIM7>, dmar), //Missing?
-    (pac::USART3, dr, u8),
-);
+address!((pac::USART3, dr, u8),);
 
 /*
 DMAR register appears to be missing from TIM6 derived timers on these devices
@@ -813,29 +755,8 @@ DMAR register appears to be missing from TIM6 derived timers on these devices
     feature = "stm32f479",
 ))]
 dma_map!(
-    (pac::DMA1, Stream1, 7, DMAR<pac::TIM6>, MemoryToPeripheral), //TIM6_UP
-    (pac::DMA1, Stream1, 7, DMAR<pac::TIM6>, PeripheralToMemory), //TIM6_UP
-);
-
-#[cfg(any(
-    feature = "stm32f417",
-    feature = "stm32f415",
-    feature = "stm32f405",
-    feature = "stm32f407",
-    feature = "stm32f410",
-    feature = "stm32f412",
-    feature = "stm32f413",
-    feature = "stm32f423",
-    feature = "stm32f427",
-    feature = "stm32f439",
-    feature = "stm32f437",
-    feature = "stm32f429",
-    feature = "stm32f446",
-    feature = "stm32f469",
-    feature = "stm32f479",
-))]
-address!(
-    (DMAR<pac::TIM6>, dmar),
+    (pac::DMA1, Stream1, 7, timer::DMAR<pac::TIM6>, MemoryToPeripheral), //TIM6_UP
+    (pac::DMA1, Stream1, 7, timer::DMAR<pac::TIM6>, PeripheralToMemory), //TIM6_UP
 );
 */
 

--- a/src/dwt.rs
+++ b/src/dwt.rs
@@ -245,7 +245,6 @@ impl MonoTimer {
         dwt.enable_cycle_counter();
 
         // now the CYCCNT counter can't be stopped or reset
-        drop(dwt);
 
         MonoTimer {
             frequency: clocks.hclk(),

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -99,10 +99,7 @@ macro_rules! hal {
                             .cc2p()
                             .clear_bit()
                     });
-                    #[cfg(not(feature = "stm32f410"))]
                     self.smcr.write(|w| w.sms().encoder_mode_3());
-                    #[cfg(feature = "stm32f410")]
-                    self.smcr.write(|w| unsafe { w.sms().bits(3) });
                     self.set_auto_reload(<$TIM as General>::Width::MAX as u32).unwrap();
                     self.cr1.write(|w| w.cen().set_bit());
                 }

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -979,15 +979,15 @@ impl CFGR {
         let hclk = self.hclk.unwrap_or(sysclk);
         let (hpre_bits, hpre_div) = match (sysclk + hclk - 1) / hclk {
             0 => unreachable!(),
-            1 => (HPRE_A::DIV1, 1),
-            2 => (HPRE_A::DIV2, 2),
-            3..=5 => (HPRE_A::DIV4, 4),
-            6..=11 => (HPRE_A::DIV8, 8),
-            12..=39 => (HPRE_A::DIV16, 16),
-            40..=95 => (HPRE_A::DIV64, 64),
-            96..=191 => (HPRE_A::DIV128, 128),
-            192..=383 => (HPRE_A::DIV256, 256),
-            _ => (HPRE_A::DIV512, 512),
+            1 => (HPRE_A::Div1, 1),
+            2 => (HPRE_A::Div2, 2),
+            3..=5 => (HPRE_A::Div4, 4),
+            6..=11 => (HPRE_A::Div8, 8),
+            12..=39 => (HPRE_A::Div16, 16),
+            40..=95 => (HPRE_A::Div64, 64),
+            96..=191 => (HPRE_A::Div128, 128),
+            192..=383 => (HPRE_A::Div256, 256),
+            _ => (HPRE_A::Div512, 512),
         };
 
         // Calculate real AHB clock
@@ -1130,11 +1130,11 @@ impl CFGR {
         // Select system clock source
         rcc.cfgr.modify(|_, w| {
             w.sw().variant(if sysclk_on_pll {
-                SW_A::PLL
+                SW_A::Pll
             } else if self.hse.is_some() {
-                SW_A::HSE
+                SW_A::Hse
             } else {
-                SW_A::HSI
+                SW_A::Hsi
             })
         });
 

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -500,7 +500,7 @@ impl SingleOutputPll {
                     return None;
                 }
                 let output = vco_out / outdiv;
-                let error = (output as i32 - target as i32).abs() as u32;
+                let error = (output as i32 - target as i32).unsigned_abs();
                 Some((n, outdiv, output, error))
             })
             .min_by_key(|(_, _, _, error)| *error)?;

--- a/src/sdio.rs
+++ b/src/sdio.rs
@@ -266,9 +266,9 @@ impl<P: SdioPeripheral> Sdio<P> {
 
         self.sdio.power.modify(|_, w| {
             w.pwrctrl().variant(if on {
-                PWRCTRL_A::POWERON
+                PWRCTRL_A::PowerOn
             } else {
-                PWRCTRL_A::POWEROFF
+                PWRCTRL_A::PowerOff
             })
         });
 
@@ -353,7 +353,7 @@ impl<P: SdioPeripheral> Sdio<P> {
                     let mut wb = [0u8; 4];
                     wb.copy_from_slice(&block[i..i + 4]);
                     let word = u32::from_le_bytes(wb);
-                    self.sdio.fifo.write(|w| unsafe { w.bits(word) });
+                    self.sdio.fifo.write(|w| w.bits(word));
                     i += 4;
                 }
             }
@@ -398,9 +398,9 @@ impl<P: SdioPeripheral> Sdio<P> {
         }
 
         let dtdir = if card_to_controller {
-            DTDIR_A::CARDTOCONTROLLER
+            DTDIR_A::CardToController
         } else {
-            DTDIR_A::CONTROLLERTOCARD
+            DTDIR_A::ControllerToCard
         };
 
         // Data timeout, in bus cycles
@@ -463,9 +463,9 @@ impl<P: SdioPeripheral> Sdio<P> {
 
         // Determine what kind of response the CPSM should wait for
         let waitresp = match cmd.response_len() {
-            ResponseLen::Zero => WAITRESP_A::NORESPONSE,
-            ResponseLen::R48 => WAITRESP_A::SHORTRESPONSE,
-            ResponseLen::R136 => WAITRESP_A::LONGRESPONSE,
+            ResponseLen::Zero => WAITRESP_A::NoResponse,
+            ResponseLen::R48 => WAITRESP_A::ShortResponse,
+            ResponseLen::R136 => WAITRESP_A::LongResponse,
         };
 
         // Send the command
@@ -688,12 +688,12 @@ impl Sdio<SdCard> {
         let card_widebus = self.card()?.supports_widebus();
 
         let width = match width {
-            Buswidth::Buswidth4 if card_widebus => WIDBUS_A::BUSWIDTH4,
+            Buswidth::Buswidth4 if card_widebus => WIDBUS_A::BusWidth4,
             // Buswidth8 is not supported for SD cards
-            _ => WIDBUS_A::BUSWIDTH1,
+            _ => WIDBUS_A::BusWidth1,
         };
 
-        self.app_cmd(sd_cmd::set_bus_width(width == WIDBUS_A::BUSWIDTH4))?;
+        self.app_cmd(sd_cmd::set_bus_width(width == WIDBUS_A::BusWidth4))?;
 
         self.sdio.clkcr.modify(|_, w| {
             w.clkdiv()
@@ -793,9 +793,9 @@ impl Sdio<Emmc> {
         ))?;
 
         let width = match width {
-            Buswidth::Buswidth1 => WIDBUS_A::BUSWIDTH1,
-            Buswidth::Buswidth4 => WIDBUS_A::BUSWIDTH4,
-            Buswidth::Buswidth8 => WIDBUS_A::BUSWIDTH8,
+            Buswidth::Buswidth1 => WIDBUS_A::BusWidth1,
+            Buswidth::Buswidth4 => WIDBUS_A::BusWidth4,
+            Buswidth::Buswidth8 => WIDBUS_A::BusWidth8,
         };
 
         // CMD6 is R1b, so wait for the card to be ready again before proceeding.

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -670,8 +670,10 @@ impl<USART: Instance, PINS, WORD> Serial<USART, PINS, WORD> {
 #[cfg(any(
     feature = "stm32f405",
     feature = "stm32f407",
+    feature = "stm32f413",
     feature = "stm32f415",
     feature = "stm32f417",
+    feature = "stm32f423",
     feature = "stm32f427",
     feature = "stm32f429",
     feature = "stm32f437",
@@ -685,8 +687,10 @@ use crate::pac::uart4 as uart_base;
 #[cfg(not(any(
     feature = "stm32f405",
     feature = "stm32f407",
+    feature = "stm32f413",
     feature = "stm32f415",
     feature = "stm32f417",
+    feature = "stm32f423",
     feature = "stm32f427",
     feature = "stm32f429",
     feature = "stm32f437",
@@ -733,7 +737,6 @@ macro_rules! halUsart {
     };
 }
 
-// TODO: fix stm32f413 UARTs
 #[cfg(any(
     feature = "uart4",
     feature = "uart5",
@@ -742,7 +745,6 @@ macro_rules! halUsart {
     feature = "uart9",
     feature = "uart10"
 ))]
-#[cfg(not(any(feature = "stm32f413", feature = "stm32f423",)))]
 macro_rules! halUart {
     ($USART:ty, $Serial:ident, $Tx:ident, $Rx:ident) => {
         pub type $Serial<PINS, WORD = u8> = Serial<$USART, PINS, WORD>;
@@ -777,29 +779,18 @@ halUsart! { pac::USART6, Serial6, Rx6, Tx6 }
 
 #[cfg(feature = "usart3")]
 halUsart! { pac::USART3, Serial3, Rx3, Tx3 }
-
 #[cfg(feature = "uart4")]
-#[cfg(not(any(feature = "stm32f413", feature = "stm32f423")))]
 halUart! { pac::UART4, Serial4, Rx4, Tx4 }
 #[cfg(feature = "uart5")]
-#[cfg(not(any(feature = "stm32f413", feature = "stm32f423")))]
 halUart! { pac::UART5, Serial5, Rx5, Tx5 }
-
-#[cfg(feature = "uart4")]
-#[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
-halUsart! { pac::UART4, Serial4, Rx4, Tx4 }
-#[cfg(feature = "uart5")]
-#[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
-halUsart! { pac::UART5, Serial5, Rx5, Tx5 }
-
 #[cfg(feature = "uart7")]
-halUsart! { pac::UART7, Serial7, Rx7, Tx7 }
+halUart! { pac::UART7, Serial7, Rx7, Tx7 }
 #[cfg(feature = "uart8")]
-halUsart! { pac::UART8, Serial8, Rx8, Tx8 }
+halUart! { pac::UART8, Serial8, Rx8, Tx8 }
 #[cfg(feature = "uart9")]
-halUsart! { pac::UART9, Serial9, Rx9, Tx9 }
+halUart! { pac::UART9, Serial9, Rx9, Tx9 }
 #[cfg(feature = "uart10")]
-halUsart! { pac::UART10, Serial10, Rx10, Tx10 }
+halUart! { pac::UART10, Serial10, Rx10, Tx10 }
 
 impl<USART: Instance, PINS> fmt::Write for Serial<USART, PINS> {
     fn write_str(&mut self, s: &str) -> fmt::Result {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -722,10 +722,10 @@ macro_rules! halUsart {
 
                 self.cr2.write(|w| {
                     w.stop().variant(match bits {
-                        StopBits::STOP0P5 => STOP_A::STOP0P5,
-                        StopBits::STOP1 => STOP_A::STOP1,
-                        StopBits::STOP1P5 => STOP_A::STOP1P5,
-                        StopBits::STOP2 => STOP_A::STOP2,
+                        StopBits::STOP0P5 => STOP_A::Stop0p5,
+                        StopBits::STOP1 => STOP_A::Stop1,
+                        StopBits::STOP1P5 => STOP_A::Stop1p5,
+                        StopBits::STOP2 => STOP_A::Stop2,
                     })
                 });
             }
@@ -760,10 +760,10 @@ macro_rules! halUart {
 
                 self.cr2.write(|w| {
                     w.stop().variant(match bits {
-                        StopBits::STOP0P5 => STOP_A::STOP1,
-                        StopBits::STOP1 => STOP_A::STOP1,
-                        StopBits::STOP1P5 => STOP_A::STOP2,
-                        StopBits::STOP2 => STOP_A::STOP2,
+                        StopBits::STOP0P5 => STOP_A::Stop1,
+                        StopBits::STOP1 => STOP_A::Stop1,
+                        StopBits::STOP1P5 => STOP_A::Stop2,
+                        StopBits::STOP2 => STOP_A::Stop2,
                     })
                 });
             }

--- a/src/timer/pwm_input.rs
+++ b/src/timer/pwm_input.rs
@@ -182,11 +182,11 @@ macro_rules! hal {
         {
             /// Period of PWM signal in terms of clock cycles
             pub fn get_period_clocks(&self) -> <$TIM as General>::Width {
-                self.tim.ccr1.read().ccr().bits()
+                self.tim.ccr1().read().ccr().bits()
             }
             /// Duty cycle in terms of clock cycles
             pub fn get_duty_cycle_clocks(&self) -> <$TIM as General>::Width {
-                self.tim.ccr2.read().ccr().bits()
+                self.tim.ccr2().read().ccr().bits()
             }
             /// Observed duty cycle as a float in range [0.00, 1.00]
             pub fn get_duty_cycle(&self) -> f32 {


### PR DESCRIPTION
Due to stm32f4 SVD bugs in some parts, some UART peripherals were incorrectly defined as (more feature-full) USARTs.  This PR relies on PAC changes made in:  https://github.com/stm32-rs/stm32-rs/pull/754
