### PR TITLE
Implement Serial DMA abstraction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - add trait bound `RegisterBlockImpl` to type `RegisterBlock` associated with `serial::Instance` [#732]
  - remove unneeded trait bound for methods that take in a `serial::Instance` and use the associated `RegisterBlock`
  - bump `sdio-host` to 0.9.0, refactor SDIO initialization [#734]
+ - Added non-blocking serial based on DMA [#738]
  - use RTCCLK for RTC wakeup timer for short durations [#746]
  - Support 8-bit FMC data bus
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,6 +507,10 @@ name = "serial-9bit"
 required-features = ["gpiod"] # stm32f411
 
 [[example]]
+name = "serial-dma"
+required-features = ["stm32f407"]
+
+[[example]]
 name = "spi-dma"
 required-features = ["stm32f411"]
 

--- a/examples/serial-dma.rs
+++ b/examples/serial-dma.rs
@@ -1,0 +1,156 @@
+#![no_std]
+#![no_main]
+
+use core::{
+    cell::RefCell,
+    sync::atomic::{AtomicBool, Ordering},
+};
+use cortex_m::interrupt::Mutex;
+use cortex_m_rt::entry;
+use panic_halt as _;
+use stm32f4xx_hal::{
+    self,
+    dma::{StreamX, StreamsTuple},
+    interrupt,
+    pac::{self, DMA1, USART2},
+    prelude::*,
+    serial::{
+        self,
+        dma::{RxDMA, SerialDma, TxDMA},
+    },
+    uart::{config::StopBits, Config, Serial},
+};
+
+/// Global variable for USART2 DMA handle.
+static USART2_DMA: Mutex<
+    RefCell<
+        Option<
+            SerialDma<
+                USART2,
+                TxDMA<USART2, StreamX<DMA1, 6>, 4>,
+                RxDMA<USART2, StreamX<DMA1, 5>, 4>,
+            >,
+        >,
+    >,
+> = Mutex::new(RefCell::new(None));
+
+/// Boolean flag to wait for DMA finish.
+static DONE: AtomicBool = AtomicBool::new(false);
+
+#[entry]
+fn main() -> ! {
+    if let Some(dp) = pac::Peripherals::take() {
+        // Set up the system clock.
+        let rcc = dp.RCC.constrain();
+        let clocks = rcc.cfgr.freeze();
+
+        // Enable DMA1.
+        let dma1 = StreamsTuple::new(dp.DMA1);
+
+        // Enable GPIOA.
+        let gpioa = dp.GPIOA.split();
+
+        // Configure USART2.
+        let rx_2 = gpioa.pa3.into_alternate();
+        let tx_2 = gpioa.pa2.into_alternate();
+        let usart2 = Serial::new(
+            dp.USART2,
+            (tx_2, rx_2),
+            Config::default()
+                .baudrate(115200.bps())
+                .parity_none()
+                .stopbits(StopBits::STOP1)
+                .dma(serial::config::DmaConfig::TxRx),
+            &clocks,
+        )
+        .unwrap();
+
+        // Make USART2 use DMA.
+        let usart2_dma = usart2.use_dma(dma1.6, dma1.5);
+
+        // Put DMA handle to the global variable.
+        cortex_m::interrupt::free(|cs| {
+            USART2_DMA.borrow(cs).borrow_mut().replace(usart2_dma);
+        });
+
+        // Enable interrupt
+        unsafe {
+            cortex_m::peripheral::NVIC::unmask(pac::Interrupt::USART2);
+            cortex_m::peripheral::NVIC::unmask(pac::Interrupt::DMA1_STREAM5);
+            cortex_m::peripheral::NVIC::unmask(pac::Interrupt::DMA1_STREAM6);
+        }
+
+        /*** Test Below ***/
+
+        let mut buf = [0u8; 6];
+
+        // Read 6 bytes to the buffer using the DMA non-blocking mode.
+        cortex_m::interrupt::free(|cs| unsafe {
+            if let Some(usart2_dma) = USART2_DMA.borrow(cs).borrow_mut().as_mut() {
+                usart2_dma.read_dma(&mut buf, None).unwrap();
+            }
+        });
+
+        // Wait until DMA finishes.
+        while !DONE.load(Ordering::SeqCst) {}
+        DONE.store(false, Ordering::SeqCst);
+
+        // Write the 6 bytes back using the DMA non-blocking mode.
+        cortex_m::interrupt::free(|cs| unsafe {
+            if let Some(usart2_dma) = USART2_DMA.borrow(cs).borrow_mut().as_mut() {
+                usart2_dma.write_dma(&buf, None).unwrap();
+            }
+        });
+
+        // Wait until DMA finishes.
+        while !DONE.load(Ordering::SeqCst) {}
+
+        // Read 6 bytes to the buffer using the blocking mode.
+        cortex_m::interrupt::free(|cs| {
+            if let Some(usart2_dma) = USART2_DMA.borrow(cs).borrow_mut().as_mut() {
+                usart2_dma.read(&mut buf).unwrap();
+            }
+        });
+
+        // Write the 6 bytes back using the blocking mode.
+        cortex_m::interrupt::free(|cs| {
+            if let Some(usart2_dma) = USART2_DMA.borrow(cs).borrow_mut().as_mut() {
+                usart2_dma.write(&buf).unwrap();
+            }
+        });
+    }
+
+    loop {}
+}
+
+#[interrupt]
+#[allow(non_snake_case)]
+fn USART2() {
+    cortex_m::interrupt::free(|cs| {
+        if let Some(usart2_dma) = USART2_DMA.borrow(cs).borrow_mut().as_mut() {
+            usart2_dma.handle_error_interrupt();
+        }
+    });
+}
+
+#[interrupt]
+#[allow(non_snake_case)]
+fn DMA1_STREAM5() {
+    cortex_m::interrupt::free(|cs| {
+        if let Some(usart2_dma) = USART2_DMA.borrow(cs).borrow_mut().as_mut() {
+            usart2_dma.handle_dma_interrupt();
+            DONE.store(true, Ordering::SeqCst);
+        }
+    });
+}
+
+#[interrupt]
+#[allow(non_snake_case)]
+fn DMA1_STREAM6() {
+    cortex_m::interrupt::free(|cs| {
+        if let Some(usart2_dma) = USART2_DMA.borrow(cs).borrow_mut().as_mut() {
+            usart2_dma.handle_dma_interrupt();
+            DONE.store(true, Ordering::SeqCst);
+        }
+    });
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -68,6 +68,9 @@ pub use crate::qei::QeiExt as _stm32f4xx_hal_QeiExt;
 pub use crate::rcc::RccExt as _stm32f4xx_hal_rcc_RccExt;
 #[cfg(feature = "rng")]
 pub use crate::rng::RngExt as _stm32f4xx_hal_rng_RngExt;
+pub use crate::serial::dma::SerialHandleIT as _stm32f4xx_hal_serial_dma_SerialHandleIT;
+pub use crate::serial::dma::SerialReadDMA as _stm32f4xx_hal_serial_dma_SerialReadDMA;
+pub use crate::serial::dma::SerialWriteDMA as _stm32f4xx_hal_serial_dma_SerialWriteDMA;
 pub use crate::serial::RxISR as _stm32f4xx_hal_serial_RxISR;
 pub use crate::serial::RxListen as _stm32f4xx_hal_serial_RxListen;
 pub use crate::serial::SerialExt as _stm32f4xx_hal_serial_SerialExt;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -30,6 +30,8 @@ use crate::pac;
 use crate::gpio::NoPin;
 use crate::rcc::Clocks;
 
+pub mod dma;
+
 /// Serial error kind
 ///
 /// This represents a common set of serial operation errors. HAL implementations are
@@ -272,6 +274,10 @@ macro_rules! halUsart {
                         StopBits::STOP2 => STOP_A::Stop2,
                     })
                 });
+            }
+
+            fn peri_address() -> u32 {
+                unsafe { (*(<$USART>::ptr() as *const Self::RegisterBlock)).peri_address() }
             }
         }
     };

