### PR TITLE
Port `rtic-time::Monotonic` implementations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.thumbv7em-none-eabihf]
-runner = 'probe-run --chip STM32F411CEUx'
+runner = 'probe-rs run --chip STM32F411CEUx'
 rustflags = [
   # `flip-link` moves stack at the end of flash
   #"-C", "linker=flip-link",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           - rust: nightly
             mcu: stm32f479
             experimental: true
-            features: usb_fs,sdio-host,can,i2s,fsmc_lcd,rtic2
+            features: usb_fs,sdio-host,can,i2s,fsmc_lcd,rtic2,rtic-tim2
 
     steps:
       - uses: actions/checkout@v4
@@ -58,9 +58,6 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: v0.19.0-${{ matrix.mcu }}
+          key: v0.20.0-${{ matrix.mcu }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features=${{ matrix.mcu }},${{ matrix.features }} --examples
+      - run: cargo check --features=${{ matrix.mcu }},${{ matrix.features }} --examples

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,9 +17,8 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: v0.18.0
+          key: v0.20.0
 
-      - uses: actions-rs/clippy-check@v1
+      - run: cargo clippy --examples --features=stm32f479,usb_fs,sdio-host,can,i2s,fsmc_lcd,rtic1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --examples --features=stm32f479,usb_fs,sdio-host

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -15,7 +15,4 @@ jobs:
       - name: Use the latest stable rustc
         run: rustup update stable && rustup default stable
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
   "rust-analyzer.check.allTargets": false,
   "rust-analyzer.check.targets": "thumbv7em-none-eabihf",
-  "rust-analyzer.cargo.features": [
-    "defmt",
-    "rtic1",
-    "stm32f411"
-  ],
+  "rust-analyzer.cargo.features": ["defmt", "rtic1", "stm32f411"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Added non-blocking serial based on DMA [#738]
  - use RTCCLK for RTC wakeup timer for short durations [#746]
  - Support 8-bit FMC data bus
+ - Port `rtic-time::Monotonic` implementations from `rtic-monotonics` for TIMx
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,10 @@ edition = "2021"
 rust-version = "1.60"
 
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
-categories = [
-    "embedded",
-    "hardware-support",
-    "no-std",
-]
+categories = ["embedded", "hardware-support", "no-std"]
 description = "Peripheral access API for STM32F4 series microcontrollers"
 documentation = "https://docs.rs/stm32f4xx-hal"
-keywords = [
-    "arm",
-    "cortex-m",
-    "stm32f4xx",
-    "hal",
-]
+keywords = ["arm", "cortex-m", "stm32f4xx", "hal"]
 license = "0BSD"
 name = "stm32f4xx-hal"
 readme = "README.md"
@@ -23,18 +14,29 @@ repository = "https://github.com/stm32-rs/stm32f4xx-hal"
 version = "0.20.0"
 
 [package.metadata.docs.rs]
-features = ["stm32f429", "usb_fs", "can", "i2s", "fsmc_lcd", "rtic1", "defmt", "sdio-host"]
+features = [
+    "stm32f429",
+    "usb_fs",
+    "can",
+    "i2s",
+    "fsmc_lcd",
+    "rtic1",
+    "defmt",
+    "sdio-host",
+]
 targets = ["thumbv7em-none-eabihf"]
 
 [dependencies]
 defmt = { version = "0.3.5", optional = true }
 bxcan = { version = "0.7", optional = true }
-cortex-m = { version = "0.7.7", features = ["critical-section-single-core"]}
+cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
 nb = "1.1"
 rand_core = "0.6.4"
 stm32f4 = "0.15.1"
-synopsys-usb-otg = { version = "0.4.0", features = ["cortex-m"], optional = true }
+synopsys-usb-otg = { version = "0.4.0", features = [
+    "cortex-m",
+], optional = true }
 sdio-host = { version = "0.9.0", optional = true }
 embedded-dma = "0.2.0"
 bare-metal = { version = "1" }
@@ -46,11 +48,14 @@ fugit-timer = "0.1.3"
 # rtic1
 rtic-monotonic = { version = "1.0", optional = true }
 systick-monotonic = { version = "1.0.1", optional = true }
-cortex-m-rtic = { version = "1.1.4", features = ["test-critical-section"], optional = true }
+cortex-m-rtic = { version = "1.1.4", features = [
+    "test-critical-section",
+], optional = true }
 # rtic2
-rtic-time = { version = "1.3", optional = true }
-rtic-monotonics = { version = "1.5", features = ["cortex-m-systick"], optional = true }
+rtic-time = { version = "2.0", optional = true }
+embedded-hal-async = { version = "1.0", optional = true }
 rtic = { version = "2.0.1", features = ["thumbv7-backend"], optional = true }
+atomic-polyfill = { version = "1.0.3", optional = true }
 
 enumflags2 = "0.7.8"
 embedded-storage = "0.3"
@@ -79,7 +84,7 @@ optional = true
 [dev-dependencies]
 defmt = "0.3.4"
 defmt-rtt = "0.4.0"
-panic-probe = { version = "0.3.0", features = [ "print-defmt" ] }
+panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 panic-semihosting = "0.6.0"
 cortex-m-semihosting = "0.5.0"
 heapless = "0.8"
@@ -116,7 +121,7 @@ features = ["macros"]
 
 # Note: stm32f4 has only one feature for some very similar device families,
 # so it's intended for e.g. stm32f405/415 to both enable stm32f4/stm32f405.
-stm32f401 = ["stm32f4/stm32f401", "gpio-f401",]
+stm32f401 = ["stm32f4/stm32f401", "gpio-f401"]
 stm32f405 = ["stm32f4/stm32f405", "gpio-f417"]
 stm32f407 = ["stm32f4/stm32f407", "gpio-f417"]
 stm32f415 = ["stm32f4/stm32f405", "gpio-f417", "cryp"]
@@ -135,31 +140,58 @@ stm32f469 = ["stm32f4/stm32f469", "gpio-f469"]
 stm32f479 = ["stm32f4/stm32f469", "gpio-f469", "cryp"]
 
 gpio-f401 = [
-    "gpiod", "gpioe",
+    "gpiod",
+    "gpioe",
     "i2c3",
     "otg-fs",
     "sdio",
-    "spi3", "spi4",
-    "tim1", "tim2", "tim3", "tim4", "tim5", "tim9", "tim10", "tim11",
+    "spi3",
+    "spi4",
+    "tim1",
+    "tim2",
+    "tim3",
+    "tim4",
+    "tim5",
+    "tim9",
+    "tim10",
+    "tim11",
 ]
 gpio-f410 = [
     "dac",
     "fmpi2c1",
     "lptim1",
     "spi5",
-    "tim1", "tim5", "tim6", "tim9", "tim11",
+    "tim1",
+    "tim5",
+    "tim6",
+    "tim9",
+    "tim11",
 ]
 gpio-f411 = [
-    "gpiod", "gpioe", # "gpioi",
+    "gpiod",
+    "gpioe",  # "gpioi",
     "i2c3",
     "otg-fs",
     "sdio",
-    "tim1", "tim2", "tim3", "tim4", "tim5", "tim9", "tim10", "tim11",
-    "spi3", "spi4", "spi5",
+    "tim1",
+    "tim2",
+    "tim3",
+    "tim4",
+    "tim5",
+    "tim9",
+    "tim10",
+    "tim11",
+    "spi3",
+    "spi4",
+    "spi5",
 ]
 gpio-f412 = [
-    "gpiod", "gpioe", "gpiof", "gpiog",
-    "can1", "can2",
+    "gpiod",
+    "gpioe",
+    "gpiof",
+    "gpiog",
+    "can1",
+    "can2",
     "dfsdm1",
     "fmpi2c1",
     "fsmc",
@@ -168,13 +200,33 @@ gpio-f412 = [
     "otg-fs",
     "rng",
     "sdio",
-    "spi3", "spi4", "spi5",
-    "tim1", "tim2", "tim3", "tim4", "tim5", "tim6", "tim7", "tim8", "tim9", "tim10", "tim11", "tim12", "tim13", "tim14",
+    "spi3",
+    "spi4",
+    "spi5",
+    "tim1",
+    "tim2",
+    "tim3",
+    "tim4",
+    "tim5",
+    "tim6",
+    "tim7",
+    "tim8",
+    "tim9",
+    "tim10",
+    "tim11",
+    "tim12",
+    "tim13",
+    "tim14",
     "usart3",
 ]
 gpio-f413 = [
-    "gpiod", "gpioe", "gpiof", "gpiog",
-    "can1", "can2", "can3",
+    "gpiod",
+    "gpioe",
+    "gpiof",
+    "gpiog",
+    "can1",
+    "can2",
+    "can3",
     "dac",
     "dfsdm1",
     "dfsdm2",
@@ -187,14 +239,41 @@ gpio-f413 = [
     "rng",
     "sai1",
     "sdio",
-    "spi3", "spi4", "spi5",
-    "tim1", "tim2", "tim3", "tim4", "tim5", "tim6", "tim7", "tim8", "tim9", "tim10", "tim11", "tim12", "tim13", "tim14",
-    "usart3", "uart4", "uart5", "uart7", "uart8", "uart9", "uart10",
+    "spi3",
+    "spi4",
+    "spi5",
+    "tim1",
+    "tim2",
+    "tim3",
+    "tim4",
+    "tim5",
+    "tim6",
+    "tim7",
+    "tim8",
+    "tim9",
+    "tim10",
+    "tim11",
+    "tim12",
+    "tim13",
+    "tim14",
+    "usart3",
+    "uart4",
+    "uart5",
+    "uart7",
+    "uart8",
+    "uart9",
+    "uart10",
 ]
 gpio-f417 = [
-    "gpiod", "gpioe", "gpiof", "gpiog", "gpioi",
-    "adc2", "adc3",
-    "can1", "can2",
+    "gpiod",
+    "gpioe",
+    "gpiof",
+    "gpiog",
+    "gpioi",
+    "adc2",
+    "adc3",
+    "can1",
+    "can2",
     "dac",
     "dcmi",
     "eth",
@@ -205,13 +284,36 @@ gpio-f417 = [
     "rng",
     "sdio",
     "spi3",
-    "tim1", "tim2", "tim3", "tim4", "tim5", "tim6", "tim7", "tim8", "tim9", "tim10", "tim11", "tim12", "tim13", "tim14",
-    "usart3", "uart4", "uart5",
+    "tim1",
+    "tim2",
+    "tim3",
+    "tim4",
+    "tim5",
+    "tim6",
+    "tim7",
+    "tim8",
+    "tim9",
+    "tim10",
+    "tim11",
+    "tim12",
+    "tim13",
+    "tim14",
+    "usart3",
+    "uart4",
+    "uart5",
 ]
 gpio-f427 = [
-    "gpiod", "gpioe", "gpiof", "gpiog", "gpioi", "gpioj", "gpiok",
-    "adc2", "adc3",
-    "can1", "can2",
+    "gpiod",
+    "gpioe",
+    "gpiof",
+    "gpiog",
+    "gpioi",
+    "gpioj",
+    "gpiok",
+    "adc2",
+    "adc3",
+    "can1",
+    "can2",
     "dac",
     "dcmi",
     "eth",
@@ -222,14 +324,39 @@ gpio-f427 = [
     "rng",
     "sai1",
     "sdio",
-    "spi3", "spi4", "spi5", "spi6",
-    "tim1", "tim2", "tim3", "tim4", "tim5", "tim6", "tim7", "tim8", "tim9", "tim10", "tim11", "tim12", "tim13", "tim14",
-    "usart3", "uart4", "uart5", "uart7", "uart8",
+    "spi3",
+    "spi4",
+    "spi5",
+    "spi6",
+    "tim1",
+    "tim2",
+    "tim3",
+    "tim4",
+    "tim5",
+    "tim6",
+    "tim7",
+    "tim8",
+    "tim9",
+    "tim10",
+    "tim11",
+    "tim12",
+    "tim13",
+    "tim14",
+    "usart3",
+    "uart4",
+    "uart5",
+    "uart7",
+    "uart8",
 ]
 gpio-f446 = [
-    "gpiod", "gpioe", "gpiof", "gpiog",
-    "adc2", "adc3",
-    "can1", "can2",
+    "gpiod",
+    "gpioe",
+    "gpiof",
+    "gpiog",
+    "adc2",
+    "adc3",
+    "can1",
+    "can2",
     "dac",
     "dcmi",
     "fmpi2c1",
@@ -241,15 +368,39 @@ gpio-f446 = [
     "sai1",
     "sai2",
     #"sdio",
-    "spi3", "spi4",
+    "spi3",
+    "spi4",
     "spdifrx",
-    "tim1", "tim2", "tim3", "tim4", "tim5", "tim6", "tim7", "tim8", "tim9", "tim10", "tim11", "tim12", "tim13", "tim14",
-    "usart3", "uart4", "uart5",
+    "tim1",
+    "tim2",
+    "tim3",
+    "tim4",
+    "tim5",
+    "tim6",
+    "tim7",
+    "tim8",
+    "tim9",
+    "tim10",
+    "tim11",
+    "tim12",
+    "tim13",
+    "tim14",
+    "usart3",
+    "uart4",
+    "uart5",
 ]
 gpio-f469 = [
-    "gpiod", "gpioe", "gpiof", "gpiog", "gpioi", "gpioj", "gpiok",
-    "adc2", "adc3",
-    "can1", "can2",
+    "gpiod",
+    "gpioe",
+    "gpiof",
+    "gpiog",
+    "gpioi",
+    "gpioj",
+    "gpiok",
+    "adc2",
+    "adc3",
+    "can1",
+    "can2",
     "dac",
     "dcmi",
     "dsihost",
@@ -263,18 +414,47 @@ gpio-f469 = [
     "rng",
     "sai1",
     "sdio",
-    "spi3", "spi4", "spi5", "spi6",
-    "tim1", "tim2", "tim3", "tim4", "tim5", "tim6", "tim7", "tim8", "tim9", "tim10", "tim11", "tim12", "tim13", "tim14",
-    "usart3", "uart4", "uart5", "uart7", "uart8",
+    "spi3",
+    "spi4",
+    "spi5",
+    "spi6",
+    "tim1",
+    "tim2",
+    "tim3",
+    "tim4",
+    "tim5",
+    "tim6",
+    "tim7",
+    "tim8",
+    "tim9",
+    "tim10",
+    "tim11",
+    "tim12",
+    "tim13",
+    "tim14",
+    "usart3",
+    "uart4",
+    "uart5",
+    "uart7",
+    "uart8",
 ]
 
 ## Support monotonic timers and other stuff that can be used by [RTICv1 framework](https://crates.io/crates/cortex-m-rtic)
 rtic1 = ["dep:rtic-monotonic", "dep:systick-monotonic", "cortex-m-rtic"]
 
 ## Support monotonic timers and other stuff that can be used by [RTICv2 framework](https://crates.io/crates/rtic)
-## 
+##
 ## Requires nightly rust compiler
-rtic2 = ["dep:rtic-time", "dep:rtic-monotonics", "dep:rtic"]
+rtic2 = [
+    "dep:rtic-time",
+    "dep:rtic",
+    "dep:atomic-polyfill",
+    "dep:embedded-hal-async",
+]
+rtic-tim2 = []
+rtic-tim3 = []
+rtic-tim4 = []
+rtic-tim5 = []
 
 ## Implementation of `defmt::Format` for public enums and structures. See [defmt](https://crates.io/crates/defmt)
 defmt = ["dep:defmt", "fugit/defmt", "nb/defmt-0-3"]
@@ -384,11 +564,11 @@ required-features = ["can", "stm32f405"]
 
 [[example]]
 name = "delay-syst-blinky"
-required-features = [] # stm32f411
+required-features = []     # stm32f411
 
 [[example]]
 name = "delay-timer-blinky"
-required-features = [] # stm32f411
+required-features = []      # stm32f411
 
 [[example]]
 name = "display-touch"
@@ -404,7 +584,14 @@ required-features = []
 
 [[example]]
 name = "f413disco-lcd-ferris"
-required-features = ["gpiod", "gpioe", "gpiof", "gpiog", "fsmc", "fsmc_lcd"] # stm32f413
+required-features = [
+    "gpiod",
+    "gpioe",
+    "gpiof",
+    "gpiog",
+    "fsmc",
+    "fsmc_lcd",
+] # stm32f413
 
 [[example]]
 name = "hd44780"
@@ -479,6 +666,10 @@ name = "rtic-tick"
 required-features = ["tim2", "rtic1"]
 
 [[example]]
+name = "rtic2-tick"
+required-features = ["rtic2", "rtic-tim2"]
+
+[[example]]
 name = "rtic-usart-shell"
 required-features = ["stm32f411", "rtic1"] # stm32f411
 
@@ -489,10 +680,6 @@ required-features = ["stm32f411", "rtic1"] # stm32f411
 [[example]]
 name = "rtic-usb-cdc-echo"
 required-features = ["stm32f411", "rtic1", "otg-fs", "usb_fs"] # stm32f411
-
-[[example]]
-name = "rtic2-systick"
-required-features = ["rtic2"]
 
 [[example]]
 name = "sd"
@@ -528,11 +715,11 @@ required-features = ["fsmc", "fsmc_lcd"] # stm32f412
 
 [[example]]
 name = "stopwatch-with-ssd1306-and-interrupts"
-required-features = ["tim2"] # stm32f411
+required-features = ["tim2"]                   # stm32f411
 
 [[example]]
 name = "stopwatch-with-ssd1306-and-interrupts-and-dma-i2c"
-required-features = ["tim2", "stm32f411"] # stm32f411
+required-features = ["tim2", "stm32f411"]                  # stm32f411
 
 [[example]]
 name = "timer-periph"

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -83,6 +83,14 @@ pub use crate::time::U32Ext as _stm32f4xx_hal_time_U32Ext;
 pub use crate::timer::MonoTimer64Ext as _;
 #[cfg(feature = "rtic1")]
 pub use crate::timer::MonoTimerExt as _;
+#[cfg(feature = "rtic2")]
+#[cfg(any(
+    feature = "rtic-tim2",
+    feature = "rtic-tim3",
+    feature = "rtic-tim4",
+    feature = "rtic-tim5"
+))]
+pub use crate::timer::MonoTimerExt as _;
 pub use crate::timer::PwmExt as _stm32f4xx_hal_timer_PwmExt;
 #[cfg(feature = "rtic1")]
 pub use crate::timer::SysMonoTimerExt as _stm32f4xx_hal_timer_SysMonoTimerExt;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -30,6 +30,22 @@ pub use pwm_input::PwmInput;
 pub mod monotonic;
 #[cfg(feature = "rtic1")]
 pub use monotonic::*;
+#[cfg(feature = "rtic2")]
+#[cfg(any(
+    feature = "rtic-tim2",
+    feature = "rtic-tim3",
+    feature = "rtic-tim4",
+    feature = "rtic-tim5"
+))]
+pub mod monotonics;
+#[cfg(feature = "rtic2")]
+#[cfg(any(
+    feature = "rtic-tim2",
+    feature = "rtic-tim3",
+    feature = "rtic-tim4",
+    feature = "rtic-tim5"
+))]
+pub use monotonics::*;
 
 mod hal_02;
 mod hal_1;

--- a/src/timer/monotonic.rs
+++ b/src/timer/monotonic.rs
@@ -1,4 +1,4 @@
-// RTIC Monotonic impl for the 32-bit timers
+// RTICv1 Monotonic impl for the 32-bit timers
 use super::{Channel, Event, FTimer, Flag, General, Instance, WithPwm};
 use crate::rcc::Clocks;
 use crate::ReadFlags;

--- a/src/timer/monotonics.rs
+++ b/src/timer/monotonics.rs
@@ -1,0 +1,294 @@
+// RTICv2 Monotonic impl
+use super::{FTimer, General};
+use crate::{pac, rcc::Clocks};
+use atomic_polyfill::{AtomicU64, Ordering};
+use core::marker::PhantomData;
+use rtic_time::timer_queue::TimerQueueBackend;
+use rtic_time::{
+    half_period_counter::calculate_now, monotonic::TimerQueueBasedMonotonic,
+    timer_queue::TimerQueue, Monotonic,
+};
+
+pub struct MonoTimer<TIM, const FREQ: u32> {
+    _tim: PhantomData<TIM>,
+}
+/// `MonoTimer` with precision of 1 μs (1 MHz sampling)
+pub type MonoTimerUs<TIM> = MonoTimer<TIM, 1_000_000>;
+
+pub struct MonoTimerBackend<TIM> {
+    _tim: PhantomData<TIM>,
+}
+
+impl<TIM: 'static, const FREQ: u32> TimerQueueBasedMonotonic for MonoTimer<TIM, FREQ>
+where
+    MonoTimerBackend<TIM>: TimerQueueBackend<Ticks = u64>,
+{
+    type Backend = MonoTimerBackend<TIM>;
+    type Instant = fugit::TimerInstantU64<FREQ>;
+    type Duration = fugit::TimerDurationU64<FREQ>;
+}
+
+pub trait MonoTimerExt: Sized {
+    fn monotonic<const FREQ: u32>(
+        self,
+        nvic: &mut cortex_m::peripheral::NVIC,
+        clocks: &Clocks,
+    ) -> MonoTimer<Self, FREQ>;
+    fn monotonic_us(
+        self,
+        nvic: &mut cortex_m::peripheral::NVIC,
+        clocks: &Clocks,
+    ) -> MonoTimer<Self, 1_000_000> {
+        self.monotonic::<1_000_000>(nvic, clocks)
+    }
+}
+
+impl<TIM: 'static, const FREQ: u32> embedded_hal::delay::DelayNs for MonoTimer<TIM, FREQ>
+where
+    Self:
+        Monotonic<Instant = fugit::TimerInstantU64<FREQ>, Duration = fugit::TimerDurationU64<FREQ>>,
+{
+    fn delay_ns(&mut self, ns: u32) {
+        let now = Self::now();
+        let mut done = now + <Self as Monotonic>::Duration::nanos_at_least(ns.into());
+        if now != done {
+            // Compensate for sub-tick uncertainty
+            done += <Self as Monotonic>::Duration::from_ticks(1);
+        }
+
+        while Self::now() < done {}
+    }
+
+    fn delay_us(&mut self, us: u32) {
+        let now = Self::now();
+        let mut done = now + <Self as Monotonic>::Duration::micros_at_least(us.into());
+        if now != done {
+            // Compensate for sub-tick uncertainty
+            done += <Self as Monotonic>::Duration::from_ticks(1);
+        }
+
+        while Self::now() < done {}
+    }
+
+    fn delay_ms(&mut self, ms: u32) {
+        let now = Self::now();
+        let mut done = now + <Self as Monotonic>::Duration::millis_at_least(ms.into());
+        if now != done {
+            // Compensate for sub-tick uncertainty
+            done += <Self as Monotonic>::Duration::from_ticks(1);
+        }
+
+        while Self::now() < done {}
+    }
+}
+
+impl<TIM: 'static, const FREQ: u32> embedded_hal_async::delay::DelayNs for MonoTimer<TIM, FREQ>
+where
+    Self:
+        Monotonic<Instant = fugit::TimerInstantU64<FREQ>, Duration = fugit::TimerDurationU64<FREQ>>,
+{
+    #[inline]
+    async fn delay_ns(&mut self, ns: u32) {
+        Self::delay(<Self as Monotonic>::Duration::nanos_at_least(ns.into())).await;
+    }
+
+    #[inline]
+    async fn delay_us(&mut self, us: u32) {
+        Self::delay(<Self as Monotonic>::Duration::micros_at_least(us.into())).await;
+    }
+
+    #[inline]
+    async fn delay_ms(&mut self, ms: u32) {
+        Self::delay(<Self as Monotonic>::Duration::millis_at_least(ms.into())).await;
+    }
+}
+
+const fn cortex_logical2hw(logical: u8, nvic_prio_bits: u8) -> u8 {
+    ((1 << nvic_prio_bits) - logical) << (8 - nvic_prio_bits)
+}
+
+pub(crate) unsafe fn set_monotonic_prio(
+    nvic: &mut cortex_m::peripheral::NVIC,
+    prio_bits: u8,
+    interrupt: impl cortex_m::interrupt::InterruptNumber,
+) {
+    extern "C" {
+        static RTIC_ASYNC_MAX_LOGICAL_PRIO: u8;
+    }
+
+    let max_prio = RTIC_ASYNC_MAX_LOGICAL_PRIO.max(1).min(1 << prio_bits);
+
+    let hw_prio = cortex_logical2hw(max_prio, prio_bits);
+
+    nvic.set_priority(interrupt, hw_prio);
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __internal_create_stm32_timer_interrupt {
+    ($timer:ident) => {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        unsafe extern "C" fn $timer() {
+            use monomod::TimerQueueBackend;
+            use $crate::timer::monotonics as monomod;
+            monomod::MonoTimerBackend::<$crate::pac::$timer>::timer_queue()
+                .on_monotonic_interrupt();
+        }
+    };
+}
+
+macro_rules! make_timer {
+    ($tim: ident, $timer:ident, $bits:ident, $overflow:ident, $tq:ident$(, doc: ($($doc:tt)*))?) => {
+        static $overflow: AtomicU64 = AtomicU64::new(0);
+        static $tq: TimerQueue<MonoTimerBackend<pac::$timer>> = TimerQueue::new();
+
+        impl MonoTimerExt for pac::$timer {
+            fn monotonic<const FREQ: u32>(
+                self,
+                nvic: &mut cortex_m::peripheral::NVIC,
+                clocks: &Clocks,
+            ) -> MonoTimer<Self, FREQ> {
+                FTimer::new(self, clocks).monotonic(nvic)
+            }
+        }
+
+        impl<const FREQ: u32> FTimer<pac::$timer, FREQ> {
+            pub fn monotonic(
+                mut self,
+                nvic: &mut cortex_m::peripheral::NVIC,
+            ) -> MonoTimer<pac::$timer, FREQ> {
+                __internal_create_stm32_timer_interrupt!($timer);
+
+                // Enable full-period interrupt.
+                self.tim.dier.modify(|_, w| w.uie().set_bit());
+
+                // Configure and enable half-period interrupt
+                self.tim.ccr[2].write(|w| w.ccr().bits(($bits::MAX - ($bits::MAX >> 1)).into()));
+                self.tim.dier.modify(|_, w| w.cc3ie().set_bit());
+
+                // Trigger an update event to load the prescaler value to the clock.
+                self.tim.egr.write(|w| w.ug().set_bit());
+
+                // The above line raises an update event which will indicate that the timer is already finished.
+                // Since this is not the case, it should be cleared.
+                self.tim.sr.modify(|_, w| w.uif().clear_bit());
+
+                $tq.initialize(MonoTimerBackend::<pac::$timer> { _tim: PhantomData });
+                $overflow.store(0, Ordering::SeqCst);
+
+                // Start the counter.
+                self.tim.enable_counter(true);
+
+                // SAFETY: We take full ownership of the peripheral and interrupt vector,
+                // plus we are not using any external shared resources so we won't impact
+                // basepri/source masking based critical sections.
+                unsafe {
+                    set_monotonic_prio(nvic, pac::NVIC_PRIO_BITS, <pac::$timer>::IRQ);
+                    cortex_m::peripheral::NVIC::unmask(<pac::$timer>::IRQ);
+                }
+                MonoTimer { _tim: PhantomData }
+            }
+        }
+
+        impl MonoTimerBackend<pac::$timer> {
+            #[inline(always)]
+            fn tim() -> &'static pac::$tim::RegisterBlock {
+                unsafe { &*<pac::$timer>::ptr() }
+            }
+        }
+
+        impl TimerQueueBackend for MonoTimerBackend<pac::$timer> {
+            type Ticks = u64;
+
+            fn now() -> Self::Ticks {
+                calculate_now(
+                    || $overflow.load(Ordering::Relaxed),
+                    || Self::tim().cnt.read().bits(),
+                )
+            }
+
+            fn set_compare(instant: Self::Ticks) {
+                let now = Self::now();
+
+                // Since the timer may or may not overflow based on the requested compare val, we check how many ticks are left.
+                // `wrapping_sup` takes care of the u64 integer overflow special case.
+                let val = if instant.wrapping_sub(now) <= ($bits::MAX as u64) {
+                    instant as $bits
+                } else {
+                    // In the past or will overflow
+                    0
+                };
+
+                Self::tim().ccr[1].write(|r| r.ccr().bits(val.into()));
+            }
+
+            fn clear_compare_flag() {
+                Self::tim().sr.modify(|_, w| w.cc2if().clear_bit());
+            }
+
+            fn pend_interrupt() {
+                cortex_m::peripheral::NVIC::pend(<pac::$timer>::IRQ);
+            }
+
+            fn enable_timer() {
+                Self::tim().dier.modify(|_, w| w.cc2ie().set_bit());
+            }
+
+            fn disable_timer() {
+                Self::tim().dier.modify(|_, w| w.cc2ie().clear_bit());
+            }
+
+            fn on_interrupt() {
+                // Full period
+                if Self::tim().sr.read().uif().bit_is_set() {
+                    Self::tim().sr.modify(|_, w| w.uif().clear_bit());
+                    let prev = $overflow.fetch_add(1, Ordering::Relaxed);
+                    assert!(prev % 2 == 1, "Monotonic must have missed an interrupt!");
+                }
+                // Half period
+                if Self::tim().sr.read().cc3if().bit_is_set() {
+                    Self::tim().sr.modify(|_, w| w.cc3if().clear_bit());
+                    let prev = $overflow.fetch_add(1, Ordering::Relaxed);
+                    assert!(prev % 2 == 0, "Monotonic must have missed an interrupt!");
+                }
+            }
+
+            fn timer_queue() -> &'static TimerQueue<Self> {
+                &$tq
+            }
+        }
+    };
+}
+
+#[cfg(all(feature = "tim2", feature = "rtic-tim2"))]
+make_timer!(tim2, TIM2, u32, TIMER2_OVERFLOWS, TIMER2_TQ);
+
+#[cfg(all(feature = "tim3", feature = "rtic-tim3"))]
+make_timer!(tim3, TIM3, u16, TIMER3_OVERFLOWS, TIMER3_TQ);
+
+#[cfg(all(feature = "tim4", feature = "rtic-tim4"))]
+make_timer!(tim4, TIM4, u16, TIMER4_OVERFLOWS, TIMER4_TQ);
+
+#[cfg(all(feature = "tim5", feature = "rtic-tim5"))]
+make_timer!(tim5, TIM5, u16, TIMER5_OVERFLOWS, TIMER5_TQ);
+
+pub trait Irq {
+    const IRQ: pac::Interrupt;
+}
+#[cfg(feature = "tim2")]
+impl Irq for pac::TIM2 {
+    const IRQ: pac::Interrupt = pac::Interrupt::TIM2;
+}
+#[cfg(feature = "tim3")]
+impl Irq for pac::TIM3 {
+    const IRQ: pac::Interrupt = pac::Interrupt::TIM3;
+}
+#[cfg(feature = "tim4")]
+impl Irq for pac::TIM4 {
+    const IRQ: pac::Interrupt = pac::Interrupt::TIM4;
+}
+#[cfg(feature = "tim5")]
+impl Irq for pac::TIM5 {
+    const IRQ: pac::Interrupt = pac::Interrupt::TIM5;
+}


### PR DESCRIPTION
from `rtic-monotonics` for TIMx
Add `rtic2-blink` example

~~Waiting for `rtic-time` 2.0 release~~