### PR TITLE
fix removed Tx::Write<u8>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Serial Tx, Rx containing pins [#514] [#515]
+- Serial Tx, Rx containing pins [#514] [#515] [#540]
 - Implementation of From trait for Pin-to-PartiallyErasedPin [#507]
 - Implementation of From trait for Pin-to-ErasedPin [#507]
 - Implementation of From trait for PartiallyErasedPin-to-ErasedPin [#507]
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#529]: https://github.com/stm32-rs/stm32f4xx-hal/pull/529
 [#536]: https://github.com/stm32-rs/stm32f4xx-hal/pull/536
 [#534]: https://github.com/stm32-rs/stm32f4xx-hal/pull/529
+[#540]: https://github.com/stm32-rs/stm32f4xx-hal/pull/540
 
 ## [v0.13.2] - 2022-05-16
 

--- a/src/serial/hal_02.rs
+++ b/src/serial/hal_02.rs
@@ -51,6 +51,17 @@ mod nb {
         }
     }
 
+    impl<USART: Instance> Write<u8> for Tx<USART, u8> {
+        type Error = Error;
+
+        fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+            self.write(word)
+        }
+        fn flush(&mut self) -> nb::Result<(), Self::Error> {
+            self.flush()
+        }
+    }
+
     /// Writes 9-bit words to the UART/USART
     ///
     /// If the UART/USART was configured with `WordLength::DataBits9`, the 9 least significant bits will


### PR DESCRIPTION
Fix #528 .
Restore implementation accidentally removed in #514