### PR TITLE
I2C+DMA: Set LAST on last RX DMA transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - add trait bound `RegisterBlockImpl` to type `RegisterBlock` associated with `serial::Instance` [#732]
  - remove unneeded trait bound for methods that take in a `serial::Instance` and use the associated `RegisterBlock`
  - bump `sdio-host` to 0.9.0, refactor SDIO initialization [#734]
+ - set LAST on the last I2C DMA RX transfer [#742]
 
 ### Fixed
 

--- a/src/i2c/dma.rs
+++ b/src/i2c/dma.rs
@@ -726,7 +726,7 @@ where
                     if let Err(e) = self.prepare_read(self.address, self.rx_len) {
                         self.finish_transfer_with_result(Err(Error::I2CError(e)))
                     }
-
+                    self.hal_i2c.i2c.cr2.modify(|_, w| w.last().set_bit());
                     self.rx.rx_transfer.as_mut().unwrap().start(|_| {});
                 } else {
                     self.send_stop();
@@ -840,6 +840,7 @@ where
             return Err(nb::Error::Other(e));
         }
 
+        self.hal_i2c.i2c.cr2.modify(|_, w| w.last().set_bit());
         // Start DMA processing
         self.rx.rx_transfer.as_mut().unwrap().start(|_| {});
 


### PR DESCRIPTION
https://www.st.com/resource/en/reference_manual/rm0402-stm32f412-advanced-armbased-32bit-mcus-stmicroelectronics.pdf 

See 24.6.2:

> 
> LAST: DMA last transfer
>     0: Next DMA EOT is not the last transfer
>     1: Next DMA EOT is the last transfer
>     Note: This bit is used in master receiver mode to permit the
>     generation of a NACK on the last received data.
> 

This solves issues with peripherals like the BMP581 which will keep the i2c bus busy until it receives a NACK.