### PR TITLE
Comment buffer usage in adc_dma_rtic example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+ - Docs in `rtic-adc-dma` example [#532]
  - `OutPortX` (X = 2..8) and `OutPortArray` structures which can handle several pins at once [#426]
  - `restore` for `ErasedPin` and `PartiallyErasedPin`
 
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Fix SDIO hardware flow control errata [#577]
 
 [#426]: https://github.com/stm32-rs/stm32f4xx-hal/pull/426
+[#532]: https://github.com/stm32-rs/stm32f4xx-hal/pull/532
 [#571]: https://github.com/stm32-rs/stm32f4xx-hal/pull/571
 [#572]: https://github.com/stm32-rs/stm32f4xx-hal/pull/572
 [#577]: https://github.com/stm32-rs/stm32f4xx-hal/pull/577


### PR DESCRIPTION
@apollolabsdev asked on Discord what was going on in the adc_dma_rtic example, and I explained it as best I could.
They seem to understand it enough to write a blog post about it, so I assume my help was sufficient.
This is the gist of that.