### PR TITLE
Allow different lengths of buffers in hal_1 SpiBus impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
  - Update readme, clippy fixes
-
-- `OutPortX` (X = 2..8) and `OutPortArray` structures which can handle several pins at once [#426]
+ - `OutPortX` (X = 2..8) and `OutPortArray` structures which can handle several pins at once [#426]
+ - Allow different lengths of buffers in hal_1 SpiBus impl [#566]
 
 ### Added
 
 [#426]: https://github.com/stm32-rs/stm32f4xx-hal/pull/426
+[#566]: https://github.com/stm32-rs/stm32f4xx-hal/pull/566
 ### Added
 
  - `restore` for `ErasedPin` and `PartiallyErasedPin`

--- a/src/spi/hal_1.rs
+++ b/src/spi/hal_1.rs
@@ -93,16 +93,16 @@ mod blocking {
                     (Some(r), Some(w)) => {
                         nb::block!(<Self as FullDuplex<W>>::write(self, w))?;
                         *r = nb::block!(<Self as FullDuplex<W>>::read(self))?;
-                    },
+                    }
                     (Some(r), None) => {
                         nb::block!(<Self as FullDuplex<W>>::write(self, W::default()))?;
                         *r = nb::block!(<Self as FullDuplex<W>>::read(self))?;
-                    },
+                    }
                     (None, Some(w)) => {
                         nb::block!(<Self as FullDuplex<W>>::write(self, w))?;
                         let _ = nb::block!(<Self as FullDuplex<W>>::read(self))?;
                     }
-                    (None, None) => break
+                    (None, None) => break,
                 }
             }
             Ok(())


### PR DESCRIPTION
In `SpiBus::transfer`
```rust
fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error>;
```

From [embedded-hal docs](https://docs.rs/embedded-hal/1.0.0-alpha.9/embedded_hal/spi/trait.SpiBus.html#tymethod.transfer): 

>**It is allowed for read and write to have different lengths, even zero length.** The transfer runs for max(read.len(), write.len()) words. If read is shorter, incoming words after read has been filled will be discarded. If write is shorter, the value of words sent in MOSI after all write has been sent is implementation-defined, typically 0x00, 0xFF, or configurable.

Current implementation requires the lengths to be equal:
https://github.com/stm32-rs/stm32f4xx-hal/blob/master/src/spi/hal_1.rs#L88
```rust
fn transfer(&mut self, buff: &mut [W], data: &[W]) -> Result<(), Self::Error> {
    assert_eq!(data.len(), buff.len()); // precondition here!

    for (d, b) in data.iter().cloned().zip(buff.iter_mut()) {
        nb::block!(<Self as FullDuplex<W>>::write(self, d))?;
        *b = nb::block!(<Self as FullDuplex<W>>::read(self))?;
    }

    Ok(())
}
```

So I changed it accordingly. Please let me know if line 103 is needed.