### PR TITLE
Join Serial for USART and UART again. Make inner traits with different implementation for USART and UART.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+ - Join `Serial`, `Rx`, `Tx` for `USART` and `UART` again. Make inner traits with different implementation for USART and UART. [#636]
+
 ### Fixed
 
 - map `$SpiSlave` into `SpiSlave` struct in `spi!` macro [#635]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -69,9 +69,12 @@ pub use crate::qei::QeiExt as _stm32f4xx_hal_QeiExt;
 pub use crate::rcc::RccExt as _stm32f4xx_hal_rcc_RccExt;
 #[cfg(all(feature = "device-selected", feature = "rng"))]
 pub use crate::rng::RngExt as _stm32f4xx_hal_rng_RngExt;
+pub use crate::serial::Listen as _stm32f4xx_hal_serial_Listen;
 pub use crate::serial::RxISR as _stm32f4xx_hal_serial_RxISR;
+pub use crate::serial::RxListen as _stm32f4xx_hal_serial_RxListen;
 pub use crate::serial::SerialExt as _stm32f4xx_hal_serial_SerialExt;
 pub use crate::serial::TxISR as _stm32f4xx_hal_serial_TxISR;
+pub use crate::serial::TxListen as _stm32f4xx_hal_serial_TxListen;
 pub use crate::spi::SpiExt as _stm32f4xx_hal_spi_SpiExt;
 pub use crate::syscfg::SysCfgExt as _stm32f4xx_hal_syscfg_SysCfgExt;
 pub use crate::time::U32Ext as _stm32f4xx_hal_time_U32Ext;
@@ -82,5 +85,3 @@ pub use crate::timer::PwmExt as _stm32f4xx_hal_timer_PwmExt;
 pub use crate::timer::SysMonoTimerExt as _stm32f4xx_hal_timer_SysMonoTimerExt;
 pub use crate::timer::SysTimerExt as _stm32f4xx_hal_timer_SysCounterExt;
 pub use crate::timer::TimerExt as _stm32f4xx_hal_timer_TimerExt;
-#[cfg(feature = "uart4")]
-pub use crate::uart::SerialExt as _stm32f4xx_hal_uart_SerialExt;

--- a/src/serial/hal_02.rs
+++ b/src/serial/hal_02.rs
@@ -1,10 +1,11 @@
 mod nb {
-    use super::super::{Error, Instance, Rx, Serial, Tx};
+    use core::ops::Deref;
+
+    use super::super::{Error, Instance, RegisterBlockImpl, Rx, Serial, Tx};
     use embedded_hal::serial::{Read, Write};
 
-    impl<USART, WORD> Read<WORD> for Serial<USART, WORD>
+    impl<USART: Instance, WORD> Read<WORD> for Serial<USART, WORD>
     where
-        USART: Instance,
         Rx<USART, WORD>: Read<WORD, Error = Error>,
     {
         type Error = Error;
@@ -14,11 +15,14 @@ mod nb {
         }
     }
 
-    impl<USART: Instance> Read<u8> for Rx<USART, u8> {
+    impl<USART: Instance> Read<u8> for Rx<USART, u8>
+    where
+        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
+    {
         type Error = Error;
 
         fn read(&mut self) -> nb::Result<u8, Self::Error> {
-            self.read()
+            unsafe { (*USART::ptr()).read_u8() }
         }
     }
 
@@ -27,17 +31,19 @@ mod nb {
     /// If the UART/USART was configured with `WordLength::DataBits9`, the returned value will contain
     /// 9 received data bits and all other bits set to zero. Otherwise, the returned value will contain
     /// 8 received data bits and all other bits set to zero.
-    impl<USART: Instance> Read<u16> for Rx<USART, u16> {
+    impl<USART: Instance> Read<u16> for Rx<USART, u16>
+    where
+        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
+    {
         type Error = Error;
 
         fn read(&mut self) -> nb::Result<u16, Self::Error> {
-            self.read()
+            unsafe { (*USART::ptr()).read_u16() }
         }
     }
 
-    impl<USART, WORD> Write<WORD> for Serial<USART, WORD>
+    impl<USART: Instance, WORD> Write<WORD> for Serial<USART, WORD>
     where
-        USART: Instance,
         Tx<USART, WORD>: Write<WORD, Error = Error>,
     {
         type Error = Error;
@@ -51,14 +57,18 @@ mod nb {
         }
     }
 
-    impl<USART: Instance> Write<u8> for Tx<USART, u8> {
+    impl<USART: Instance> Write<u8> for Tx<USART, u8>
+    where
+        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
+        USART: Deref<Target = <USART as Instance>::RegisterBlock>,
+    {
         type Error = Error;
 
         fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
-            self.write(word)
+            self.usart.write_u8(word)
         }
         fn flush(&mut self) -> nb::Result<(), Self::Error> {
-            self.flush()
+            self.usart.flush()
         }
     }
 
@@ -67,36 +77,49 @@ mod nb {
     /// If the UART/USART was configured with `WordLength::DataBits9`, the 9 least significant bits will
     /// be transmitted and the other 7 bits will be ignored. Otherwise, the 8 least significant bits
     /// will be transmitted and the other 8 bits will be ignored.
-    impl<USART: Instance> Write<u16> for Tx<USART, u16> {
+    impl<USART: Instance> Write<u16> for Tx<USART, u16>
+    where
+        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
+        USART: Deref<Target = <USART as Instance>::RegisterBlock>,
+    {
         type Error = Error;
 
         fn write(&mut self, word: u16) -> nb::Result<(), Self::Error> {
-            self.write(word)
+            self.usart.write_u16(word)
         }
 
         fn flush(&mut self) -> nb::Result<(), Self::Error> {
-            self.flush()
+            self.usart.flush()
         }
     }
 }
 
 mod blocking {
-    use super::super::{Error, Instance, Serial, Tx};
+    use core::ops::Deref;
+
+    use super::super::{Error, Instance, RegisterBlockImpl, Serial, Tx};
     use embedded_hal::blocking::serial::Write;
 
-    impl<USART: Instance> Write<u8> for Tx<USART, u8> {
+    impl<USART: Instance> Write<u8> for Tx<USART, u8>
+    where
+        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
+        USART: Deref<Target = <USART as Instance>::RegisterBlock>,
+    {
         type Error = Error;
 
         fn bwrite_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
-            self.bwrite_all(bytes)
+            self.usart.bwrite_all_u8(bytes)
         }
 
         fn bflush(&mut self) -> Result<(), Self::Error> {
-            self.bflush()
+            self.usart.bflush()
         }
     }
 
-    impl<USART: Instance> Write<u8> for Serial<USART, u8> {
+    impl<USART: Instance> Write<u8> for Serial<USART, u8>
+    where
+        Tx<USART, u8>: Write<u8, Error = Error>,
+    {
         type Error = Error;
 
         fn bwrite_all(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
@@ -108,23 +131,30 @@ mod blocking {
         }
     }
 
-    impl<USART: Instance> Write<u16> for Tx<USART, u16> {
+    impl<USART: Instance> Write<u16> for Tx<USART, u16>
+    where
+        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
+        USART: Deref<Target = <USART as Instance>::RegisterBlock>,
+    {
         type Error = Error;
 
         fn bwrite_all(&mut self, slice: &[u16]) -> Result<(), Self::Error> {
-            self.bwrite_all(slice)
+            self.usart.bwrite_all_u16(slice)
         }
 
         fn bflush(&mut self) -> Result<(), Self::Error> {
-            self.bflush()
+            self.usart.bflush()
         }
     }
 
-    impl<USART: Instance> Write<u16> for Serial<USART, u16> {
+    impl<USART: Instance> Write<u16> for Serial<USART, u16>
+    where
+        Tx<USART, u16>: Write<u16, Error = Error>,
+    {
         type Error = Error;
 
-        fn bwrite_all(&mut self, slice: &[u16]) -> Result<(), Self::Error> {
-            self.tx.bwrite_all(slice)
+        fn bwrite_all(&mut self, bytes: &[u16]) -> Result<(), Self::Error> {
+            self.tx.bwrite_all(bytes)
         }
 
         fn bflush(&mut self) -> Result<(), Self::Error> {

--- a/src/serial/uart_impls.rs
+++ b/src/serial/uart_impls.rs
@@ -100,7 +100,7 @@ pub trait RegisterBlockImpl: crate::Sealed {
 macro_rules! uartCommon {
     ($RegisterBlock:ty) => {
         impl RegisterBlockImpl for $RegisterBlock {
-            fn new<UART: Instance<RegisterBlock = $RegisterBlock>, WORD>(
+            fn new<UART: Instance<RegisterBlock = Self>, WORD>(
                 uart: UART,
                 pins: (impl Into<UART::Tx<PushPull>>, impl Into<UART::Rx<PushPull>>),
                 config: impl Into<config::Config>,

--- a/src/serial/uart_impls.rs
+++ b/src/serial/uart_impls.rs
@@ -16,6 +16,10 @@ use crate::rcc::{self, Clocks};
 pub(crate) use crate::pac::uart4::RegisterBlock as RegisterBlockUart;
 pub(crate) use crate::pac::usart1::RegisterBlock as RegisterBlockUsart;
 
+#[cfg(feature = "uart4")]
+impl crate::Sealed for RegisterBlockUart {}
+impl crate::Sealed for RegisterBlockUsart {}
+
 // Implemented by all USART/UART instances
 pub trait Instance: crate::Sealed + rcc::Enable + rcc::Reset + rcc::BusClock + CommonPins {
     type RegisterBlock;
@@ -26,7 +30,7 @@ pub trait Instance: crate::Sealed + rcc::Enable + rcc::Reset + rcc::BusClock + C
     fn set_stopbits(&self, bits: config::StopBits);
 }
 
-pub trait RegisterBlockImpl {
+pub trait RegisterBlockImpl: crate::Sealed {
     fn new<UART: Instance<RegisterBlock = Self>, WORD>(
         uart: UART,
         pins: (impl Into<UART::Tx<PushPull>>, impl Into<UART::Rx<PushPull>>),

--- a/src/serial/uart_impls.rs
+++ b/src/serial/uart_impls.rs
@@ -1,324 +1,457 @@
-use crate::dma::{traits::DMASet, MemoryToPeripheral, PeripheralToMemory};
+use core::{fmt, ops::Deref};
 
-use super::*;
+use nb::block;
 
-impl<UART: CommonPins> Rx<UART, u8> {
-    pub(super) fn with_u16_data(self) -> Rx<UART, u16> {
-        Rx::new(self.pin)
-    }
+use super::{
+    config, Error, Event, Listen, Rx, RxISR, RxListen, Serial, SerialExt, Tx, TxISR, TxListen,
+};
+use crate::dma::{
+    traits::{DMASet, PeriAddress},
+    MemoryToPeripheral, PeripheralToMemory,
+};
+use crate::gpio::{alt::SerialAsync as CommonPins, NoPin, PushPull};
+use crate::rcc::{self, Clocks};
+
+#[cfg(feature = "uart4")]
+pub(crate) use crate::pac::uart4::RegisterBlock as RegisterBlockUart;
+pub(crate) use crate::pac::usart1::RegisterBlock as RegisterBlockUsart;
+
+// Implemented by all USART/UART instances
+pub trait Instance: crate::Sealed + rcc::Enable + rcc::Reset + rcc::BusClock + CommonPins {
+    type RegisterBlock;
+
+    #[doc(hidden)]
+    fn ptr() -> *const Self::RegisterBlock;
+    #[doc(hidden)]
+    fn set_stopbits(&self, bits: config::StopBits);
 }
 
-impl<UART: CommonPins> Rx<UART, u16> {
-    pub(super) fn with_u8_data(self) -> Rx<UART, u8> {
-        Rx::new(self.pin)
-    }
-}
+pub trait RegisterBlockImpl {
+    fn new<UART: Instance<RegisterBlock = Self>, WORD>(
+        uart: UART,
+        pins: (impl Into<UART::Tx<PushPull>>, impl Into<UART::Rx<PushPull>>),
+        config: impl Into<config::Config>,
+        clocks: &Clocks,
+    ) -> Result<Serial<UART, WORD>, config::InvalidConfig>;
 
-impl<UART: CommonPins> Tx<UART, u8> {
-    pub(super) fn with_u16_data(self) -> Tx<UART, u16> {
-        Tx::new(self.usart, self.pin)
-    }
-}
+    fn read_u16(&self) -> nb::Result<u16, Error>;
+    fn write_u16(&self, word: u16) -> nb::Result<(), Error>;
 
-impl<UART: CommonPins> Tx<UART, u16> {
-    pub(super) fn with_u8_data(self) -> Tx<UART, u8> {
-        Tx::new(self.usart, self.pin)
+    fn read_u8(&self) -> nb::Result<u8, Error> {
+        // Delegate to u16 version, then truncate to 8 bits
+        self.read_u16().map(|word16| word16 as u8)
     }
-}
 
-impl<UART: CommonPins, WORD> Rx<UART, WORD> {
-    pub(super) fn new(pin: UART::Rx<PushPull>) -> Self {
-        Self {
-            _word: PhantomData,
-            pin,
+    fn write_u8(&self, word: u8) -> nb::Result<(), Error> {
+        // Delegate to u16 version
+        self.write_u16(u16::from(word))
+    }
+
+    fn flush(&self) -> nb::Result<(), Error>;
+
+    fn bwrite_all_u8(&self, buffer: &[u8]) -> Result<(), Error> {
+        for &b in buffer {
+            nb::block!(self.write_u8(b))?;
         }
+        Ok(())
     }
-}
 
-impl<UART: CommonPins, WORD> Tx<UART, WORD> {
-    pub(super) fn new(usart: UART, pin: UART::Tx<PushPull>) -> Self {
-        Self {
-            _word: PhantomData,
-            usart,
-            pin,
+    fn bwrite_all_u16(&self, buffer: &[u16]) -> Result<(), Error> {
+        for &b in buffer {
+            nb::block!(self.write_u16(b))?;
         }
+        Ok(())
     }
+
+    fn bflush(&self) -> Result<(), Error> {
+        nb::block!(self.flush())
+    }
+
+    // RxISR
+    fn is_idle(&self) -> bool;
+    fn is_rx_not_empty(&self) -> bool;
+    fn clear_idle_interrupt(&self);
+
+    // TxISR
+    fn is_tx_empty(&self) -> bool;
+
+    // RxListen
+    fn listen_rxne(&self);
+    fn unlisten_rxne(&self);
+    fn listen_idle(&self);
+    fn unlisten_idle(&self);
+
+    // TxListen
+    fn listen_txe(&self);
+    fn unlisten_txe(&self);
+
+    // Listen
+    fn listen(&self, event: Event);
+    fn unlisten(&self, event: Event);
+
+    // PeriAddress
+    fn peri_address(&self) -> u32;
 }
 
-impl<UART: Instance, WORD> AsRef<Tx<UART, WORD>> for Serial<UART, WORD> {
-    #[inline(always)]
-    fn as_ref(&self) -> &Tx<UART, WORD> {
-        &self.tx
-    }
-}
+macro_rules! uartCommon {
+    ($RegisterBlock:ty) => {
+        impl RegisterBlockImpl for $RegisterBlock {
+            fn new<UART: Instance<RegisterBlock = $RegisterBlock>, WORD>(
+                uart: UART,
+                pins: (impl Into<UART::Tx<PushPull>>, impl Into<UART::Rx<PushPull>>),
+                config: impl Into<config::Config>,
+                clocks: &Clocks,
+            ) -> Result<Serial<UART, WORD>, config::InvalidConfig>
+        where {
+                use self::config::*;
 
-impl<UART: Instance, WORD> AsRef<Rx<UART, WORD>> for Serial<UART, WORD> {
-    #[inline(always)]
-    fn as_ref(&self) -> &Rx<UART, WORD> {
-        &self.rx
-    }
-}
+                let config = config.into();
+                unsafe {
+                    // Enable clock.
+                    UART::enable_unchecked();
+                    UART::reset_unchecked();
+                }
 
-impl<UART: Instance, WORD> AsMut<Tx<UART, WORD>> for Serial<UART, WORD> {
-    #[inline(always)]
-    fn as_mut(&mut self) -> &mut Tx<UART, WORD> {
-        &mut self.tx
-    }
-}
+                let pclk_freq = UART::clock(clocks).raw();
+                let baud = config.baudrate.0;
 
-impl<UART: Instance, WORD> AsMut<Rx<UART, WORD>> for Serial<UART, WORD> {
-    #[inline(always)]
-    fn as_mut(&mut self) -> &mut Rx<UART, WORD> {
-        &mut self.rx
-    }
-}
+                // The frequency to calculate USARTDIV is this:
+                //
+                // (Taken from STM32F411xC/E Reference Manual,
+                // Section 19.3.4, Equation 1)
+                //
+                // 16 bit oversample: OVER8 = 0
+                // 8 bit oversample:  OVER8 = 1
+                //
+                // USARTDIV =          (pclk)
+                //            ------------------------
+                //            8 x (2 - OVER8) x (baud)
+                //
+                // BUT, the USARTDIV has 4 "fractional" bits, which effectively
+                // means that we need to "correct" the equation as follows:
+                //
+                // USARTDIV =      (pclk) * 16
+                //            ------------------------
+                //            8 x (2 - OVER8) x (baud)
+                //
+                // When OVER8 is enabled, we can only use the lowest three
+                // fractional bits, so we'll need to shift those last four bits
+                // right one bit
 
-impl<UART: Instance, WORD> Rx<UART, WORD> {
-    pub fn join<TX>(self, tx: Tx<UART, WORD>) -> Serial<UART, WORD> {
-        Serial { tx, rx: self }
-    }
+                // Calculate correct baudrate divisor on the fly
+                let (over8, div) = if (pclk_freq / 16) >= baud {
+                    // We have the ability to oversample to 16 bits, take
+                    // advantage of it.
+                    //
+                    // We also add `baud / 2` to the `pclk_freq` to ensure
+                    // rounding of values to the closest scale, rather than the
+                    // floored behavior of normal integer division.
+                    let div = (pclk_freq + (baud / 2)) / baud;
+                    (false, div)
+                } else if (pclk_freq / 8) >= baud {
+                    // We are close enough to pclk where we can only
+                    // oversample 8.
+                    //
+                    // See note above regarding `baud` and rounding.
+                    let div = ((pclk_freq * 2) + (baud / 2)) / baud;
 
-    /// Start listening for an rx not empty interrupt event
-    ///
-    /// Note, you will also have to enable the corresponding interrupt
-    /// in the NVIC to start receiving events.
-    pub fn listen(&mut self) {
-        unsafe { (*UART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) }
-    }
+                    // Ensure the the fractional bits (only 3) are
+                    // right-aligned.
+                    let frac = div & 0xF;
+                    let div = (div & !0xF) | (frac >> 1);
+                    (true, div)
+                } else {
+                    return Err(config::InvalidConfig);
+                };
 
-    /// Stop listening for the rx not empty interrupt event
-    pub fn unlisten(&mut self) {
-        unsafe { (*UART::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) }
-    }
+                let register_block = unsafe { &*UART::ptr() };
+                register_block.brr.write(|w| unsafe { w.bits(div) });
 
-    /// Start listening for a line idle interrupt event
-    ///
-    /// Note, you will also have to enable the corresponding interrupt
-    /// in the NVIC to start receiving events.
-    pub fn listen_idle(&mut self) {
-        unsafe { (*UART::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) }
-    }
+                // Reset other registers to disable advanced USART features
+                register_block.cr2.reset();
+                register_block.cr3.reset();
 
-    /// Stop listening for the line idle interrupt event
-    pub fn unlisten_idle(&mut self) {
-        unsafe { (*UART::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) }
-    }
-}
+                // Enable transmission and receiving
+                // and configure frame
 
-impl<UART: Instance, WORD> RxISR for Rx<UART, WORD> {
-    /// Return true if the line idle status is set
-    fn is_idle(&self) -> bool {
-        unsafe { (*UART::ptr()).sr.read().idle().bit_is_set() }
-    }
+                register_block.cr1.write(|w| {
+                    w.ue().set_bit();
+                    w.over8().bit(over8);
+                    w.te().set_bit();
+                    w.re().set_bit();
+                    w.m().bit(config.wordlength == WordLength::DataBits9);
+                    w.pce().bit(config.parity != Parity::ParityNone);
+                    w.ps().bit(config.parity == Parity::ParityOdd)
+                });
 
-    /// Return true if the rx register is not empty (and can be read)
-    fn is_rx_not_empty(&self) -> bool {
-        unsafe { (*UART::ptr()).sr.read().rxne().bit_is_set() }
-    }
+                match config.dma {
+                    DmaConfig::Tx => register_block.cr3.write(|w| w.dmat().enabled()),
+                    DmaConfig::Rx => register_block.cr3.write(|w| w.dmar().enabled()),
+                    DmaConfig::TxRx => register_block
+                        .cr3
+                        .write(|w| w.dmar().enabled().dmat().enabled()),
+                    DmaConfig::None => {}
+                }
 
-    /// Clear idle line interrupt flag
-    fn clear_idle_interrupt(&self) {
-        unsafe {
-            let _ = (*UART::ptr()).sr.read();
-            let _ = (*UART::ptr()).dr.read();
+                let serial = Serial {
+                    tx: Tx::new(uart, pins.0.into()),
+                    rx: Rx::new(pins.1.into()),
+                };
+                serial.tx.usart.set_stopbits(config.stopbits);
+                Ok(serial)
+            }
+
+            fn read_u16(&self) -> nb::Result<u16, Error> {
+                // NOTE(unsafe) atomic read with no side effects
+                let sr = self.sr.read();
+
+                // Any error requires the dr to be read to clear
+                if sr.pe().bit_is_set()
+                    || sr.fe().bit_is_set()
+                    || sr.nf().bit_is_set()
+                    || sr.ore().bit_is_set()
+                {
+                    self.dr.read();
+                }
+
+                Err(if sr.pe().bit_is_set() {
+                    Error::Parity.into()
+                } else if sr.fe().bit_is_set() {
+                    Error::FrameFormat.into()
+                } else if sr.nf().bit_is_set() {
+                    Error::Noise.into()
+                } else if sr.ore().bit_is_set() {
+                    Error::Overrun.into()
+                } else if sr.rxne().bit_is_set() {
+                    // NOTE(unsafe) atomic read from stateless register
+                    return Ok(self.dr.read().dr().bits());
+                } else {
+                    nb::Error::WouldBlock
+                })
+            }
+
+            fn write_u16(&self, word: u16) -> nb::Result<(), Error> {
+                // NOTE(unsafe) atomic read with no side effects
+                let sr = self.sr.read();
+
+                if sr.txe().bit_is_set() {
+                    // NOTE(unsafe) atomic write to stateless register
+                    self.dr.write(|w| w.dr().bits(word));
+                    Ok(())
+                } else {
+                    Err(nb::Error::WouldBlock)
+                }
+            }
+
+            fn flush(&self) -> nb::Result<(), Error> {
+                // NOTE(unsafe) atomic read with no side effects
+                let sr = self.sr.read();
+
+                if sr.tc().bit_is_set() {
+                    Ok(())
+                } else {
+                    Err(nb::Error::WouldBlock)
+                }
+            }
+
+            fn is_idle(&self) -> bool {
+                self.sr.read().idle().bit_is_set()
+            }
+
+            fn is_rx_not_empty(&self) -> bool {
+                self.sr.read().rxne().bit_is_set()
+            }
+
+            fn clear_idle_interrupt(&self) {
+                let _ = self.sr.read();
+                let _ = self.dr.read();
+            }
+
+            fn is_tx_empty(&self) -> bool {
+                self.sr.read().txe().bit_is_set()
+            }
+
+            fn listen_rxne(&self) {
+                self.cr1.modify(|_, w| w.rxneie().set_bit())
+            }
+
+            fn unlisten_rxne(&self) {
+                self.cr1.modify(|_, w| w.rxneie().clear_bit())
+            }
+
+            fn listen_idle(&self) {
+                self.cr1.modify(|_, w| w.idleie().set_bit())
+            }
+
+            fn unlisten_idle(&self) {
+                self.cr1.modify(|_, w| w.idleie().clear_bit())
+            }
+
+            fn listen_txe(&self) {
+                self.cr1.modify(|_, w| w.txeie().set_bit())
+            }
+
+            fn unlisten_txe(&self) {
+                self.cr1.modify(|_, w| w.txeie().clear_bit())
+            }
+
+            fn listen(&self, event: Event) {
+                match event {
+                    Event::Rxne => self.cr1.modify(|_, w| w.rxneie().set_bit()),
+                    Event::Txe => self.cr1.modify(|_, w| w.txeie().set_bit()),
+                    Event::Idle => self.cr1.modify(|_, w| w.idleie().set_bit()),
+                }
+            }
+
+            fn unlisten(&self, event: Event) {
+                match event {
+                    Event::Rxne => self.cr1.modify(|_, w| w.rxneie().clear_bit()),
+                    Event::Txe => self.cr1.modify(|_, w| w.txeie().clear_bit()),
+                    Event::Idle => self.cr1.modify(|_, w| w.idleie().clear_bit()),
+                }
+            }
+
+            fn peri_address(&self) -> u32 {
+                &self.dr as *const _ as u32
+            }
         }
-    }
+    };
 }
 
-impl<UART: Instance, WORD> Tx<UART, WORD> {
-    pub fn join(self, rx: Rx<UART, WORD>) -> Serial<UART, WORD> {
-        Serial { tx: self, rx }
-    }
+uartCommon! { RegisterBlockUsart }
 
-    /// Start listening for a tx empty interrupt event
-    ///
-    /// Note, you will also have to enable the corresponding interrupt
-    /// in the NVIC to start receiving events.
-    pub fn listen(&mut self) {
-        unsafe { (*UART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) }
-    }
+#[cfg(feature = "uart4")]
+uartCommon! { RegisterBlockUart }
 
-    /// Stop listening for the tx empty interrupt event
-    pub fn unlisten(&mut self) {
-        unsafe { (*UART::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) }
-    }
-}
-
-impl<UART: Instance, WORD> TxISR for Tx<UART, WORD> {
-    /// Return true if the tx register is empty (and can accept data)
-    fn is_tx_empty(&self) -> bool {
-        unsafe { (*UART::ptr()).sr.read().txe().bit_is_set() }
-    }
-}
-
-impl<UART: Instance, WORD> Serial<UART, WORD> {
-    /// Starts listening for an interrupt event
-    ///
-    /// Note, you will also have to enable the corresponding interrupt
-    /// in the NVIC to start receiving events.
-    pub fn listen(&mut self, event: Event) {
-        match event {
-            Event::Rxne => unsafe { (*UART::ptr()).cr1.modify(|_, w| w.rxneie().set_bit()) },
-            Event::Txe => unsafe { (*UART::ptr()).cr1.modify(|_, w| w.txeie().set_bit()) },
-            Event::Idle => unsafe { (*UART::ptr()).cr1.modify(|_, w| w.idleie().set_bit()) },
-        }
-    }
-
-    /// Stop listening for an interrupt event
-    pub fn unlisten(&mut self, event: Event) {
-        match event {
-            Event::Rxne => unsafe { (*UART::ptr()).cr1.modify(|_, w| w.rxneie().clear_bit()) },
-            Event::Txe => unsafe { (*UART::ptr()).cr1.modify(|_, w| w.txeie().clear_bit()) },
-            Event::Idle => unsafe { (*UART::ptr()).cr1.modify(|_, w| w.idleie().clear_bit()) },
-        }
-    }
-
-    pub fn split(self) -> (Tx<UART, WORD>, Rx<UART, WORD>) {
-        (self.tx, self.rx)
-    }
-}
-
-impl<UART: Instance, WORD> RxISR for Serial<UART, WORD> {
-    /// Return true if the line idle status is set
+impl<UART: Instance, WORD> RxISR for Serial<UART, WORD>
+where
+    Rx<UART, WORD>: RxISR,
+{
     fn is_idle(&self) -> bool {
         self.rx.is_idle()
     }
 
-    /// Return true if the rx register is not empty (and can be read)
     fn is_rx_not_empty(&self) -> bool {
         self.rx.is_rx_not_empty()
     }
 
-    /// Clear idle line interrupt flag
     fn clear_idle_interrupt(&self) {
         self.rx.clear_idle_interrupt();
     }
 }
 
-impl<UART: Instance, WORD> TxISR for Serial<UART, WORD> {
-    /// Return true if the tx register is empty (and can accept data)
+impl<UART: Instance, WORD> RxISR for Rx<UART, WORD>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+{
+    fn is_idle(&self) -> bool {
+        unsafe { (*UART::ptr()).is_idle() }
+    }
+
+    fn is_rx_not_empty(&self) -> bool {
+        unsafe { (*UART::ptr()).is_rx_not_empty() }
+    }
+
+    fn clear_idle_interrupt(&self) {
+        unsafe {
+            (*UART::ptr()).clear_idle_interrupt();
+        }
+    }
+}
+
+impl<UART: Instance, WORD> TxISR for Serial<UART, WORD>
+where
+    Tx<UART, WORD>: TxISR,
+{
     fn is_tx_empty(&self) -> bool {
         self.tx.is_tx_empty()
     }
 }
 
-impl<UART: Instance> fmt::Write for Serial<UART> {
+impl<UART: Instance, WORD> TxISR for Tx<UART, WORD>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+    UART: Deref<Target = <UART as Instance>::RegisterBlock>,
+{
+    fn is_tx_empty(&self) -> bool {
+        self.usart.is_tx_empty()
+    }
+}
+
+impl<UART: Instance, WORD> RxListen for Rx<UART, WORD>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+{
+    fn listen(&mut self) {
+        unsafe { (*UART::ptr()).listen_rxne() }
+    }
+
+    fn unlisten(&mut self) {
+        unsafe { (*UART::ptr()).unlisten_rxne() }
+    }
+
+    fn listen_idle(&mut self) {
+        unsafe { (*UART::ptr()).listen_idle() }
+    }
+
+    fn unlisten_idle(&mut self) {
+        unsafe { (*UART::ptr()).unlisten_idle() }
+    }
+}
+
+impl<UART: Instance, WORD> TxListen for Tx<UART, WORD>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+    UART: Deref<Target = <UART as Instance>::RegisterBlock>,
+{
+    fn listen(&mut self) {
+        self.usart.listen_txe()
+    }
+
+    fn unlisten(&mut self) {
+        self.usart.unlisten_txe()
+    }
+}
+
+impl<UART: Instance, WORD> Listen for Serial<UART, WORD>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+    UART: Deref<Target = <UART as Instance>::RegisterBlock>,
+{
+    fn listen(&mut self, event: Event) {
+        self.tx.usart.listen(event)
+    }
+
+    fn unlisten(&mut self, event: Event) {
+        self.tx.usart.unlisten(event)
+    }
+}
+
+impl<UART: Instance> fmt::Write for Serial<UART>
+where
+    Tx<UART>: fmt::Write,
+{
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.tx.write_str(s)
     }
 }
 
-impl<UART: Instance> fmt::Write for Tx<UART> {
+impl<UART: Instance> fmt::Write for Tx<UART>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+    UART: Deref<Target = <UART as Instance>::RegisterBlock>,
+{
     fn write_str(&mut self, s: &str) -> fmt::Result {
         s.bytes()
-            .try_for_each(|c| block!(self.write(c)))
+            .try_for_each(|c| block!(self.usart.write_u8(c)))
             .map_err(|_| fmt::Error)
     }
 }
 
-impl<UART: Instance> Rx<UART, u8> {
-    pub(super) fn read(&mut self) -> nb::Result<u8, Error> {
-        // Delegate to the Read<u16> implementation, then truncate to 8 bits
-        unsafe {
-            (*(self as *mut Self as *mut Rx<UART, u16>))
-                .read()
-                .map(|word16| word16 as u8)
-        }
-    }
-}
-
-impl<UART: Instance> Rx<UART, u16> {
-    pub(super) fn read(&mut self) -> nb::Result<u16, Error> {
-        // NOTE(unsafe) atomic read with no side effects
-        let sr = unsafe { (*UART::ptr()).sr.read() };
-
-        // Any error requires the dr to be read to clear
-        if sr.pe().bit_is_set()
-            || sr.fe().bit_is_set()
-            || sr.nf().bit_is_set()
-            || sr.ore().bit_is_set()
-        {
-            unsafe { (*UART::ptr()).dr.read() };
-        }
-
-        Err(if sr.pe().bit_is_set() {
-            Error::Parity.into()
-        } else if sr.fe().bit_is_set() {
-            Error::FrameFormat.into()
-        } else if sr.nf().bit_is_set() {
-            Error::Noise.into()
-        } else if sr.ore().bit_is_set() {
-            Error::Overrun.into()
-        } else if sr.rxne().bit_is_set() {
-            // NOTE(unsafe) atomic read from stateless register
-            return Ok(unsafe { &*UART::ptr() }.dr.read().dr().bits());
-        } else {
-            nb::Error::WouldBlock
-        })
-    }
-}
-
-impl<UART: Instance> Tx<UART, u8> {
-    pub(super) fn write(&mut self, word: u8) -> nb::Result<(), Error> {
-        // Delegate to u16 version
-        unsafe { (*(self as *mut Self as *mut Tx<UART, u16>)).write(u16::from(word)) }
-    }
-
-    pub(super) fn flush(&mut self) -> nb::Result<(), Error> {
-        // Delegate to u16 version
-        unsafe { (*(self as *mut Self as *mut Tx<UART, u16>)).flush() }
-    }
-
-    pub(super) fn bwrite_all(&mut self, bytes: &[u8]) -> Result<(), Error> {
-        for &b in bytes {
-            nb::block!(self.write(b))?;
-        }
-        Ok(())
-    }
-
-    pub(super) fn bflush(&mut self) -> Result<(), Error> {
-        nb::block!(self.flush())
-    }
-}
-
-impl<UART: Instance> Tx<UART, u16> {
-    pub(super) fn write(&mut self, word: u16) -> nb::Result<(), Error> {
-        // NOTE(unsafe) atomic read with no side effects
-        let sr = unsafe { (*UART::ptr()).sr.read() };
-
-        if sr.txe().bit_is_set() {
-            // NOTE(unsafe) atomic write to stateless register
-            unsafe { &*UART::ptr() }.dr.write(|w| w.dr().bits(word));
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
-    }
-
-    pub(super) fn flush(&mut self) -> nb::Result<(), Error> {
-        // NOTE(unsafe) atomic read with no side effects
-        let sr = unsafe { (*UART::ptr()).sr.read() };
-
-        if sr.tc().bit_is_set() {
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
-    }
-
-    pub(super) fn bwrite_all(&mut self, buffer: &[u16]) -> Result<(), Error> {
-        for &b in buffer {
-            nb::block!(self.write(b))?;
-        }
-        Ok(())
-    }
-
-    pub(super) fn bflush(&mut self) -> Result<(), Error> {
-        nb::block!(self.flush())
-    }
-}
-
-impl<UART: Instance> SerialExt for UART {
+impl<UART: Instance> SerialExt for UART
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+{
     fn serial<WORD>(
         self,
         pins: (impl Into<Self::Tx<PushPull>>, impl Into<Self::Rx<PushPull>>),
@@ -351,7 +484,10 @@ impl<UART: Instance> SerialExt for UART {
     }
 }
 
-impl<UART: Instance, WORD> Serial<UART, WORD> {
+impl<UART: Instance, WORD> Serial<UART, WORD>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+{
     pub fn tx(
         usart: UART,
         tx_pin: impl Into<UART::Tx<PushPull>>,
@@ -365,7 +501,10 @@ impl<UART: Instance, WORD> Serial<UART, WORD> {
     }
 }
 
-impl<UART: Instance, WORD> Serial<UART, WORD> {
+impl<UART: Instance, WORD> Serial<UART, WORD>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+{
     pub fn rx(
         usart: UART,
         rx_pin: impl Into<UART::Rx<PushPull>>,
@@ -379,34 +518,13 @@ impl<UART: Instance, WORD> Serial<UART, WORD> {
     }
 }
 
-impl<UART: Instance> Serial<UART, u8> {
-    /// Converts this Serial into a version that can read and write `u16` values instead of `u8`s
-    ///
-    /// This can be used with a word length of 9 bits.
-    pub fn with_u16_data(self) -> Serial<UART, u16> {
-        Serial {
-            tx: self.tx.with_u16_data(),
-            rx: self.rx.with_u16_data(),
-        }
-    }
-}
-
-impl<UART: Instance> Serial<UART, u16> {
-    /// Converts this Serial into a version that can read and write `u8` values instead of `u16`s
-    ///
-    /// This can be used with a word length of 8 bits.
-    pub fn with_u8_data(self) -> Serial<UART, u8> {
-        Serial {
-            tx: self.tx.with_u8_data(),
-            rx: self.rx.with_u8_data(),
-        }
-    }
-}
-
-unsafe impl<UART: Instance> PeriAddress for Rx<UART, u8> {
+unsafe impl<UART: Instance> PeriAddress for Rx<UART, u8>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+{
     #[inline(always)]
     fn address(&self) -> u32 {
-        &(unsafe { &(*UART::ptr()) }.dr) as *const _ as u32
+        unsafe { (*UART::ptr()).peri_address() }
     }
 
     type MemSize = u8;
@@ -419,10 +537,14 @@ where
 {
 }
 
-unsafe impl<UART: Instance> PeriAddress for Tx<UART, u8> {
+unsafe impl<UART: Instance> PeriAddress for Tx<UART, u8>
+where
+    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
+    UART: Deref<Target = <UART as Instance>::RegisterBlock>,
+{
     #[inline(always)]
     fn address(&self) -> u32 {
-        &(unsafe { &(*UART::ptr()) }.dr) as *const _ as u32
+        self.usart.peri_address()
     }
 
     type MemSize = u8;

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -14,222 +14,26 @@
 //! the embedded-hal read and write traits with `u16` as the word type. You can use these
 //! implementations for 9-bit words.
 
-use core::fmt;
-use core::marker::PhantomData;
-
-use crate::rcc;
-use nb::block;
-
-#[allow(clippy::duplicate_mod)]
-#[path = "./serial/hal_02.rs"]
-mod hal_02;
-#[allow(clippy::duplicate_mod)]
-#[path = "./serial/hal_1.rs"]
-mod hal_1;
-#[allow(clippy::duplicate_mod)]
-#[path = "./serial/uart_impls.rs"]
-mod uart_impls;
-
 use crate::pac;
 
-use crate::gpio::{NoPin, PushPull};
-use crate::rcc::Clocks;
+use crate::serial::uart_impls::RegisterBlockUart;
 
-use crate::dma::traits::PeriAddress;
-
-pub use crate::serial::{config, CommonPins, Event, NoRx, NoTx, RxISR, TxISR};
+pub use crate::serial::{config, Event, Instance, NoRx, NoTx, Rx, RxISR, Serial, Tx, TxISR};
 pub use config::Config;
 /// Serial error
 pub use embedded_hal_one::serial::ErrorKind as Error;
 
-/// Serial abstraction
-pub struct Serial<UART: CommonPins, WORD = u8> {
-    tx: Tx<UART, WORD>,
-    rx: Rx<UART, WORD>,
-}
-
-/// Serial receiver containing RX pin
-pub struct Rx<UART: CommonPins, WORD = u8> {
-    _word: PhantomData<(UART, WORD)>,
-    pin: UART::Rx<PushPull>,
-}
-
-/// Serial transmitter containing TX pin
-pub struct Tx<UART: CommonPins, WORD = u8> {
-    _word: PhantomData<WORD>,
-    usart: UART,
-    pin: UART::Tx<PushPull>,
-}
-
-pub trait SerialExt: Sized + Instance {
-    fn serial<WORD>(
-        self,
-        pins: (impl Into<Self::Tx<PushPull>>, impl Into<Self::Rx<PushPull>>),
-        config: impl Into<config::Config>,
-        clocks: &Clocks,
-    ) -> Result<Serial<Self, WORD>, config::InvalidConfig>;
-
-    fn tx<WORD>(
-        self,
-        tx_pin: impl Into<Self::Tx<PushPull>>,
-        config: impl Into<config::Config>,
-        clocks: &Clocks,
-    ) -> Result<Tx<Self, WORD>, config::InvalidConfig>
-    where
-        NoPin: Into<Self::Rx<PushPull>>;
-
-    fn rx<WORD>(
-        self,
-        rx_pin: impl Into<Self::Rx<PushPull>>,
-        config: impl Into<config::Config>,
-        clocks: &Clocks,
-    ) -> Result<Rx<Self, WORD>, config::InvalidConfig>
-    where
-        NoPin: Into<Self::Tx<PushPull>>;
-}
-
-impl<UART: Instance, WORD> Serial<UART, WORD> {
-    /*
-        StopBits::STOP0P5 and StopBits::STOP1P5 aren't supported when using UART
-        STOP_A::STOP1 and STOP_A::STOP2 will be used, respectively
-    */
-    pub fn new(
-        usart: UART,
-        pins: (impl Into<UART::Tx<PushPull>>, impl Into<UART::Rx<PushPull>>),
-        config: impl Into<config::Config>,
-        clocks: &Clocks,
-    ) -> Result<Self, config::InvalidConfig> {
-        use self::config::*;
-
-        let config = config.into();
-        unsafe {
-            // Enable clock.
-            UART::enable_unchecked();
-            UART::reset_unchecked();
-        }
-
-        let pclk_freq = UART::clock(clocks).raw();
-        let baud = config.baudrate.0;
-
-        // The frequency to calculate UARTDIV is this:
-        //
-        // (Taken from STM32F411xC/E Reference Manual,
-        // Section 19.3.4, Equation 1)
-        //
-        // 16 bit oversample: OVER8 = 0
-        // 8 bit oversample:  OVER8 = 1
-        //
-        // UARTDIV =          (pclk)
-        //            ------------------------
-        //            8 x (2 - OVER8) x (baud)
-        //
-        // BUT, the UARTDIV has 4 "fractional" bits, which effectively
-        // means that we need to "correct" the equation as follows:
-        //
-        // UARTDIV =      (pclk) * 16
-        //            ------------------------
-        //            8 x (2 - OVER8) x (baud)
-        //
-        // When OVER8 is enabled, we can only use the lowest three
-        // fractional bits, so we'll need to shift those last four bits
-        // right one bit
-
-        // Calculate correct baudrate divisor on the fly
-        let (over8, div) = if (pclk_freq / 16) >= baud {
-            // We have the ability to oversample to 16 bits, take
-            // advantage of it.
-            //
-            // We also add `baud / 2` to the `pclk_freq` to ensure
-            // rounding of values to the closest scale, rather than the
-            // floored behavior of normal integer division.
-            let div = (pclk_freq + (baud / 2)) / baud;
-            (false, div)
-        } else if (pclk_freq / 8) >= baud {
-            // We are close enough to pclk where we can only
-            // oversample 8.
-            //
-            // See note above regarding `baud` and rounding.
-            let div = ((pclk_freq * 2) + (baud / 2)) / baud;
-
-            // Ensure the the fractional bits (only 3) are
-            // right-aligned.
-            let frac = div & 0xF;
-            let div = (div & !0xF) | (frac >> 1);
-            (true, div)
-        } else {
-            return Err(config::InvalidConfig);
-        };
-
-        unsafe { (*UART::ptr()).brr.write(|w| w.bits(div)) };
-
-        // Reset other registers to disable advanced UART features
-        unsafe { (*UART::ptr()).cr2.reset() };
-        unsafe { (*UART::ptr()).cr3.reset() };
-
-        // Enable transmission and receiving
-        // and configure frame
-        unsafe {
-            (*UART::ptr()).cr1.write(|w| {
-                w.ue().set_bit();
-                w.over8().bit(over8);
-                w.te().set_bit();
-                w.re().set_bit();
-                w.m().bit(config.wordlength == WordLength::DataBits9);
-                w.pce().bit(config.parity != Parity::ParityNone);
-                w.ps().bit(config.parity == Parity::ParityOdd)
-            })
-        };
-
-        match config.dma {
-            DmaConfig::Tx => unsafe { (*UART::ptr()).cr3.write(|w| w.dmat().enabled()) },
-            DmaConfig::Rx => unsafe { (*UART::ptr()).cr3.write(|w| w.dmar().enabled()) },
-            DmaConfig::TxRx => unsafe {
-                (*UART::ptr())
-                    .cr3
-                    .write(|w| w.dmar().enabled().dmat().enabled())
-            },
-            DmaConfig::None => {}
-        }
-
-        Ok(Serial {
-            tx: Tx::new(usart, pins.0.into()),
-            rx: Rx::new(pins.1.into()),
-        }
-        .config_stop(config))
-    }
-
-    #[allow(clippy::type_complexity)]
-    pub fn release(self) -> (UART, (UART::Tx<PushPull>, UART::Rx<PushPull>)) {
-        (self.tx.usart, (self.tx.pin, self.rx.pin))
-    }
-}
-
-impl<UART: Instance, WORD> Serial<UART, WORD> {
-    fn config_stop(self, config: config::Config) -> Self {
-        self.tx.usart.set_stopbits(config.stopbits);
-        self
-    }
-}
-
-use crate::pac::uart4 as uart_base;
-
-// Implemented by all UART instances
-pub trait Instance: crate::Sealed + rcc::Enable + rcc::Reset + rcc::BusClock + CommonPins {
-    #[doc(hidden)]
-    fn ptr() -> *const uart_base::RegisterBlock;
-    #[doc(hidden)]
-    fn set_stopbits(&self, bits: config::StopBits);
-}
-
 #[cfg(not(any(feature = "stm32f413", feature = "stm32f423",)))]
 macro_rules! halUart {
-    ($UART:ty, $usart:ident, $Serial:ident, $Tx:ident, $Rx:ident) => {
+    ($UART:ty, $Serial:ident, $Tx:ident, $Rx:ident) => {
         pub type $Serial<WORD = u8> = Serial<$UART, WORD>;
         pub type $Tx<WORD = u8> = Tx<$UART, WORD>;
         pub type $Rx<WORD = u8> = Rx<$UART, WORD>;
 
         impl Instance for $UART {
-            fn ptr() -> *const uart_base::RegisterBlock {
+            type RegisterBlock = RegisterBlockUart;
+
+            fn ptr() -> *const RegisterBlockUart {
                 <$UART>::ptr() as *const _
             }
 
@@ -237,6 +41,10 @@ macro_rules! halUart {
                 use crate::pac::uart4::cr2::STOP_A;
                 use config::StopBits;
 
+                /*
+                    StopBits::STOP0P5 and StopBits::STOP1P5 aren't supported when using UART
+                    STOP_A::STOP1 and STOP_A::STOP2 will be used, respectively
+                */
                 self.cr2.write(|w| {
                     w.stop().variant(match bits {
                         StopBits::STOP0P5 => STOP_A::Stop1,
@@ -252,15 +60,17 @@ macro_rules! halUart {
 
 #[cfg(feature = "uart4")]
 #[cfg(not(any(feature = "stm32f413", feature = "stm32f423")))]
-halUart! { pac::UART4, uart4, Serial4, Rx4, Tx4 }
+halUart! { pac::UART4, Serial4, Rx4, Tx4 }
 #[cfg(feature = "uart5")]
 #[cfg(not(any(feature = "stm32f413", feature = "stm32f423")))]
-halUart! { pac::UART5, uart5, Serial5, Rx5, Tx5 }
+halUart! { pac::UART5, Serial5, Rx5, Tx5 }
 
 #[cfg(feature = "uart4")]
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
 impl Instance for pac::UART4 {
-    fn ptr() -> *const uart_base::RegisterBlock {
+    type RegisterBlock = RegisterBlockUart;
+
+    fn ptr() -> *const RegisterBlockUart {
         pac::UART4::ptr() as *const _
     }
 
@@ -271,13 +81,13 @@ impl Instance for pac::UART4 {
 
 #[cfg(feature = "uart5")]
 #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
-crate::serial::halUsart! { pac::UART5, uart5, Serial5, Rx5, Tx5 }
+crate::serial::halUsart! { pac::UART5, Serial5, Rx5, Tx5 }
 
 #[cfg(feature = "uart7")]
-crate::serial::halUsart! { pac::UART7, uart7, Serial7, Rx7, Tx7 }
+crate::serial::halUsart! { pac::UART7, Serial7, Rx7, Tx7 }
 #[cfg(feature = "uart8")]
-crate::serial::halUsart! { pac::UART8, uart8, Serial8, Rx8, Tx8 }
+crate::serial::halUsart! { pac::UART8, Serial8, Rx8, Tx8 }
 #[cfg(feature = "uart9")]
-crate::serial::halUsart! { pac::UART9, uart9, Serial9, Rx9, Tx9 }
+crate::serial::halUsart! { pac::UART9, Serial9, Rx9, Tx9 }
 #[cfg(feature = "uart10")]
-crate::serial::halUsart! { pac::UART10, uart10, Serial10, Rx10, Tx10 }
+crate::serial::halUsart! { pac::UART10, Serial10, Rx10, Tx10 }


### PR DESCRIPTION
cc #630
@burrbull 

## Main idea
```rust
#[cfg(feature = "uart4")]
pub(crate) use crate::pac::uart4::RegisterBlock as RegisterBlockUart;
pub(crate) use crate::pac::usart1::RegisterBlock as RegisterBlockUsart;

pub trait RegisterBlockImpl {
    fn new<UART: Instance<RegisterBlock = Self>, WORD>(
        uart: UART,
        pins: (impl Into<UART::Tx<PushPull>>, impl Into<UART::Rx<PushPull>>),
        config: impl Into<config::Config>,
        clocks: &Clocks,
    ) -> Result<Serial<UART, WORD>, config::InvalidConfig>;

    fn read_u16(&self) -> nb::Result<u16, Error>;
    fn write_u16(&self, word: u16) -> nb::Result<(), Error>;

    fn read_u8(&self) -> nb::Result<u8, Error> {
        // Delegate to u16 version, then truncate to 8 bits
        self.read_u16().map(|word16| word16 as u8)
    }

    fn write_u8(&self, word: u8) -> nb::Result<(), Error> {
        // Delegate to u16 version
        self.write_u16(u16::from(word))
    }

    fn flush(&self) -> nb::Result<(), Error>;

    fn bwrite_all_u8(&self, buffer: &[u8]) -> Result<(), Error> {
        for &b in buffer {
            nb::block!(self.write_u8(b))?;
        }
        Ok(())
    }

    fn bwrite_all_u16(&self, buffer: &[u16]) -> Result<(), Error> {
        for &b in buffer {
            nb::block!(self.write_u16(b))?;
        }
        Ok(())
    }

    fn bflush(&self) -> Result<(), Error> {
        nb::block!(self.flush())
    }

    // RxISR
    fn is_idle(&self) -> bool;
    fn is_rx_not_empty(&self) -> bool;
    fn clear_idle_interrupt(&self);

    // TxISR
    fn is_tx_empty(&self) -> bool;

    // RxListen
    fn listen_rxne(&self);
    fn unlisten_rxne(&self);
    fn listen_idle(&self);
    fn unlisten_idle(&self);

    // TxListen
    fn listen_txe(&self);
    fn unlisten_txe(&self);

    // Listen
    fn listen(&self, event: Event);
    fn unlisten(&self, event: Event);

    // PeriAddress
    fn peri_address(&self) -> u32;
}

macro_rules! uartCommon {
    ($RegisterBlock:ty) => {
        impl RegisterBlockImpl for $RegisterBlock {
			...
		}
    }
}

uartCommon! { RegisterBlockUsart }

#[cfg(feature = "uart4")]
uartCommon! { RegisterBlockUart }
```
Note that `RegisterBlockImpl` not exports from `stm32f4xx-hal`.

## Changes in public API
- add `type RegisterBlock;` to `Instance`
```rust 
pub trait Instance: crate::Sealed + rcc::Enable + rcc::Reset + rcc::BusClock + CommonPins {
    type RegisterBlock;

    #[doc(hidden)]
    fn ptr() -> *const Self::RegisterBlock;
    #[doc(hidden)]
    fn set_stopbits(&self, bits: config::StopBits);
}
```
- remove `uart::{Serial, Rx, Tx}`
- add `RxListen`, `TxListen`, `Listen` traits
```rust
/// Trait for listening [`Rx`] interrupt events.
pub trait RxListen {
    /// Start listening for an rx not empty interrupt event
    ///
    /// Note, you will also have to enable the corresponding interrupt
    /// in the NVIC to start receiving events.
    fn listen(&mut self);

    /// Stop listening for the rx not empty interrupt event
    fn unlisten(&mut self);

    /// Start listening for a line idle interrupt event
    ///
    /// Note, you will also have to enable the corresponding interrupt
    /// in the NVIC to start receiving events.
    fn listen_idle(&mut self);

    /// Stop listening for the line idle interrupt event
    fn unlisten_idle(&mut self);
}

/// Trait for listening [`Tx`] interrupt event.
pub trait TxListen {
    /// Start listening for a tx empty interrupt event
    ///
    /// Note, you will also have to enable the corresponding interrupt
    /// in the NVIC to start receiving events.
    fn listen(&mut self);

    /// Stop listening for the tx empty interrupt event
    fn unlisten(&mut self);
}

/// Trait for listening [`Serial`] interrupt events.
pub trait Listen {
    /// Starts listening for an interrupt event
    ///
    /// Note, you will also have to enable the corresponding interrupt
    /// in the NVIC to start receiving events.
    fn listen(&mut self, event: Event);

    /// Stop listening for an interrupt event
    fn unlisten(&mut self, event: Event);
}
```
- relax `Serial.split` and `Serial.release` trait bounds to `UART: CommonPins`
- relax `Rx.join` and `Tx.join` trait bounds to `UART: CommonPins`

## Questions
- Why `PeriAddress` and `DMASet` implemented for `Rx<UART, u8>`, not `Rx<UART, WORD>`? And Tx too.

## P.S.
I have tried use `#![feature(specialization)]` and `#![feature(min_specialization)]` and failed miserably.
The `min_specialization` not does not cover this case, the `specialization` cause ICE.

Besides I think that current [specialization RFC](https://github.com/rust-lang/rfcs/blob/master/text/1210-impl-specialization.md)  not suitable for our case at all, because we have `impl InstanceUsart` and `impl InstanceUart` with the same "specialization", but not trait bounds inheritance. 