### PR TITLE
Fixed typo in DMA2/ADCx traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - add missing generic param for Spi::release implementation.
  - build rtic-usb-cdc-echo example [#554]
  - reset timer cnt register when changing pwm period [#555]
+ - Trait typo preventing ADC2 being used with DMA2 [#557]
 
 ### Added
 

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -870,8 +870,8 @@ dma_map!(
     (Stream2<DMA2>, 1, pac::ADC2, PeripheralToMemory),  //ADC2
     (Stream3<DMA2>, 1, pac::ADC2, PeripheralToMemory),  //ADC2
     (Stream7<DMA2>, 1, pac::DCMI, PeripheralToMemory),  //DCMI
-    (Stream2<DMA2>, 1, Adc<pac::ADC3>, PeripheralToMemory), //ADC2
-    (Stream3<DMA2>, 1, Adc<pac::ADC3>, PeripheralToMemory), //ADC2
+    (Stream2<DMA2>, 1, Adc<pac::ADC2>, PeripheralToMemory), //ADC2
+    (Stream3<DMA2>, 1, Adc<pac::ADC2>, PeripheralToMemory), //ADC2
     (Stream0<DMA2>, 2, Adc<pac::ADC3>, PeripheralToMemory), //ADC3
     (Stream1<DMA2>, 2, Adc<pac::ADC3>, PeripheralToMemory), //ADC3
 );


### PR DESCRIPTION
I was working with the ADC and DMA and noticed there was a typo. I've verified this on the reference manual and with my hardware setup.