### PR TITLE
Upgrade synopsys-usb-otg to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - i2s module don't reuse marker from spi module and define its own.
  - `i2s-audio-out` example updated and now use pcm5102 dac module instead one from discovery board.
  - extend visibility of gpio/marker to crate since i2s module require it.
+ - Bump `synopsys-usb-otg` to `0.3.0`
 
 ### Added
  - example of using i2s in out with rtic and interrupt.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cortex-m-rt = "0.7"
 nb = "1"
 rand_core = "0.6"
 stm32f4 = "0.14.0"
-synopsys-usb-otg = { version = "0.2.0", features = ["cortex-m"], optional = true }
+synopsys-usb-otg = { version = "0.3.0", features = ["cortex-m"], optional = true }
 sdio-host = { version = "0.6.0", optional = true }
 embedded-dma = "0.2.0"
 bare-metal = { version = "1" }

--- a/src/otg_hs.rs
+++ b/src/otg_hs.rs
@@ -58,7 +58,7 @@ unsafe impl UsbPeripheral for USB {
     }
 
     fn ahb_frequency_hz(&self) -> u32 {
-        self.hclk.0
+        self.hclk.raw()
     }
 }
 


### PR DESCRIPTION
See changes: [v0.2.4..v0.3.0](https://github.com/stm32-rs/synopsys-usb-otg/compare/v0.2.4...v0.3.0)

Notably:

* [Update cortex-m to 0.7](https://github.com/stm32-rs/synopsys-usb-otg/commit/ce5d5fe24d2b6a21c3304a59ac53c276a06c42b6)
* [Implement force_reset](https://github.com/stm32-rs/synopsys-usb-otg/commit/baac8a19725fa9f1264db799b9507516a9c3afc8)
* [Allow enabling transciever delay to fix USB334x](https://github.com/stm32-rs/synopsys-usb-otg/commit/8704eb3dc3fb9ff3903c68e554f7b24d07bbc011)

None of these should be breaking changes.