### PR TITLE
Require the RegisterBlock associated with a serial::Instance to implement RegisterBlockImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+ - add trait bound `RegisterBlockImpl` to type `RegisterBlock` associated with `serial::Instance` [#732]
+ - remove unneeded trait bound for methods that take in a `serial::Instance` and use the associated `RegisterBlock`
+
 ## [v0.20.0] - 2024-01-14
 
 ### Changed

--- a/src/serial/hal_02.rs
+++ b/src/serial/hal_02.rs
@@ -15,10 +15,7 @@ mod nb {
         }
     }
 
-    impl<USART: Instance> Read<u8> for Rx<USART, u8>
-    where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
-    {
+    impl<USART: Instance> Read<u8> for Rx<USART, u8> {
         type Error = Error;
 
         fn read(&mut self) -> nb::Result<u8, Self::Error> {
@@ -31,10 +28,7 @@ mod nb {
     /// If the UART/USART was configured with `WordLength::DataBits9`, the returned value will contain
     /// 9 received data bits and all other bits set to zero. Otherwise, the returned value will contain
     /// 8 received data bits and all other bits set to zero.
-    impl<USART: Instance> Read<u16> for Rx<USART, u16>
-    where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
-    {
+    impl<USART: Instance> Read<u16> for Rx<USART, u16> {
         type Error = Error;
 
         fn read(&mut self) -> nb::Result<u16, Self::Error> {
@@ -59,7 +53,6 @@ mod nb {
 
     impl<USART: Instance> Write<u8> for Tx<USART, u8>
     where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
         USART: Deref<Target = <USART as Instance>::RegisterBlock>,
     {
         type Error = Error;
@@ -79,7 +72,6 @@ mod nb {
     /// will be transmitted and the other 8 bits will be ignored.
     impl<USART: Instance> Write<u16> for Tx<USART, u16>
     where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
         USART: Deref<Target = <USART as Instance>::RegisterBlock>,
     {
         type Error = Error;
@@ -102,7 +94,6 @@ mod blocking {
 
     impl<USART: Instance> Write<u8> for Tx<USART, u8>
     where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
         USART: Deref<Target = <USART as Instance>::RegisterBlock>,
     {
         type Error = Error;
@@ -133,7 +124,6 @@ mod blocking {
 
     impl<USART: Instance> Write<u16> for Tx<USART, u16>
     where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
         USART: Deref<Target = <USART as Instance>::RegisterBlock>,
     {
         type Error = Error;

--- a/src/serial/hal_1.rs
+++ b/src/serial/hal_1.rs
@@ -35,10 +35,7 @@ mod nb {
         }
     }
 
-    impl<USART: Instance> Read<u8> for Rx<USART, u8>
-    where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
-    {
+    impl<USART: Instance> Read<u8> for Rx<USART, u8> {
         fn read(&mut self) -> nb::Result<u8, Self::Error> {
             unsafe { (*USART::ptr()).read_u8() }
         }
@@ -49,10 +46,7 @@ mod nb {
     /// If the UART/USART was configured with `WordLength::DataBits9`, the returned value will contain
     /// 9 received data bits and all other bits set to zero. Otherwise, the returned value will contain
     /// 8 received data bits and all other bits set to zero.
-    impl<USART: Instance> Read<u16> for Rx<USART, u16>
-    where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
-    {
+    impl<USART: Instance> Read<u16> for Rx<USART, u16> {
         fn read(&mut self) -> nb::Result<u16, Self::Error> {
             unsafe { (*USART::ptr()).read_u16() }
         }
@@ -73,7 +67,6 @@ mod nb {
 
     impl<USART: Instance> Write<u8> for Tx<USART, u8>
     where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
         USART: Deref<Target = <USART as Instance>::RegisterBlock>,
     {
         fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
@@ -91,7 +84,6 @@ mod nb {
     /// will be transmitted and the other 8 bits will be ignored.
     impl<USART: Instance> Write<u16> for Tx<USART, u16>
     where
-        <USART as Instance>::RegisterBlock: RegisterBlockImpl,
         USART: Deref<Target = <USART as Instance>::RegisterBlock>,
     {
         fn write(&mut self, word: u16) -> nb::Result<(), Self::Error> {

--- a/src/serial/uart_impls.rs
+++ b/src/serial/uart_impls.rs
@@ -23,7 +23,7 @@ impl crate::Sealed for RegisterBlockUsart {}
 
 // Implemented by all USART/UART instances
 pub trait Instance: crate::Sealed + rcc::Enable + rcc::Reset + rcc::BusClock + CommonPins {
-    type RegisterBlock;
+    type RegisterBlock: RegisterBlockImpl;
 
     #[doc(hidden)]
     fn ptr() -> *const Self::RegisterBlock;
@@ -343,10 +343,7 @@ where
     }
 }
 
-impl<UART: Instance, WORD> RxISR for Rx<UART, WORD>
-where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
-{
+impl<UART: Instance, WORD> RxISR for Rx<UART, WORD> {
     fn is_idle(&self) -> bool {
         unsafe { (*UART::ptr()).is_idle() }
     }
@@ -374,7 +371,6 @@ where
 
 impl<UART: Instance, WORD> TxISR for Tx<UART, WORD>
 where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
     UART: Deref<Target = <UART as Instance>::RegisterBlock>,
 {
     fn is_tx_empty(&self) -> bool {
@@ -382,10 +378,7 @@ where
     }
 }
 
-impl<UART: Instance, WORD> RxListen for Rx<UART, WORD>
-where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
-{
+impl<UART: Instance, WORD> RxListen for Rx<UART, WORD> {
     fn listen(&mut self) {
         unsafe { (*UART::ptr()).listen_rxne() }
     }
@@ -405,7 +398,6 @@ where
 
 impl<UART: Instance, WORD> TxListen for Tx<UART, WORD>
 where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
     UART: Deref<Target = <UART as Instance>::RegisterBlock>,
 {
     fn listen(&mut self) {
@@ -419,7 +411,6 @@ where
 
 impl<UART: Instance, WORD> crate::ClearFlags for Serial<UART, WORD>
 where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
     UART: Deref<Target = <UART as Instance>::RegisterBlock>,
 {
     type Flag = CFlag;
@@ -432,7 +423,6 @@ where
 
 impl<UART: Instance, WORD> crate::ReadFlags for Serial<UART, WORD>
 where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
     UART: Deref<Target = <UART as Instance>::RegisterBlock>,
 {
     type Flag = Flag;
@@ -445,7 +435,6 @@ where
 
 impl<UART: Instance, WORD> crate::Listen for Serial<UART, WORD>
 where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
     UART: Deref<Target = <UART as Instance>::RegisterBlock>,
 {
     type Event = Event;
@@ -479,7 +468,6 @@ where
 
 impl<UART: Instance> fmt::Write for Tx<UART>
 where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
     UART: Deref<Target = <UART as Instance>::RegisterBlock>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
@@ -489,10 +477,7 @@ where
     }
 }
 
-impl<UART: Instance> SerialExt for UART
-where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
-{
+impl<UART: Instance> SerialExt for UART {
     fn serial<WORD>(
         self,
         pins: (impl Into<Self::Tx<PushPull>>, impl Into<Self::Rx<PushPull>>),
@@ -525,10 +510,7 @@ where
     }
 }
 
-impl<UART: Instance, WORD> Serial<UART, WORD>
-where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
-{
+impl<UART: Instance, WORD> Serial<UART, WORD> {
     pub fn tx(
         usart: UART,
         tx_pin: impl Into<UART::Tx<PushPull>>,
@@ -542,10 +524,7 @@ where
     }
 }
 
-impl<UART: Instance, WORD> Serial<UART, WORD>
-where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
-{
+impl<UART: Instance, WORD> Serial<UART, WORD> {
     pub fn rx(
         usart: UART,
         rx_pin: impl Into<UART::Rx<PushPull>>,
@@ -559,10 +538,7 @@ where
     }
 }
 
-unsafe impl<UART: Instance> PeriAddress for Rx<UART, u8>
-where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
-{
+unsafe impl<UART: Instance> PeriAddress for Rx<UART, u8> {
     #[inline(always)]
     fn address(&self) -> u32 {
         unsafe { (*UART::ptr()).peri_address() }
@@ -580,7 +556,6 @@ where
 
 unsafe impl<UART: Instance> PeriAddress for Tx<UART, u8>
 where
-    <UART as Instance>::RegisterBlock: RegisterBlockImpl,
     UART: Deref<Target = <UART as Instance>::RegisterBlock>,
 {
     #[inline(always)]


### PR DESCRIPTION
The `Serial::new` method cannot be called using a generic `serial::Instance` because the `Instance` trait does not require that the associated `RegisterBlock` implements `RegisterBlockImpl`. See the example below.

```rust
use stm32f4xx_hal::{
    gpio::PushPull,
    prelude::*,
    rcc::Clocks,
    serial::{Instance, Serial},
    uart::config::InvalidConfig,
};

struct SerialConnection<UartX: Instance>(Serial<UartX, u8>);

fn make_serial<UartX: Instance>(
    usart: UartX,
    tx: impl Into<UartX::Tx<PushPull>>,
    rx: impl Into<UartX::Rx<PushPull>>,
    baud_rate: u32,
    clocks: &Clocks,
) -> Result<SerialConnection<UartX>, InvalidConfig> {
    Serial::<_, u8>::new(usart, (tx, rx), baud_rate.bps(), &clocks)
        .map(|conn| SerialConnection(conn))
}
```
This fails to compile with the following error.
```
error[E0277]: the trait bound `<UartX as stm32f4xx_hal::serial::Instance>::RegisterBlock: stm32f4xx_hal::serial::uart_impls::RegisterBlockImpl` is not satisfied
   --> src/main.rs:18:26
    |
18  |     Serial::<_, u8>::new(usart, (tx, rx), baud_rate.bps(), &clo...
    |     -------------------- ^^^^^ the trait `stm32f4xx_hal::serial::uart_impls::RegisterBlockImpl` is not implemented for `<UartX as stm32f4xx_hal::serial::Instance>::RegisterBlock`
    |     |
    |     required by a bound introduced by this call
    |
note: required by a bound in `Serial::<USART, WORD>::new`
   --> /home/george/.cargo/registry/src/index.crates.io-6f17d22bba15001f/stm32f4xx-hal-0.20.0/src/serial.rs:233:45
    |
223 | ...fn new(
    |       --- required by a bound in this associated function
...
233 | ...<USART as Instance>::RegisterBlock: uart_impls::RegisterBlockIm...
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Serial::<USART, WORD>::new`
help: consider further restricting the associated type
    |
17  | ) -> Result<SerialConnection<UartX>, InvalidConfig> where <UartX as stm32f4xx_hal::serial::Instance>::RegisterBlock: stm32f4xx_hal::serial::uart_impls::RegisterBlockImpl {
    |                                                     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```

Every `Instance` has a `RegisterBlock` that implements `RegisterBlockImpl`, so we can simply require it. This also makes many trait bounds unneeded. There are many impl block that require `where <USART as Instance>::RegisterBlock: RegisterBlockImpl,`. But since `RegisterBlock` always implements `RegisterBlockImpl`, those lines are unneeded.

Let me know if I've misunderstood something. I think this is fine, but I'm still figuring out how this crate works.

Thank you!