### PR TITLE
adapt to use stm32_i2s v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+ - Integrate new version of stm32_i2s (v0.4)
  - Fix mstr bit for SPI Master/Slave [#625]
  - Add `ReadPin`, `PinSpeed` & `PinPull` traits [#623]
  - Add autoimplementations of `DMASet` [#614]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ version = "=1.0.0-alpha.8"
 package = "embedded-hal"
 
 [dependencies.stm32_i2s_v12x]
-version = "0.3.0"
+version = "0.4.0"
 optional = true
 
 [dev-dependencies]

--- a/examples/rtic-i2s-audio-in-out.rs
+++ b/examples/rtic-i2s-audio-in-out.rs
@@ -350,9 +350,7 @@ mod app {
         if status.fre() {
             log::spawn("i2s3 Frame error").ok();
             i2s3_driver.disable();
-            i2s3_driver
-                .ws_pin_mut()
-                .enable_interrupt(exti);
+            i2s3_driver.ws_pin_mut().enable_interrupt(exti);
         }
         if status.udr() {
             log::spawn("i2s3 udr").ok();

--- a/examples/rtic-i2s-audio-in-out.rs
+++ b/examples/rtic-i2s-audio-in-out.rs
@@ -197,7 +197,7 @@ mod app {
         i2s3_driver.set_error_interrupt(true);
 
         // set up an interrupt on WS pin
-        let ws_pin = i2s3_driver.i2s_peripheral_mut().ws_pin_mut();
+        let ws_pin = i2s3_driver.ws_pin_mut();
         ws_pin.make_interrupt_source(&mut syscfg);
         ws_pin.trigger_on_edge(&mut exti, Edge::Rising);
         // we will enable i2s3 in interrupt
@@ -351,7 +351,6 @@ mod app {
             log::spawn("i2s3 Frame error").ok();
             i2s3_driver.disable();
             i2s3_driver
-                .i2s_peripheral_mut()
                 .ws_pin_mut()
                 .enable_interrupt(exti);
         }
@@ -367,7 +366,7 @@ mod app {
     fn exti4(cx: exti4::Context) {
         let i2s3_driver = cx.shared.i2s3_driver;
         let exti = cx.shared.exti;
-        let ws_pin = i2s3_driver.i2s_peripheral_mut().ws_pin_mut();
+        let ws_pin = i2s3_driver.ws_pin_mut();
         ws_pin.clear_interrupt_pending_bit();
         // yes, in this case we already know that pin is high, but some other exti can be triggered
         // by several pins


### PR DESCRIPTION
I, we released an new version of stm32_i2s_V12x (now v0.4). This new version implement fix that require some API change

