### PR TITLE
Add GPIO speed into SPI example, improve docs.

### DIFF
--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -39,8 +39,11 @@ fn main() -> ! {
         let stream = steams.4;
 
         let gpiob = dp.GPIOB.split();
-        let pb15 = gpiob.pb15.into_alternate().internal_pull_up(true);
-        let pb13 = gpiob.pb13.into_alternate();
+        
+        // Note. We set GPIO speed as VeryHigh to it corresponds to SPI frequency 3MHz.
+        // Otherwise it may lead to the 'wrong last bit in every received byte' problem.
+        let pb15 = gpiob.pb15.into_alternate().speed(Speed::VeryHigh).internal_pull_up(true);
+        let pb13 = gpiob.pb13.into_alternate().speed(Speed::VeryHigh);
 
         let mode = Mode {
             polarity: Polarity::IdleLow,


### PR DESCRIPTION
Fix 'wrong last bit in every received byte' problem, see [#564](https://github.com/stm32-rs/stm32f4xx-hal/issues/564) for details.