### PR TITLE
Prevent starting a new I2C transmission before previous stop finishes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - Fix transmission termination in I2C master DMA read [#736]
+ - Prevent starting a new I2C transmission before previous stop finishes [#737]
 
 ## [v0.20.0] - 2024-01-14
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -285,6 +285,9 @@ impl<I2C: Instance> I2c<I2C> {
     /// Sends START and Address for writing
     #[inline(always)]
     fn prepare_write(&self, addr: u8) -> Result<(), Error> {
+        // Wait until a previous STOP condition finishes
+        while self.i2c.cr1.read().stop().bit_is_set() {}
+
         // Send a START condition
         self.i2c.cr1.modify(|_, w| w.start().set_bit());
 
@@ -327,6 +330,9 @@ impl<I2C: Instance> I2c<I2C> {
 
     /// Sends START and Address for reading
     fn prepare_read(&self, addr: u8) -> Result<(), Error> {
+        // Wait until a previous STOP condition finishes
+        while self.i2c.cr1.read().stop().bit_is_set() {}
+
         // Send a START condition and set ACK bit
         self.i2c
             .cr1
@@ -443,9 +449,6 @@ impl<I2C: Instance> I2c<I2C> {
             // Receive last byte
             *last = self.recv_byte()?;
 
-            // Wait for the STOP to be sent.
-            while self.i2c.cr1.read().stop().bit_is_set() {}
-
             // Fallthrough is success
             Ok(())
         } else {
@@ -465,9 +468,6 @@ impl<I2C: Instance> I2c<I2C> {
         // Send a STOP condition
         self.i2c.cr1.modify(|_, w| w.stop().set_bit());
 
-        // Wait for STOP condition to transmit.
-        while self.i2c.cr1.read().stop().bit_is_set() {}
-
         // Fallthrough is success
         Ok(())
     }
@@ -481,9 +481,6 @@ impl<I2C: Instance> I2c<I2C> {
 
         // Send a STOP condition
         self.i2c.cr1.modify(|_, w| w.stop().set_bit());
-
-        // Wait for STOP condition to transmit.
-        while self.i2c.cr1.read().stop().bit_is_set() {}
 
         // Fallthrough is success
         Ok(())

--- a/src/i2c/dma.rs
+++ b/src/i2c/dma.rs
@@ -628,7 +628,6 @@ where
                 // Wait for BTF
                 while self.hal_i2c.i2c.sr1.read().btf().bit_is_clear() {}
 
-                // Generate stop and wait for it
                 self.send_stop();
             }
         }
@@ -668,7 +667,7 @@ where
 
                 // Clear ACK
                 self.hal_i2c.i2c.cr1.modify(|_, w| w.ack().clear_bit());
-                // Generate stop and wait for it
+
                 self.send_stop();
             }
         }
@@ -730,7 +729,6 @@ where
 
                     self.rx.rx_transfer.as_mut().unwrap().start(|_| {});
                 } else {
-                    // Generate stop and wait for it
                     self.send_stop();
                 }
             }
@@ -756,7 +754,7 @@ where
 
                 // Clear ACK
                 self.hal_i2c.i2c.cr1.modify(|_, w| w.ack().clear_bit());
-                // Generate stop and wait for it
+
                 self.send_stop();
             }
         }


### PR DESCRIPTION
When a stop condition is generated by the I2C DMA ([example](https://github.com/stm32-rs/stm32f4xx-hal/blob/533797526ec093d5c04bad02171cba856e30d20d/src/i2c/dma.rs#L632)), the [code](https://github.com/stm32-rs/stm32f4xx-hal/blob/533797526ec093d5c04bad02171cba856e30d20d/src/i2c/dma.rs#L456-L458) does not wait for the finish of the stop condition. However, the [comments](https://github.com/stm32-rs/stm32f4xx-hal/blob/533797526ec093d5c04bad02171cba856e30d20d/src/i2c/dma.rs#L631) **falsely** indicate that there will be a spin-wait.

The I2C interface can get stuck if a new I2C transmission attempts to start while the previous stop condition is being generated. The new transaction will be inadvertently terminated by the previous stop condition. Subsequently, the I2C interface gets stuck. The following figure shows that a previous stop condition being generated can immediately terminate a new start condition, and after that the I2C interface is stuck.

![image](https://github.com/stm32-rs/stm32f4xx-hal/assets/98667854/4ed440ea-1cf2-4f99-9d24-c62da7740854)

Since ISRs should finish as quickly as possible, the fix should not let ISRs spin-wait in the interrupt handler until the stop condition finishes. Instead, the spin-wait should be placed before starting a new transmission.

The patch also removes incorrect comments that falsely indicate that the code will spin-wait until the stop condition finishes.