### PR TITLE
Updating to embedded-storage 0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - complete and rework Dma Stream API [#666]
  - SPI bidi takes 2 pins [#526]
  - `Fast Read Quad I/O (EBh)` in `qspi-w25q` example now matches W25QXX datasheet. [#682]
+ - `embedded-storage` version bumped to 0.3
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ fugit-timer = "0.1.3"
 rtic-monotonic = { version = "1.0", optional = true }
 systick-monotonic = { version = "1.0", optional = true }
 bitflags = "2.2"
-embedded-storage = "0.2"
+embedded-storage = "0.3"
 vcell = "0.1.3"
 
 [dependencies.time]


### PR DESCRIPTION
This PR bumps the version of `embedded-storage` to 0.3, the latest version.