### PR TITLE
Apply #[inline] attribute to bitbanding functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+ - apply #[inline] attribute to bitbanding functions [#517]
  - update `stm32f4` to 0.15.1 [#481]
  - use `stm32_i2s_v12x` version 0.3, reexport it, and implements requirement for it [#490]
  - i2s module don't reuse marker from spi module and define its own [#490]
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#510]: https://github.com/stm32-rs/stm32f4xx-hal/pull/510
 [#514]: https://github.com/stm32-rs/stm32f4xx-hal/pull/514
 [#515]: https://github.com/stm32-rs/stm32f4xx-hal/pull/515
+[#517]: https://github.com/stm32-rs/stm32f4xx-hal/pull/517
 
 ## [v0.13.2] - 2022-05-16
 

--- a/src/bb.rs
+++ b/src/bb.rs
@@ -18,6 +18,7 @@ const PERI_BIT_BAND_BASE: usize = 0x4200_0000;
 /// # Safety
 ///
 /// Some registers have reserved bits which should not be modified.
+#[inline]
 pub unsafe fn clear<T>(register: *const T, bit: u8) {
     write(register, bit, false);
 }
@@ -27,6 +28,7 @@ pub unsafe fn clear<T>(register: *const T, bit: u8) {
 /// # Safety
 ///
 /// Some registers have reserved bits which should not be modified.
+#[inline]
 pub unsafe fn set<T>(register: *const T, bit: u8) {
     write(register, bit, true);
 }
@@ -36,6 +38,7 @@ pub unsafe fn set<T>(register: *const T, bit: u8) {
 /// # Safety
 ///
 /// Some registers have reserved bits which should not be modified.
+#[inline]
 pub unsafe fn write<T>(register: *const T, bit: u8, set: bool) {
     let addr = register as usize;
 


### PR DESCRIPTION
The generated code for the functions is usually only 1-2 instruction(s),
calling such a function causes more overhead than inlining it. Most
example binaries shrink up to 1kB by this hint.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>