--- a/src/serial/dma.rs
+++ b/src/serial/dma.rs
@@ -1,0 +1,658 @@
+use core::{marker::PhantomData, mem::transmute, ops::Deref};
+
+use super::{Instance, RegisterBlockImpl, Serial};
+use crate::dma::{
+    config::DmaConfig,
+    traits::{Channel, DMASet, DmaFlagExt, PeriAddress, Stream, StreamISR},
+    ChannelX, MemoryToPeripheral, PeripheralToMemory, Transfer,
+};
+use crate::ReadFlags;
+
+use nb;
+
+#[non_exhaustive]
+pub enum Error {
+    SerialError(super::Error),
+    TransferError,
+}
+
+/// Tag for TX/RX channel that a corresponding channel should not be used in DMA mode
+#[non_exhaustive]
+pub struct NoDMA;
+
+/// Callback type to notify user code of completion serial transfers
+pub type SerialCompleteCallback = fn(Result<(), Error>);
+
+pub trait SerialWriteDMA {
+    /// Writes `bytes` to the serial interface in non-blocking mode
+    ///
+    /// # Arguments
+    /// * `bytes` - byte slice that need to send
+    /// * `callback` - callback that will be called on completion
+    ///
+    /// # Safety
+    /// This function relies on supplied slice `bytes` until `callback` called. So the slice must live until that moment.
+    ///
+    /// # Warning
+    /// `callback` may be called before function returns value. It happens on errors in preparation stages.
+    unsafe fn write_dma(
+        &mut self,
+        bytes: &[u8],
+        callback: Option<SerialCompleteCallback>,
+    ) -> nb::Result<(), super::Error>;
+}
+
+pub trait SerialReadDMA {
+    /// Reads bytes from the serial interface in non-blocking mode and writes these bytes in `buf`
+    ///
+    /// # Arguments
+    /// * `buf` - byte slice where received bytes will be written
+    /// * `callback` - callback that will be called on completion
+    ///
+    /// # Safety
+    /// This function relies on supplied slice `buf` until `callback` called. So the slice must live until that moment.
+    ///
+    /// # Warning
+    /// `callback` may be called before function returns value. It happens on errors in preparation stages.
+    unsafe fn read_dma(
+        &mut self,
+        buf: &mut [u8],
+        callback: Option<SerialCompleteCallback>,
+    ) -> nb::Result<(), super::Error>;
+}
+
+/// Trait with handle interrupts functions
+pub trait SerialHandleIT {
+    fn handle_dma_interrupt(&mut self);
+    fn handle_error_interrupt(&mut self);
+}
+
+impl<Serial_> Serial<Serial_>
+where
+    Serial_: Instance,
+    Serial_: Deref<Target = <Serial_ as Instance>::RegisterBlock>,
+    <Serial_ as Instance>::RegisterBlock: RegisterBlockImpl,
+{
+    /// Converts blocking [Serial] to non-blocking [SerialDma] that use `tx_stream` and `rx_stream` to send/receive data
+    pub fn use_dma<TX_STREAM, const TX_CH: u8, RX_STREAM, const RX_CH: u8>(
+        self,
+        tx_stream: TX_STREAM,
+        rx_stream: RX_STREAM,
+    ) -> SerialDma<Serial_, TxDMA<Serial_, TX_STREAM, TX_CH>, RxDMA<Serial_, RX_STREAM, RX_CH>>
+    where
+        TX_STREAM: Stream,
+        ChannelX<TX_CH>: Channel,
+        Tx<Serial_>: DMASet<TX_STREAM, TX_CH, MemoryToPeripheral>,
+
+        RX_STREAM: Stream,
+        ChannelX<RX_CH>: Channel,
+        Rx<Serial_>: DMASet<RX_STREAM, RX_CH, PeripheralToMemory>,
+    {
+        let tx = TxDMA::new(tx_stream);
+        let rx = RxDMA::new(rx_stream);
+
+        SerialDma {
+            hal_serial: self,
+            callback: None,
+            tx,
+            rx,
+        }
+    }
+
+    /// Converts blocking [Serial] to non-blocking [SerialDma] that use `tx_stream` to only send data
+    pub fn use_dma_tx<TX_STREAM, const TX_CH: u8>(
+        self,
+        tx_stream: TX_STREAM,
+    ) -> SerialDma<Serial_, TxDMA<Serial_, TX_STREAM, TX_CH>, NoDMA>
+    where
+        TX_STREAM: Stream,
+        ChannelX<TX_CH>: Channel,
+        Tx<Serial_>: DMASet<TX_STREAM, TX_CH, MemoryToPeripheral>,
+    {
+        let tx = TxDMA::new(tx_stream);
+        let rx = NoDMA;
+
+        SerialDma {
+            hal_serial: self,
+            callback: None,
+            tx,
+            rx,
+        }
+    }
+
+    /// Converts blocking [Serial] to non-blocking [SerialDma] that use `rx_stream` to only receive data
+    pub fn use_dma_rx<RX_STREAM, const RX_CH: u8>(
+        self,
+        rx_stream: RX_STREAM,
+    ) -> SerialDma<Serial_, NoDMA, RxDMA<Serial_, RX_STREAM, RX_CH>>
+    where
+        RX_STREAM: Stream,
+        ChannelX<RX_CH>: Channel,
+        Rx<Serial_>: DMASet<RX_STREAM, RX_CH, PeripheralToMemory>,
+    {
+        let tx = NoDMA;
+        let rx = RxDMA::new(rx_stream);
+
+        SerialDma {
+            hal_serial: self,
+            callback: None,
+            tx,
+            rx,
+        }
+    }
+}
+
+/// Serial abstraction that can work in non-blocking mode by using DMA
+///
+/// The struct should be used for sending/receiving bytes to/from the serial interface in non-blocking mode.
+/// A client must follow these requirements to use that feature:
+/// * Enable interrupts DMAx_STREAMy used for transmit and another DMAq_STREAMp used for receive.
+/// * In these interrupts call [`handle_dma_interrupt`](Self::handle_dma_interrupt); defined in trait SerialHandleIT.
+/// * Enable interrupts USARTx or UARTx for handling errors and call [`handle_error_interrupt`](Self::handle_error_interrupt) in corresponding handler; defined in trait SerialHandleIT.
+///
+/// The struct can be also used to send/receive bytes in blocking mode with methods:
+/// [`write`](Self::write()), [`read`](Self::read()), [`write_read`](Self::write_read()).
+pub struct SerialDma<Serial_, TX_TRANSFER, RX_TRANSFER>
+where
+    Serial_: Instance,
+{
+    hal_serial: Serial<Serial_>,
+    callback: Option<SerialCompleteCallback>,
+    tx: TX_TRANSFER,
+    rx: RX_TRANSFER,
+}
+
+/// trait for DMA transfer holder
+pub trait DMATransfer<BUF> {
+    /// Creates DMA Transfer using specified buffer
+    fn create_transfer(&mut self, buf: BUF);
+    /// Destroys created transfer
+    /// # Panics
+    ///   - If transfer had not created before
+    fn destroy_transfer(&mut self);
+    /// Checks if transfer created
+    fn created(&self) -> bool;
+}
+
+// Mock implementations for NoDMA
+// For Tx operations
+impl DMATransfer<&'static [u8]> for NoDMA {
+    fn create_transfer(&mut self, _: &'static [u8]) {
+        unreachable!()
+    }
+    fn destroy_transfer(&mut self) {
+        unreachable!()
+    }
+    fn created(&self) -> bool {
+        false
+    }
+}
+// ... and for Rx operations
+impl DMATransfer<&'static mut [u8]> for NoDMA {
+    fn create_transfer(&mut self, _: &'static mut [u8]) {
+        unreachable!()
+    }
+    fn destroy_transfer(&mut self) {
+        unreachable!()
+    }
+    fn created(&self) -> bool {
+        false
+    }
+}
+
+/// DMA Transfer holder for Tx operations
+pub struct TxDMA<Serial_, TX_STREAM, const TX_CH: u8>
+where
+    Serial_: Instance,
+    TX_STREAM: Stream,
+{
+    tx: Option<Tx<Serial_>>,
+    tx_stream: Option<TX_STREAM>,
+    tx_transfer: Option<Transfer<TX_STREAM, TX_CH, Tx<Serial_>, MemoryToPeripheral, &'static [u8]>>,
+}
+
+impl<Serial_, TX_STREAM, const TX_CH: u8> TxDMA<Serial_, TX_STREAM, TX_CH>
+where
+    Serial_: Instance,
+    TX_STREAM: Stream,
+{
+    fn new(stream: TX_STREAM) -> Self {
+        let tx = Tx {
+            serial: PhantomData,
+        };
+
+        Self {
+            tx: Some(tx),
+            tx_stream: Some(stream),
+            tx_transfer: None,
+        }
+    }
+}
+
+impl<Serial_, TX_STREAM, const TX_CH: u8> DMATransfer<&'static [u8]>
+    for TxDMA<Serial_, TX_STREAM, TX_CH>
+where
+    Serial_: Instance,
+    TX_STREAM: Stream,
+    ChannelX<TX_CH>: Channel,
+    Tx<Serial_>: DMASet<TX_STREAM, TX_CH, MemoryToPeripheral>,
+{
+    fn create_transfer(&mut self, buf: &'static [u8]) {
+        assert!(self.tx.is_some());
+        assert!(self.tx_stream.is_some());
+
+        let transfer = Transfer::init_memory_to_peripheral(
+            self.tx_stream.take().unwrap(),
+            self.tx.take().unwrap(),
+            buf,
+            None,
+            DmaConfig::default()
+                .memory_increment(true)
+                .transfer_complete_interrupt(true)
+                .transfer_error_interrupt(true),
+        );
+
+        self.tx_transfer = Some(transfer);
+    }
+
+    fn destroy_transfer(&mut self) {
+        assert!(self.tx_transfer.is_some());
+
+        let (str, tx, ..) = self.tx_transfer.take().unwrap().release();
+        self.tx = Some(tx);
+        self.tx_stream = Some(str);
+    }
+
+    fn created(&self) -> bool {
+        self.tx_transfer.is_some()
+    }
+}
+
+/// DMA Transfer holder for Rx operations
+pub struct RxDMA<Serial_, RX_STREAM, const RX_CH: u8>
+where
+    Serial_: Instance,
+    RX_STREAM: Stream,
+{
+    rx: Option<Rx<Serial_>>,
+    rx_stream: Option<RX_STREAM>,
+    rx_transfer:
+        Option<Transfer<RX_STREAM, RX_CH, Rx<Serial_>, PeripheralToMemory, &'static mut [u8]>>,
+}
+
+impl<Serial_, RX_STREAM, const RX_CH: u8> RxDMA<Serial_, RX_STREAM, RX_CH>
+where
+    Serial_: Instance,
+    RX_STREAM: Stream,
+{
+    fn new(stream: RX_STREAM) -> Self {
+        let tx = Rx {
+            serial: PhantomData,
+        };
+
+        Self {
+            rx: Some(tx),
+            rx_stream: Some(stream),
+            rx_transfer: None,
+        }
+    }
+}
+
+impl<Serial_, RX_STREAM, const RX_CH: u8> DMATransfer<&'static mut [u8]>
+    for RxDMA<Serial_, RX_STREAM, RX_CH>
+where
+    Serial_: Instance,
+    RX_STREAM: Stream,
+    ChannelX<RX_CH>: Channel,
+    Rx<Serial_>: DMASet<RX_STREAM, RX_CH, PeripheralToMemory>,
+{
+    fn create_transfer(&mut self, buf: &'static mut [u8]) {
+        assert!(self.rx.is_some());
+        assert!(self.rx_stream.is_some());
+
+        let transfer = Transfer::init_peripheral_to_memory(
+            self.rx_stream.take().unwrap(),
+            self.rx.take().unwrap(),
+            buf,
+            None,
+            DmaConfig::default()
+                .memory_increment(true)
+                .transfer_complete_interrupt(true)
+                .transfer_error_interrupt(true),
+        );
+
+        self.rx_transfer = Some(transfer);
+    }
+
+    fn destroy_transfer(&mut self) {
+        assert!(self.rx_transfer.is_some());
+
+        let (str, tx, ..) = self.rx_transfer.take().unwrap().release();
+        self.rx = Some(tx);
+        self.rx_stream = Some(str);
+    }
+
+    fn created(&self) -> bool {
+        self.rx_transfer.is_some()
+    }
+}
+
+/// Common implementation
+impl<Serial_, TX_TRANSFER, RX_TRANSFER> SerialDma<Serial_, TX_TRANSFER, RX_TRANSFER>
+where
+    Serial_: Instance,
+    Serial_: Deref<Target = <Serial_ as Instance>::RegisterBlock>,
+    <Serial_ as Instance>::RegisterBlock: RegisterBlockImpl,
+    TX_TRANSFER: DMATransfer<&'static [u8]>,
+    RX_TRANSFER: DMATransfer<&'static mut [u8]>,
+{
+    fn call_callback_once(&mut self, res: Result<(), Error>) {
+        if let Some(c) = self.callback.take() {
+            c(res);
+        }
+    }
+
+    pub fn write(&mut self, bytes: &[u8]) -> Result<(), super::Error> {
+        self.hal_serial.tx.usart.deref().bwrite_all_u8(bytes)
+    }
+
+    pub fn read(&mut self, bytes: &mut [u8]) -> Result<(), super::Error> {
+        self.hal_serial.tx.usart.deref().bread_all_u8(bytes)
+    }
+
+    fn enable_error_interrupt_generation(&mut self) {
+        self.hal_serial.tx.usart.enable_error_interrupt_generation();
+    }
+
+    fn disable_error_interrupt_generation(&mut self) {
+        self.hal_serial
+            .tx
+            .usart
+            .disable_error_interrupt_generation();
+    }
+
+    fn finish_transfer_with_result(&mut self, result: Result<(), Error>) {
+        self.disable_error_interrupt_generation();
+
+        self.call_callback_once(result);
+
+        if self.tx.created() {
+            self.tx.destroy_transfer();
+        }
+
+        if self.rx.created() {
+            self.rx.destroy_transfer();
+        }
+    }
+}
+
+impl<Serial_, TX_STREAM, const TX_CH: u8> SerialHandleIT
+    for SerialDma<Serial_, TxDMA<Serial_, TX_STREAM, TX_CH>, NoDMA>
+where
+    Serial_: Instance,
+    Serial_: Deref<Target = <Serial_ as Instance>::RegisterBlock>,
+    <Serial_ as Instance>::RegisterBlock: RegisterBlockImpl,
+
+    TX_STREAM: Stream,
+    ChannelX<TX_CH>: Channel,
+    Tx<Serial_>: DMASet<TX_STREAM, TX_CH, MemoryToPeripheral>,
+{
+    fn handle_dma_interrupt(&mut self) {
+        if let Some(tx_t) = &mut self.tx.tx_transfer {
+            let flags = tx_t.flags();
+
+            if flags.is_fifo_error() {
+                tx_t.clear_fifo_error();
+            } else if flags.is_transfer_error() {
+                tx_t.clear_transfer_error();
+
+                self.finish_transfer_with_result(Err(Error::TransferError));
+            } else if flags.is_transfer_complete() {
+                tx_t.clear_transfer_complete();
+
+                self.finish_transfer_with_result(Ok(()));
+            }
+        }
+    }
+
+    fn handle_error_interrupt(&mut self) {
+        let res = self
+            .hal_serial
+            .tx
+            .usart
+            .deref()
+            .check_and_clear_error_flags();
+        if let Err(e) = res {
+            self.finish_transfer_with_result(Err(Error::SerialError(e)));
+        }
+    }
+}
+
+impl<Serial_, RX_STREAM, const RX_CH: u8> SerialHandleIT
+    for SerialDma<Serial_, NoDMA, RxDMA<Serial_, RX_STREAM, RX_CH>>
+where
+    Serial_: Instance,
+    Serial_: Deref<Target = <Serial_ as Instance>::RegisterBlock>,
+    <Serial_ as Instance>::RegisterBlock: RegisterBlockImpl,
+
+    RX_STREAM: Stream,
+    ChannelX<RX_CH>: Channel,
+    Rx<Serial_>: DMASet<RX_STREAM, RX_CH, PeripheralToMemory>,
+{
+    fn handle_dma_interrupt(&mut self) {
+        if let Some(rx_t) = &mut self.rx.rx_transfer {
+            let flags = rx_t.flags();
+
+            if flags.is_fifo_error() {
+                rx_t.clear_fifo_error();
+            } else if flags.is_transfer_error() {
+                rx_t.clear_transfer_error();
+
+                self.finish_transfer_with_result(Err(Error::TransferError));
+            } else if flags.is_transfer_complete() {
+                rx_t.clear_transfer_complete();
+
+                self.finish_transfer_with_result(Ok(()));
+            }
+        }
+    }
+
+    fn handle_error_interrupt(&mut self) {
+        let res = self
+            .hal_serial
+            .tx
+            .usart
+            .deref()
+            .check_and_clear_error_flags();
+        if let Err(e) = res {
+            self.finish_transfer_with_result(Err(Error::SerialError(e)));
+        }
+    }
+}
+
+/// Only for both TX and RX DMA
+impl<Serial_, TX_STREAM, const TX_CH: u8, RX_STREAM, const RX_CH: u8> SerialHandleIT
+    for SerialDma<Serial_, TxDMA<Serial_, TX_STREAM, TX_CH>, RxDMA<Serial_, RX_STREAM, RX_CH>>
+where
+    Serial_: Instance,
+    Serial_: Deref<Target = <Serial_ as Instance>::RegisterBlock>,
+    <Serial_ as Instance>::RegisterBlock: RegisterBlockImpl,
+
+    TX_STREAM: Stream,
+    ChannelX<TX_CH>: Channel,
+    Tx<Serial_>: DMASet<TX_STREAM, TX_CH, MemoryToPeripheral>,
+
+    RX_STREAM: Stream,
+    ChannelX<RX_CH>: Channel,
+    Rx<Serial_>: DMASet<RX_STREAM, RX_CH, PeripheralToMemory>,
+{
+    fn handle_dma_interrupt(&mut self) {
+        // Handle Transmit
+        if let Some(tx_t) = &mut self.tx.tx_transfer {
+            let flags = tx_t.flags();
+
+            if flags.is_fifo_error() {
+                tx_t.clear_fifo_error();
+            } else if flags.is_transfer_error() {
+                tx_t.clear_transfer_error();
+
+                self.finish_transfer_with_result(Err(Error::TransferError));
+            } else if flags.is_transfer_complete() {
+                tx_t.clear_transfer_complete();
+
+                // If we have prepared Rx Transfer, there are write_read command, generate restart signal and do not disable DMA requests
+                // Indicate that we have read after this transmit
+                let have_read_after = self.rx.rx_transfer.is_some();
+
+                self.tx.destroy_transfer();
+
+                // If we have prepared Rx Transfer, there are write_read command, generate restart signal
+                if have_read_after {
+                    self.rx.rx_transfer.as_mut().unwrap().start(|_| {});
+                } else {
+                    self.finish_transfer_with_result(Ok(()));
+                }
+            }
+
+            // If Transmit handled then receive should not be handled even if exists.
+            // This return protects for handling Tx and Rx events in one interrupt.
+            return;
+        }
+
+        if let Some(rx_t) = &mut self.rx.rx_transfer {
+            let flags = rx_t.flags();
+
+            if flags.is_fifo_error() {
+                rx_t.clear_fifo_error();
+            } else if flags.is_transfer_error() {
+                rx_t.clear_transfer_error();
+
+                self.finish_transfer_with_result(Err(Error::TransferError));
+            } else if flags.is_transfer_complete() {
+                rx_t.clear_transfer_complete();
+
+                self.finish_transfer_with_result(Ok(()));
+            }
+        }
+    }
+
+    fn handle_error_interrupt(&mut self) {
+        let res = self
+            .hal_serial
+            .tx
+            .usart
+            .deref()
+            .check_and_clear_error_flags();
+        if let Err(e) = res {
+            self.finish_transfer_with_result(Err(Error::SerialError(e)));
+        }
+    }
+}
+
+// Write DMA implementations for TX only and TX/RX Serial DMA
+impl<Serial_, TX_STREAM, const TX_CH: u8, RX_TRANSFER> SerialWriteDMA
+    for SerialDma<Serial_, TxDMA<Serial_, TX_STREAM, TX_CH>, RX_TRANSFER>
+where
+    Serial_: Instance,
+    Serial_: Deref<Target = <Serial_ as Instance>::RegisterBlock>,
+    <Serial_ as Instance>::RegisterBlock: RegisterBlockImpl,
+
+    TX_STREAM: Stream,
+    ChannelX<TX_CH>: Channel,
+    Tx<Serial_>: DMASet<TX_STREAM, TX_CH, MemoryToPeripheral>,
+
+    RX_TRANSFER: DMATransfer<&'static mut [u8]>,
+{
+    unsafe fn write_dma(
+        &mut self,
+        bytes: &[u8],
+        callback: Option<SerialCompleteCallback>,
+    ) -> nb::Result<(), super::Error> {
+        self.enable_error_interrupt_generation();
+        let static_bytes: &'static [u8] = transmute(bytes);
+        self.tx.create_transfer(static_bytes);
+        self.callback = callback;
+
+        // Start DMA processing
+        self.tx.tx_transfer.as_mut().unwrap().start(|_| {});
+
+        Ok(())
+    }
+}
+
+// Read DMA implementations for RX only and TX/RX Serial DMA
+impl<Serial_, TX_TRANSFER, RX_STREAM, const RX_CH: u8> SerialReadDMA
+    for SerialDma<Serial_, TX_TRANSFER, RxDMA<Serial_, RX_STREAM, RX_CH>>
+where
+    Serial_: Instance,
+    Serial_: Deref<Target = <Serial_ as Instance>::RegisterBlock>,
+    <Serial_ as Instance>::RegisterBlock: RegisterBlockImpl,
+
+    RX_STREAM: Stream,
+    ChannelX<RX_CH>: Channel,
+    Rx<Serial_>: DMASet<RX_STREAM, RX_CH, PeripheralToMemory>,
+
+    TX_TRANSFER: DMATransfer<&'static [u8]>,
+{
+    unsafe fn read_dma(
+        &mut self,
+        buf: &mut [u8],
+        callback: Option<SerialCompleteCallback>,
+    ) -> nb::Result<(), super::Error> {
+        self.enable_error_interrupt_generation();
+        let static_buf: &'static mut [u8] = transmute(buf);
+        self.rx.create_transfer(static_buf);
+        self.callback = callback;
+
+        // Start DMA processing
+        self.rx.rx_transfer.as_mut().unwrap().start(|_| {});
+
+        Ok(())
+    }
+}
+
+pub struct Tx<Serial_> {
+    serial: PhantomData<Serial_>,
+}
+
+pub struct Rx<Serial_> {
+    serial: PhantomData<Serial_>,
+}
+
+unsafe impl<Serial_> PeriAddress for Rx<Serial_>
+where
+    Serial_: Instance,
+{
+    #[inline(always)]
+    fn address(&self) -> u32 {
+        <Serial_ as Instance>::peri_address()
+    }
+
+    type MemSize = u8;
+}
+
+unsafe impl<Serial_> PeriAddress for Tx<Serial_>
+where
+    Serial_: Instance,
+{
+    #[inline(always)]
+    fn address(&self) -> u32 {
+        <Serial_ as Instance>::peri_address()
+    }
+
+    type MemSize = u8;
+}
+
+unsafe impl<Serial_, STREAM, const CHANNEL: u8> DMASet<STREAM, CHANNEL, PeripheralToMemory>
+    for Rx<Serial_>
+where
+    Serial_: DMASet<STREAM, CHANNEL, PeripheralToMemory>,
+{
+}
+
+unsafe impl<Serial_, STREAM, const CHANNEL: u8> DMASet<STREAM, CHANNEL, MemoryToPeripheral>
+    for Tx<Serial_>
+where
+    Serial_: DMASet<STREAM, CHANNEL, MemoryToPeripheral>,
+{
+}

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -16,7 +16,7 @@
 
 use crate::pac;
 
-use crate::serial::uart_impls::RegisterBlockUart;
+use crate::serial::uart_impls::{RegisterBlockImpl, RegisterBlockUart};
 
 pub use crate::serial::{config, Error, Event, Instance, NoRx, NoTx, Rx, RxISR, Serial, Tx, TxISR};
 pub use config::Config;
@@ -52,6 +52,10 @@ macro_rules! halUart {
                     })
                 });
             }
+
+            fn peri_address() -> u32 {
+                unsafe { (*Self::ptr()).peri_address() }
+            }
         }
     };
 }
@@ -74,6 +78,10 @@ impl Instance for pac::UART4 {
 
     fn set_stopbits(&self, _bits: config::StopBits) {
         todo!()
+    }
+
+    fn peri_address() -> u32 {
+        unsafe { (*Self::ptr()).peri_address() }
     }
 }
 


### PR DESCRIPTION
The implementation follows existing DMA abstraction for I2C interface.

The implementation has been tested on STM32F407-Discovery board with the code in `examples/serial-dma.rs`.