### PR TITLE
Sdio-host: update to 0.9.0, add AddressMode enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
  - add trait bound `RegisterBlockImpl` to type `RegisterBlock` associated with `serial::Instance` [#732]
  - remove unneeded trait bound for methods that take in a `serial::Instance` and use the associated `RegisterBlock`
+ - bump `sdio-host` to 0.9.0, refactor SDIO initialization [#734]
 
 ## [v0.20.0] - 2024-01-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ nb = "1.1"
 rand_core = "0.6.4"
 stm32f4 = "0.15.1"
 synopsys-usb-otg = { version = "0.4.0", features = ["cortex-m"], optional = true }
-sdio-host = { version = "0.6.0", optional = true }
+sdio-host = { version = "0.9.0", optional = true }
 embedded-dma = "0.2.0"
 bare-metal = { version = "1" }
 void = { default-features = false, version = "1.0.2" }


### PR DESCRIPTION
Bump sdio-host to 0.9.0, which includes new voltabe_range format for send_op_conditon, generic arguments for registers (SD, EMMC).

Significantly, the SdioPeripheral::get_capacity() method has been replaced with SdioPeripheral::get_address_mode(). This change provides a more intuitive and accurate representation for eMMC cards, which unlike SD cards, do not have a distinction between standard and high capacity variants and uniformly use block addressing. The previous implementation relied on the high capacity bit in the OCR register, which is not applicable to eMMC cards. This bit has been removed in the sdio-host library to reflect the correct specifications for eMMC cards.

Was not tested yet, i don't have eMMC card, but I can test with SD card tomorrow.

(Recreated #733)