### PR TITLE
Transactional I2C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - example of using i2s in out with rtic and interrupt.
 - example of using USB CDC with interrupts.
 - Added non-blocking I2C based on DMA [#534]
+- Added Transactional I2C API [#542]
 
 [#481]: https://github.com/stm32-rs/stm32f4xx-hal/pull/481
 [#489]: https://github.com/stm32-rs/stm32f4xx-hal/pull/489
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#536]: https://github.com/stm32-rs/stm32f4xx-hal/pull/536
 [#534]: https://github.com/stm32-rs/stm32f4xx-hal/pull/529
 [#540]: https://github.com/stm32-rs/stm32f4xx-hal/pull/540
+[#542]: https://github.com/stm32-rs/stm32f4xx-hal/pull/542
 
 ## [v0.13.2] - 2022-05-16
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -458,11 +458,11 @@ impl<I2C: Instance, PINS> I2c<I2C, PINS> {
         }
 
         self.prepare_read(addr)?;
-        self.read_wo_start(buffer)
+        self.read_wo_prepare(buffer)
     }
 
     /// Reads like normal but does'n genereate start and don't send address
-    fn read_wo_start(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+    fn read_wo_prepare(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
         if let Some((last, buffer)) = buffer.split_last_mut() {
             // Read all bytes but not last
             self.read_bytes(buffer)?;
@@ -487,11 +487,11 @@ impl<I2C: Instance, PINS> I2c<I2C, PINS> {
 
     pub fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
         self.prepare_write(addr)?;
-        self.write_wo_start(bytes)
+        self.write_wo_prepare(bytes)
     }
 
-    /// Reads like normal but does'n genereate start and don't send address
-    fn write_wo_start(&mut self, bytes: &[u8]) -> Result<(), Error> {
+    /// Writes like normal but does'n genereate start and don't send address
+    fn write_wo_prepare(&mut self, bytes: &[u8]) -> Result<(), Error> {
         self.write_bytes(bytes.iter().cloned())?;
 
         // Send a STOP condition
@@ -566,8 +566,8 @@ impl<I2C: Instance, PINS> I2c<I2C, PINS> {
 
             // 4. Now, prev_op is last command use methods variations that will generate stop
             match prev_op {
-                Operation::Read(rb) => self.read_wo_start(rb)?,
-                Operation::Write(wb) => self.write_wo_start(wb)?,
+                Operation::Read(rb) => self.read_wo_prepare(rb)?,
+                Operation::Write(wb) => self.write_wo_prepare(wb)?,
             };
         }
 
@@ -607,8 +607,8 @@ impl<I2C: Instance, PINS> I2c<I2C, PINS> {
 
             // 4. Now, prev_op is last command use methods variations that will generate stop
             match prev_op {
-                Operation::Read(rb) => self.read_wo_start(rb)?,
-                Operation::Write(wb) => self.write_wo_start(wb)?,
+                Operation::Read(rb) => self.read_wo_prepare(rb)?,
+                Operation::Write(wb) => self.write_wo_prepare(wb)?,
             };
         }
 

--- a/src/i2c/hal_1.rs
+++ b/src/i2c/hal_1.rs
@@ -59,17 +59,18 @@ mod blocking {
 
         fn transaction<'a>(
             &mut self,
-            _addr: u8,
-            _operations: &mut [Operation<'a>],
+            addr: u8,
+            operations: &mut [Operation<'a>],
         ) -> Result<(), Self::Error> {
-            todo!()
+            self.transaction_slice(addr, operations)
         }
 
-        fn transaction_iter<'a, O>(&mut self, _addr: u8, _operations: O) -> Result<(), Self::Error>
+        fn transaction_iter<'a, O>(&mut self, addr: u8, operations: O) -> Result<(), Self::Error>
         where
             O: IntoIterator<Item = Operation<'a>>,
         {
-            todo!()
+            let it = operations.into_iter();
+            self.transaction(addr, it)
         }
     }
 }


### PR DESCRIPTION
A transactional HAL API implementation for I2C. Closes #445.

I have to rework i2c code to implement this:
  * `prepare_read`, `prepare_write` - methods to send start and address only
  * `write_wo_prepare`, `read_wo_prepare` - methods  like old `read`, `write` but they do not send start and address.
  * `read_bytes`, `write_bytes` - this methods now only for send/receive. The do not send start, stop or address.
  * All public api's behaviour is untouched so there are no breaking changes for users.

Note: I have to create duplicate methods `transaction_slice` and `transaction` because `Operation` doesn't implement Clone to send slice as iterator.