### PR TITLE
`delay-syst-blinky` example: us `toggle`

### DIFF
--- a/examples/delay-syst-blinky.rs
+++ b/examples/delay-syst-blinky.rs
@@ -32,9 +32,7 @@ fn main() -> ! {
 
         loop {
             // On for 1s, off for 1s.
-            led.set_high();
-            delay.delay_ms(1000_u32);
-            led.set_low();
+            led.toggle();
             delay.delay_ms(1000_u32);
         }
     }


### PR DESCRIPTION
as the on & off periods are the same and it doesn't matter what the initial state is we can just use `toggle` instead of `set_high` and `set_low`.
the latter is still present in other examples, e.g. `delay-timer-blinky` which uses different delays for the on & off periods.