### PR TITLE
Bump synopsys-usb-otg to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Bump `synopsys-usb-otg` to `0.3.0` [#508]
  - Bump `embedded-hal` to `1.0.0-alpha.8` [#510]
  - Update `bxcan`, `rtic` and other dependencies [#519]
+ - Bump `synopsys-usb-otg` to `0.3.1` [#535]
 
 ### Removed
  - `i2s-audio-out-dma.rs` example, too difficult to fix.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cortex-m-rt = "0.7.1"
 nb = "1"
 rand_core = "0.6.3"
 stm32f4 = "0.15.1"
-synopsys-usb-otg = { version = "0.3.0", features = ["cortex-m"], optional = true }
+synopsys-usb-otg = { version = "0.3.1", features = ["cortex-m"], optional = true }
 sdio-host = { version = "0.6.0", optional = true }
 embedded-dma = "0.2.0"
 bare-metal = { version = "1" }


### PR DESCRIPTION
Fixes an issue with FIFO allocation limits. tl;dr the previous version assumed that 16 32-bit words were allocated for every _possible_ TX endpoint, when only active endpoints should be considered.

See stm32-rs/synopsys-usb-otg#26