### PR TITLE
From trait for Pin, PartiallyErasedPin, and ErasedPin structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Implementation of From trait for Pin-to-PartiallyErasedPin [#507]
+- Implementation of From trait for Pin-to-ErasedPin [#507]
+- Implementation of From trait for PartiallyErasedPin-to-ErasedPin [#507]
+
+[#507]: https://github.com/stm32-rs/stm32f4xx-hal/pull/507
+
 ### Changed
  - use `stm32_i2s_v12x` version 0.3, reexport it, and implements requirement for it
  - i2s module don't reuse marker from spi module and define its own.

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -341,21 +341,21 @@ impl<const P: char, const N: u8, MODE> Pin<P, N, MODE> {
     }
 }
 
-impl<const P: char, const N: u8, MODE> From<Pin<P, N, MODE>> for ErasedPin<MODE> {
-    /// Pin-to-erased pin conversion using the [`From`] trait.
-    ///
-    /// Note that [`From`] is the reciprocal of [`Into`].
-    fn from(p: Pin<P, N, MODE>) -> Self {
-        p.erase()
-    }
-}
-
 impl<const P: char, const N: u8, MODE> From<Pin<P, N, MODE>> for PartiallyErasedPin<P, MODE> {
     /// Pin-to-partially erased pin conversion using the [`From`] trait.
     ///
     /// Note that [`From`] is the reciprocal of [`Into`].
     fn from(p: Pin<P, N, MODE>) -> Self {
         p.erase_number()
+    }
+}
+
+impl<const P: char, const N: u8, MODE> From<Pin<P, N, MODE>> for ErasedPin<MODE> {
+    /// Pin-to-erased pin conversion using the [`From`] trait.
+    ///
+    /// Note that [`From`] is the reciprocal of [`Into`].
+    fn from(p: Pin<P, N, MODE>) -> Self {
+        p.erase()
     }
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -341,6 +341,24 @@ impl<const P: char, const N: u8, MODE> Pin<P, N, MODE> {
     }
 }
 
+impl<const P: char, const N: u8, MODE> From<Pin<P, N, MODE>> for ErasedPin<MODE> {
+    /// Pin-to-erased pin conversion using the [`From`] trait.
+    ///
+    /// Note that [`From`] is the reciprocal of [`Into`].
+    fn from(p: Pin<P, N, MODE>) -> Self {
+        p.erase()
+    }
+}
+
+impl<const P: char, const N: u8, MODE> From<Pin<P, N, MODE>> for PartiallyErasedPin<P, MODE> {
+    /// Pin-to-partially erased pin conversion using the [`From`] trait.
+    ///
+    /// Note that [`From`] is the reciprocal of [`Into`].
+    fn from(p: Pin<P, N, MODE>) -> Self {
+        p.erase_number()
+    }
+}
+
 impl<const P: char, const N: u8, MODE> Pin<P, N, MODE> {
     /// Set the output of the pin regardless of its mode.
     /// Primarily used to set the output value of the pin

--- a/src/gpio/partially_erased.rs
+++ b/src/gpio/partially_erased.rs
@@ -136,3 +136,12 @@ where
         unsafe { (*Gpio::<P>::ptr()).idr.read().bits() & (1 << self.i) == 0 }
     }
 }
+
+impl<const P: char, MODE> From<PartiallyErasedPin<P, MODE>> for ErasedPin<MODE> {
+    /// Partially erased pin-to-erased pin conversion using the [`From`] trait.
+    ///
+    /// Note that [`From`] is the reciprocal of [`Into`].
+    fn from(p: PartiallyErasedPin<P, MODE>) -> Self {
+        ErasedPin::new(P as u8 - b'A', p.i)
+    }
+}


### PR DESCRIPTION
I implemented the `For` trait for the following pin type conversions:
- From `Pin<P, N, MODE>` to `PartiallyErasedPin<P, MODE>`
- From `Pin<P, N, MODE>` to `ErasedPin<MODE>`
- From `PartiallyErasedPin<P, MODE>` to `ErasedPin<MODE>`