### PR TITLE
update to `embedded-hal=1.0.0-alpha.10`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
  - move gpio impls in subdir, remove unused `From` impls
+ - Bump `embedded-hal` to `1.0.0-alpha.10`. See [their changelog][embedded-hal-1.0.0-alpha.10] for further details. Note that this included breaking changes to the previous alpha APIs. [#663]
+
+[#663]: https://github.com/stm32-rs/stm32f4xx-hal/pull/663
+[embedded-hal-1.0.0-alpha.10]: https://github.com/rust-embedded/embedded-hal/blob/v1.0.0-alpha.10/embedded-hal/CHANGELOG.md
 
 ## [v0.16.2] - 2023-06-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ embedded-dma = "0.2.0"
 bare-metal = { version = "1" }
 void = { default-features = false, version = "1.0.2" }
 embedded-hal = { features = ["unproven"], version = "0.2.7" }
+embedded-hal-nb = "1.0.0-alpha.2"
 display-interface = { version = "0.4.1", optional = true }
 fugit = "0.3.6"
 fugit-timer = "0.1.3"
@@ -53,7 +54,7 @@ version = "0.3.14"
 default-features = false
 
 [dependencies.embedded-hal-one]
-version = "=1.0.0-alpha.8"
+version = "=1.0.0-alpha.10"
 package = "embedded-hal"
 
 [dependencies.stm32_i2s_v12x]

--- a/src/dwt.rs
+++ b/src/dwt.rs
@@ -114,23 +114,19 @@ impl<T: Into<u64>> embedded_hal::blocking::delay::DelayMs<T> for Delay {
     }
 }
 
-impl embedded_hal_one::delay::blocking::DelayUs for Delay {
-    type Error = core::convert::Infallible;
-
-    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+impl embedded_hal_one::delay::DelayUs for Delay {
+    fn delay_us(&mut self, us: u32) {
         // Convert us to ticks
         let start = DWT::cycle_count();
         let ticks = (us as u64 * self.clock.raw() as u64) / 1_000_000;
         Delay::delay_ticks(start, ticks);
-        Ok(())
     }
 
-    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+    fn delay_ms(&mut self, ms: u32) {
         // Convert ms to ticks
         let start = DWT::cycle_count();
         let ticks = (ms as u64 * self.clock.raw() as u64) / 1_000;
         Delay::delay_ticks(start, ticks);
-        Ok(())
     }
 }
 

--- a/src/fmpi2c/hal_1.rs
+++ b/src/fmpi2c/hal_1.rs
@@ -9,9 +9,9 @@ impl<I2C: Instance> ErrorType for super::FMPI2c<I2C> {
 mod blocking {
     use super::super::{fmpi2c1, FMPI2c, Instance};
     use core::ops::Deref;
-    use embedded_hal_one::i2c::blocking::Operation;
+    use embedded_hal_one::i2c::Operation;
 
-    impl<I2C: Instance> embedded_hal_one::i2c::blocking::I2c for FMPI2c<I2C>
+    impl<I2C: Instance> embedded_hal_one::i2c::I2c for FMPI2c<I2C>
     where
         I2C: Deref<Target = fmpi2c1::RegisterBlock>,
     {
@@ -23,13 +23,6 @@ mod blocking {
             self.write(addr, bytes)
         }
 
-        fn write_iter<B>(&mut self, _addr: u8, _bytes: B) -> Result<(), Self::Error>
-        where
-            B: IntoIterator<Item = u8>,
-        {
-            todo!()
-        }
-
         fn write_read(
             &mut self,
             addr: u8,
@@ -39,30 +32,11 @@ mod blocking {
             self.write_read(addr, bytes, buffer)
         }
 
-        fn write_iter_read<B>(
-            &mut self,
-            _addr: u8,
-            _bytes: B,
-            _buffer: &mut [u8],
-        ) -> Result<(), Self::Error>
-        where
-            B: IntoIterator<Item = u8>,
-        {
-            todo!()
-        }
-
         fn transaction(
             &mut self,
             _addr: u8,
             _operations: &mut [Operation<'_>],
         ) -> Result<(), Self::Error> {
-            todo!()
-        }
-
-        fn transaction_iter<'a, O>(&mut self, _addr: u8, _operations: O) -> Result<(), Self::Error>
-        where
-            O: IntoIterator<Item = Operation<'a>>,
-        {
             todo!()
         }
     }

--- a/src/gpio/dynamic.rs
+++ b/src/gpio/dynamic.rs
@@ -1,4 +1,5 @@
 use super::*;
+use embedded_hal_one::digital::ErrorKind;
 
 /// Pin type with dynamic mode
 ///
@@ -28,6 +29,12 @@ pub enum Dynamic {
 pub enum PinModeError {
     /// For operations unsupported in current mode
     IncorrectMode,
+}
+
+impl embedded_hal_one::digital::Error for PinModeError {
+    fn kind(&self) -> ErrorKind {
+        ErrorKind::Other
+    }
 }
 
 impl Dynamic {

--- a/src/gpio/hal_1.rs
+++ b/src/gpio/hal_1.rs
@@ -1,22 +1,13 @@
 use core::convert::Infallible;
 
 use super::{
-    dynamic::PinModeError, marker, DynamicPin, ErasedPin, Input, OpenDrain, Output,
-    PartiallyErasedPin, Pin, PinMode,
+    dynamic::PinModeError, marker, DynamicPin, ErasedPin, Output, PartiallyErasedPin, Pin,
 };
 
 pub use embedded_hal_one::digital::PinState;
 use embedded_hal_one::digital::{
-    blocking::{InputPin, IoPin, OutputPin, StatefulOutputPin, ToggleableOutputPin},
-    ErrorType,
+    ErrorType, InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin,
 };
-
-fn into_state(state: PinState) -> super::PinState {
-    match state {
-        PinState::Low => super::PinState::Low,
-        PinState::High => super::PinState::High,
-    }
-}
 
 // Implementations for `Pin`
 impl<const P: char, const N: u8, MODE> ErrorType for Pin<P, N, MODE> {
@@ -69,45 +60,6 @@ where
     #[inline(always)]
     fn is_low(&self) -> Result<bool, Self::Error> {
         Ok(self.is_low())
-    }
-}
-
-impl<const P: char, const N: u8> IoPin<Self, Self> for Pin<P, N, Output<OpenDrain>> {
-    type Error = Infallible;
-    fn into_input_pin(self) -> Result<Self, Self::Error> {
-        Ok(self)
-    }
-    fn into_output_pin(mut self, state: PinState) -> Result<Self, Self::Error> {
-        self.set_state(into_state(state));
-        Ok(self)
-    }
-}
-
-impl<const P: char, const N: u8, Otype> IoPin<Pin<P, N, Input>, Self> for Pin<P, N, Output<Otype>>
-where
-    Output<Otype>: PinMode,
-{
-    type Error = Infallible;
-    fn into_input_pin(self) -> Result<Pin<P, N, Input>, Self::Error> {
-        Ok(self.into_input())
-    }
-    fn into_output_pin(mut self, state: PinState) -> Result<Self, Self::Error> {
-        self.set_state(into_state(state));
-        Ok(self)
-    }
-}
-
-impl<const P: char, const N: u8, Otype> IoPin<Self, Pin<P, N, Output<Otype>>> for Pin<P, N, Input>
-where
-    Output<Otype>: PinMode,
-{
-    type Error = Infallible;
-    fn into_input_pin(self) -> Result<Self, Self::Error> {
-        Ok(self)
-    }
-    fn into_output_pin(mut self, state: PinState) -> Result<Pin<P, N, Output<Otype>>, Self::Error> {
-        self._set_state(into_state(state));
-        Ok(self.into_mode())
     }
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -6,7 +6,7 @@ use crate::rcc::{Enable, Reset};
 use crate::gpio;
 
 use crate::rcc::Clocks;
-use embedded_hal_one::i2c::blocking::Operation;
+use embedded_hal_one::i2c::Operation;
 use fugit::{HertzU32 as Hertz, RateExtU32};
 
 mod hal_02;

--- a/src/i2c/hal_1.rs
+++ b/src/i2c/hal_1.rs
@@ -18,22 +18,15 @@ impl<I2C: super::Instance> ErrorType for super::I2c<I2C> {
 
 mod blocking {
     use super::super::{I2c, Instance};
-    use embedded_hal_one::i2c::blocking::Operation;
+    use embedded_hal_one::i2c::Operation;
 
-    impl<I2C: Instance> embedded_hal_one::i2c::blocking::I2c for I2c<I2C> {
+    impl<I2C: Instance> embedded_hal_one::i2c::I2c for I2c<I2C> {
         fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
             self.read(addr, buffer)
         }
 
         fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
             self.write(addr, bytes)
-        }
-
-        fn write_iter<B>(&mut self, addr: u8, bytes: B) -> Result<(), Self::Error>
-        where
-            B: IntoIterator<Item = u8>,
-        {
-            self.write_iter(addr, bytes)
         }
 
         fn write_read(
@@ -45,32 +38,12 @@ mod blocking {
             self.write_read(addr, bytes, buffer)
         }
 
-        fn write_iter_read<B>(
-            &mut self,
-            addr: u8,
-            bytes: B,
-            buffer: &mut [u8],
-        ) -> Result<(), Self::Error>
-        where
-            B: IntoIterator<Item = u8>,
-        {
-            self.write_iter_read(addr, bytes, buffer)
-        }
-
         fn transaction(
             &mut self,
             addr: u8,
             operations: &mut [Operation<'_>],
         ) -> Result<(), Self::Error> {
             self.transaction_slice(addr, operations)
-        }
-
-        fn transaction_iter<'a, O>(&mut self, addr: u8, operations: O) -> Result<(), Self::Error>
-        where
-            O: IntoIterator<Item = Operation<'a>>,
-        {
-            let it = operations.into_iter();
-            self.transaction(addr, it)
         }
     }
 }

--- a/src/serial/hal_1.rs
+++ b/src/serial/hal_1.rs
@@ -18,10 +18,7 @@ mod nb {
     use core::ops::Deref;
 
     use super::super::{Error, Instance, RegisterBlockImpl, Rx, Serial, Tx};
-    use embedded_hal_one::serial::{
-        nb::{Read, Write},
-        ErrorType,
-    };
+    use embedded_hal_nb::serial::{ErrorType, Read, Write};
 
     impl<USART: Instance, WORD: Copy> Read<WORD> for Serial<USART, WORD>
     where
@@ -107,7 +104,7 @@ mod blocking {
 
     use super::super::{Instance, RegisterBlockImpl, Serial, Tx};
     use super::ErrorType;
-    use embedded_hal_one::serial::blocking::Write;
+    use embedded_hal_one::serial::Write;
 
     impl<USART: Instance, WORD: Copy> Write<WORD> for Serial<USART, WORD>
     where

--- a/src/spi/hal_1.rs
+++ b/src/spi/hal_1.rs
@@ -45,7 +45,7 @@ impl<SPI: Instance, const BIDI: bool, W> ErrorType for super::Spi<SPI, BIDI, W> 
 
 mod nb {
     use super::super::{Error, FrameSize, Instance, Spi};
-    use embedded_hal_one::spi::nb::FullDuplex;
+    use embedded_hal_nb::spi::FullDuplex;
 
     impl<SPI, const BIDI: bool, W: FrameSize> FullDuplex<W> for Spi<SPI, BIDI, W>
     where
@@ -63,10 +63,7 @@ mod nb {
 
 mod blocking {
     use super::super::{FrameSize, Instance, Spi};
-    use embedded_hal_one::spi::{
-        blocking::{SpiBus, SpiBusFlush, SpiBusRead, SpiBusWrite},
-        nb::FullDuplex,
-    };
+    use embedded_hal_one::spi::{SpiBus, SpiBusFlush, SpiBusRead, SpiBusWrite};
 
     impl<SPI, const BIDI: bool, W: FrameSize + 'static> SpiBus<W> for Spi<SPI, BIDI, W>
     where
@@ -112,8 +109,8 @@ mod blocking {
     {
         fn read(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
             for word in words {
-                nb::block!(<Self as FullDuplex<W>>::write(self, W::default()))?;
-                *word = nb::block!(<Self as FullDuplex<W>>::read(self))?;
+                nb::block!(self.write_nonblocking(W::default()))?;
+                *word = nb::block!(self.read_nonblocking())?;
             }
 
             Ok(())

--- a/src/timer/hal_1.rs
+++ b/src/timer/hal_1.rs
@@ -3,36 +3,27 @@
 //! TIM2 and TIM5 are a general purpose 32-bit auto-reload up/downcounter with
 //! a 16-bit prescaler.
 
-use core::convert::Infallible;
-use embedded_hal_one::delay::blocking::DelayUs;
+use embedded_hal_one::delay::DelayUs;
 
-use super::{Delay, Error, Instance, SysDelay};
+use super::{Delay, Instance, SysDelay};
 use fugit::ExtU32;
 
 impl DelayUs for SysDelay {
-    type Error = Infallible;
-
-    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+    fn delay_us(&mut self, us: u32) {
         self.delay(us.micros());
-
-        Ok(())
     }
 
-    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
-        self.delay_us(ms * 1_000)
+    fn delay_ms(&mut self, ms: u32) {
+        self.delay_us(ms * 1_000);
     }
 }
 
 impl<TIM: Instance, const FREQ: u32> DelayUs for Delay<TIM, FREQ> {
-    type Error = Error;
-
-    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+    fn delay_us(&mut self, us: u32) {
         self.delay(us.micros());
-        Ok(())
     }
 
-    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+    fn delay_ms(&mut self, ms: u32) {
         self.delay(ms.millis());
-        Ok(())
     }
 }

--- a/src/timer/hal_1.rs
+++ b/src/timer/hal_1.rs
@@ -3,9 +3,10 @@
 //! TIM2 and TIM5 are a general purpose 32-bit auto-reload up/downcounter with
 //! a 16-bit prescaler.
 
+use core::convert::Infallible;
 use embedded_hal_one::delay::DelayUs;
 
-use super::{Delay, Instance, SysDelay};
+use super::{Delay, Instance, PwmChannel, SysDelay, WithPwm};
 use fugit::ExtU32;
 
 impl DelayUs for SysDelay {
@@ -25,5 +26,21 @@ impl<TIM: Instance, const FREQ: u32> DelayUs for Delay<TIM, FREQ> {
 
     fn delay_ms(&mut self, ms: u32) {
         self.delay(ms.millis());
+    }
+}
+
+impl<TIM: Instance + WithPwm, const C: u8> embedded_hal_one::pwm::ErrorType for PwmChannel<TIM, C> {
+    type Error = Infallible;
+}
+
+impl<TIM: Instance + WithPwm, const C: u8> embedded_hal_one::pwm::SetDutyCycle
+    for PwmChannel<TIM, C>
+{
+    fn get_max_duty_cycle(&self) -> u16 {
+        self.get_max_duty()
+    }
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        self.set_duty(duty);
+        Ok(())
     }
 }


### PR DESCRIPTION
there were various breaking changes in alpha.9 and alpha.10 which have been applied here. see [their changelog][embedded-hal-1.0.0-alpha.10] for further details.

important: this is completely untested beyond "it compiles", please test this carefully!
compilation has been tested with the `stm32f401` feature, the CI will show whether it'll also compile for all others.

note that this does only the bare minimum to make it build against the new version - it does not implement any of the newly added APIs. this can be done in subsequent commits.

this fixes #602

[embedded-hal-1.0.0-alpha.10]: https://github.com/rust-embedded/embedded-hal/blob/v1.0.0-alpha.10/embedded-hal/CHANGELOG.md