### PR TITLE
Fix transmission termination in I2C DMA master read.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - remove unneeded trait bound for methods that take in a `serial::Instance` and use the associated `RegisterBlock`
  - bump `sdio-host` to 0.9.0, refactor SDIO initialization [#734]
 
+### Fixed
+
+ - Fix transmission termination in I2C master DMA read [#736]
+
 ## [v0.20.0] - 2024-01-14
 
 ### Changed


### PR DESCRIPTION
We should set the `last` control bit in I2C when the read length is larger than or equal to 2 and when using DMA in master mode.

Failing to set the `last` bit leads to elusive bugs that will be revealed only when the system is under some stress. In the following example, the I2C and DMA is configured to read 6 bytes from a peripheral.

When the `last` bit is not set, the I2C interface will not respond the peripheral with NACK after receiving the 6th byte, causing the peripheral to continue to transmit the 7th byte. The DMA interrupt, however, will be triggered after receiving the 6th byte. When the system is not under stress, the DMA interrupt will get served promptly. Inside the ISR the I2C `stop` bit will be programed, causing the peripheral to terminate the transmission. Even though the I2C master receives one more byte than requested by the user code, it will not get stuck in this case. The sequence is shown with the following figure.

![image](https://github.com/stm32-rs/stm32f4xx-hal/assets/98667854/00029969-3809-44fd-8d1a-4dc4d1237b87)

In contrast, when the system is under stress, the DMA interrupt will not be served promptly, e.g., when there exists other higher priority interrupts. In this case, the peripheral continues to transmit the 7th and 8th byte. However, since the DMA has stopped fetching bytes from the I2C `dr` register after receiving the 6th byte, the 7th bytes will stay in the `dr` register while the 8th byte stay in the shift-in register.

The I2C bus will get stuck after reaching this condition. Now the I2C master interface will be stretching the SCL line to low to prevent the peripheral from sending any more bit, while the peripheral is holding the SDA line trying to send more bit. Since the peripheral is controlling SDA line, the I2C master has no way to send a stop condition by raising SDA to high. The following figure shows the transmission on the I2C bus before it gets stuck.

![image](https://github.com/stm32-rs/stm32f4xx-hal/assets/98667854/8d7072ae-9898-432b-b9ab-81cb3d804f33)

The bug can be fixed simply by setting the `last` control bit when it is required by STM32 reference manual RM0090.

