### PR TITLE
fix: complementary output polarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
  - Fix transmission termination in I2C master DMA read [#736]
  - Prevent starting a new I2C transmission before previous stop finishes [#737]
+ - Fix complementary output polarity for PWM [#754]
 
 ## [v0.20.0] - 2024-01-14
 

--- a/src/timer/pwm.rs
+++ b/src/timer/pwm.rs
@@ -484,7 +484,7 @@ where
     /// Set the polarity of the active state for the complementary PWM output of the advanced timer on channel `channel`
     #[inline]
     pub fn set_complementary_polarity(&mut self, channel: Channel, p: Polarity) {
-        TIM::set_channel_polarity(PINS::check_complementary_used(channel) as u8, p);
+        TIM::set_nchannel_polarity(PINS::check_complementary_used(channel) as u8, p);
     }
 }
 


### PR DESCRIPTION
`set_complementary_polarity` was setting the polarity for the for the primary output instead of the complementary output