### PR TITLE
Revised ADC temperature sensor pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+ - Revised temperature sensor input pins for all MCUs #529
  - Support `u16` read/write for SPI
  - Use `bool` for BIDI mode type
  - `PwmHz::get_period`: fix computation of return value, prevent division by zero
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#515]: https://github.com/stm32-rs/stm32f4xx-hal/pull/515
 [#517]: https://github.com/stm32-rs/stm32f4xx-hal/pull/517
 [#519]: https://github.com/stm32-rs/stm32f4xx-hal/pull/519
+[#529]: https://github.com/stm32-rs/stm32f4xx-hal/pull/529
 
 ## [v0.13.2] - 2022-05-16
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1116,7 +1116,7 @@ adc_pins!(
     gpio::PA7<Analog> => (ADC1, 7),
     gpio::PB0<Analog> => (ADC1, 8),
     gpio::PB1<Analog> => (ADC1, 9),
-    Temperature => (ADC1, 18),
+    Temperature => (ADC1, 16),
     Vbat => (ADC1, 18),
     Vref => (ADC1, 17),
 );
@@ -1240,9 +1240,9 @@ adc_pins!(
     gpio::PC4<Analog> => (ADC2, 14),
     gpio::PC5<Analog> => (ADC1, 15),
     gpio::PC5<Analog> => (ADC2, 15),
-    Temperature => (ADC1, 18),
-    Temperature => (ADC2, 18),
-    Temperature => (ADC3, 18),
+    Temperature => (ADC1, 16),
+    Temperature => (ADC2, 16),
+    Temperature => (ADC3, 16),
     Vbat => (ADC1, 18),
     Vbat => (ADC2, 18),
     Vbat => (ADC3, 18),
@@ -1271,7 +1271,7 @@ adc_pins!(
     gpio::PA3<Analog> => (ADC1, 3),
     gpio::PA5<Analog> => (ADC1, 5),
     Temperature => (ADC1, 18),
-    Vbat => (ADC1, 18),
+    Vbat => (ADC1, 16),
     Vref => (ADC1, 17),
 );
 
@@ -1309,7 +1309,7 @@ adc_pins!(
     gpio::PA7<Analog> => (ADC1, 7),
     gpio::PB0<Analog> => (ADC1, 8),
     gpio::PB1<Analog> => (ADC1, 9),
-    Temperature => (ADC1, 18),
+    Temperature => (ADC1, 16),
     Vbat => (ADC1, 18),
     Vref => (ADC1, 17),
 );


### PR DESCRIPTION
For each MCU listed checked ST's reference manual for temperature sensor ADC input pin.
Some are exclusively `ADC1_18`, others have `ADC1_16` available, and some are shared. Opted to use `ADC1_16` when available, always giving preference to what the manual says to use in order to read temperature.

Example:
[STM32F411 Reference Manual page 226](https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf)