### PR TITLE
Reset timer CNT register when PWM period is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - use register.modify instead of register.write to start PWM [#501]
  - add missing generic param for Spi::release implementation.
  - build rtic-usb-cdc-echo example [#554]
+ - reset timer cnt register when changing pwm period [#555]
 
 ### Added
 
@@ -77,6 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#552]: https://github.com/stm32-rs/stm32f4xx-hal/pull/552
 [#553]: https://github.com/stm32-rs/stm32f4xx-hal/pull/553
 [#554]: https://github.com/stm32-rs/stm32f4xx-hal/pull/554
+[#555]: https://github.com/stm32-rs/stm32f4xx-hal/pull/555
 
 ## [v0.13.2] - 2022-05-16
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -382,10 +382,10 @@ macro_rules! hal {
                 fn cr1_reset(&mut self) {
                     self.cr1.reset();
                 }
-				#[inline(always)]
-				fn cnt_reset(&mut self) {
-					self.cnt.reset();
-				}
+                #[inline(always)]
+                fn cnt_reset(&mut self) {
+                    self.cnt.reset();
+                }
             }
 
             $(with_dmar!($TIM, $memsize);)?

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -254,6 +254,7 @@ mod sealed {
         fn start_one_pulse(&mut self);
         fn start_no_update(&mut self);
         fn cr1_reset(&mut self);
+        fn cnt_reset(&mut self);
     }
 
     pub trait WithPwm: General {
@@ -381,6 +382,10 @@ macro_rules! hal {
                 fn cr1_reset(&mut self) {
                     self.cr1.reset();
                 }
+				#[inline(always)]
+				fn cnt_reset(&mut self) {
+					self.cnt.reset();
+				}
             }
 
             $(with_dmar!($TIM, $memsize);)?

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -445,5 +445,6 @@ where
 
     pub fn set_period(&mut self, period: TimerDurationU32<FREQ>) {
         self.tim.set_auto_reload(period.ticks() - 1).unwrap();
+        self.tim.cnt_reset();
     }
 }

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -310,6 +310,7 @@ where
         let (psc, arr) = compute_arr_presc(period.raw(), clk.raw());
         self.tim.set_prescaler(psc);
         self.tim.set_auto_reload(arr).unwrap();
+        self.tim.cnt_reset();
     }
 }
 


### PR DESCRIPTION
When changing the period of a PWM timer repeatedly, it will sporadically stop working. This is because the CNT register isn't being reset.

Minimum reproducible example:

```rust
#![no_main]
#![no_std]

// use panic_halt as _;
use panic_semihosting as _;

use cortex_m_rt::entry;
use stm32f4xx_hal as hal;

use crate::hal::{pac, prelude::*, timer::Channel};

#[entry]
fn main() -> ! {
    let dp = pac::Peripherals::take().unwrap();

    let buzzer = dp.GPIOA.split().pa0.into_alternate();

    // Set up the system clock. We want to run at 48MHz for this one.
    let rcc = dp.RCC.constrain();
    let clocks = rcc.cfgr.use_hse(25.MHz()).sysclk(48.MHz()).freeze();

    let mut pwm = dp.TIM5.pwm_hz(buzzer, 1000.Hz(), &clocks);
    pwm.set_duty(Channel::C1, pwm.get_max_duty() / 2);
    pwm.enable(Channel::C1);

    let mut delay = dp.TIM1.delay_us(&clocks);

    loop {
        pwm.set_period(1000.Hz());
        pwm.set_duty(Channel::C1, pwm.get_max_duty() / 2);
        pwm.configure(&clocks);

        delay.delay_ms(1000_u32);

        pwm.set_period(2000.Hz());
        pwm.set_duty(Channel::C1, pwm.get_max_duty() / 2);
        pwm.configure(&clocks);

        delay.delay(1.secs());
    }
}
```

Before this PR, this would work for a few cycles before the signal disappears. It would occasionally reappear every few minutes. After this PR, the code is consistently outputting a signal that alternates between 1 and 2 KHz.