### PR TITLE
Fix SDIO hardware flow control errata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - Fix alternate function pin definitions for FMPI2C1 [#572]
+ - Fix SDIO hardware flow control errata [#577]
 
 [#426]: https://github.com/stm32-rs/stm32f4xx-hal/pull/426
 [#572]: https://github.com/stm32-rs/stm32f4xx-hal/pull/572
-
+[#577]: https://github.com/stm32-rs/stm32f4xx-hal/pull/577
 
 ## [v0.14.0] - 2022-12-12
 

--- a/src/sdio.rs
+++ b/src/sdio.rs
@@ -247,7 +247,9 @@ impl<P: SdioPeripheral> Sdio<P> {
                 .rising()
                 // Do not use hardware flow control.
                 // Using it causes clock glitches and CRC errors.
-                // See chip errata SDIO section.
+                // See chip errata SDIO section:
+                // - F42x/F43x: https://www.st.com/resource/en/errata_sheet/es0206-stm32f427437-and-stm32f429439-line-limitations-stmicroelectronics.pdf
+                // - F40x/F41x: https://www.st.com/resource/en/errata_sheet/es0182-stm32f405407xx-and-stm32f415417xx-device-limitations-stmicroelectronics.pdf
                 .hwfc_en()
                 .disabled()
         });

--- a/src/sdio.rs
+++ b/src/sdio.rs
@@ -245,8 +245,11 @@ impl<P: SdioPeripheral> Sdio<P> {
                 .disabled()
                 .negedge()
                 .rising()
+                // Do not use hardware flow control.
+                // Using it causes clock glitches and CRC errors.
+                // See chip errata SDIO section.
                 .hwfc_en()
-                .enabled()
+                .disabled()
         });
 
         let mut host = Self {


### PR DESCRIPTION
Using SDIO above 12 MHz causes clock glitches, which result in CRC errors (at least in embassy-stm32). In this HAL, the CRC error is not caught and write silently fails without changing any bytes on SD card.

Section from `STM32F42xx and STM32F43xx Errata sheet`:
```
2.13.1 SDIO HW flow control

Description
When enabling the HW flow control by setting bit 14 of the SDIO_CLKCR register to ‘1’,
glitches can occur on the SDIOCLK output clock resulting in wrong data to be written into
the SD/MMC card or into the SDIO device. As a consequence, a CRC error will be reported
to the SD/SDIO MMC host interface (DCRCFAIL bit set to ‘1’ in SDIO_STA register).

Workaround
None.

Note: Do not use the HW flow control. Overrun errors (Rx mode) and FIFO underrun (Tx mode)
should be managed by the application software.
```

AFAIK, this affects all SDIOv1 peripherals including the F1 family, and possibly others.

I'm not sure about the CRC error not getting caught, but this PR at least fixes the chip errata.