### PR TITLE
move PWM pins connecting after inialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
  - RTC: `ClockSource` enum instead of generic [#785]
  - Bump MSRV to 1.62 [#778]
+ - Move PWM pins connecting after PWM inialization [#791]
  - Use `stm32f4-staging` until `stm32f4` is released [#706]
  - use GPIO pac fields instead of raw write [#777]
  - RTIC2 monotonics fix: CC1 instead of CC3 [#771]
@@ -51,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#778]: https://github.com/stm32-rs/stm32f4xx-hal/pull/778
 [#783]: https://github.com/stm32-rs/stm32f4xx-hal/pull/783
 [#785]: https://github.com/stm32-rs/stm32f4xx-hal/pull/785
+[#791]: https://github.com/stm32-rs/stm32f4xx-hal/pull/791
 [#796]: https://github.com/stm32-rs/stm32f4xx-hal/pull/796
 
 ## [v0.21.0] - 2024-05-30

--- a/examples/pwm-input.rs
+++ b/examples/pwm-input.rs
@@ -6,11 +6,7 @@
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-use stm32f4xx_hal::{
-    pac,
-    prelude::*,
-    timer::{Channel1, Channel2, Timer},
-};
+use stm32f4xx_hal::{pac, prelude::*, timer::Timer};
 
 #[entry]
 fn main() -> ! {
@@ -22,10 +18,10 @@ fn main() -> ! {
         let gpioa = dp.GPIOA.split();
         let gpioc = dp.GPIOC.split();
 
-        let channels = (Channel1::new(gpioa.pa8), Channel2::new(gpioa.pa9));
         // configure tim1 as a PWM output of known frequency.
-        let pwm = Timer::new(dp.TIM1, &clocks).pwm_hz(channels, 501.Hz());
-        let (mut ch1, _ch2) = pwm.split();
+        let (_, (ch1, ch2, ..)) = Timer::new(dp.TIM1, &clocks).pwm_hz(501.Hz());
+        let mut ch1 = ch1.with(gpioa.pa8);
+        let mut _ch2 = ch2.with(gpioa.pa9);
         let max_duty = ch1.get_max_duty();
         ch1.set_duty(max_duty / 2);
         ch1.enable();

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -6,11 +6,7 @@
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-use stm32f4xx_hal::{
-    pac,
-    prelude::*,
-    timer::{Channel1, Channel2},
-};
+use stm32f4xx_hal::{pac, prelude::*};
 
 #[entry]
 fn main() -> ! {
@@ -20,10 +16,11 @@ fn main() -> ! {
         let clocks = rcc.cfgr.freeze();
 
         let gpioa = dp.GPIOA.split();
-        let channels = (Channel1::new(gpioa.pa8), Channel2::new(gpioa.pa9));
 
-        let pwm = dp.TIM1.pwm_hz(channels, 20.kHz(), &clocks).split();
-        let (mut ch1, _ch2) = pwm;
+        let (_, (ch1, ch2, ..)) = dp.TIM1.pwm_us(100.micros(), &clocks);
+        let mut ch1 = ch1.with(gpioa.pa8);
+        let mut _ch2 = ch2.with(gpioa.pa9);
+
         let max_duty = ch1.get_max_duty();
         ch1.set_duty(max_duty / 2);
         ch1.enable();

--- a/src/timer/hal_02.rs
+++ b/src/timer/hal_02.rs
@@ -11,7 +11,7 @@ use fugit::{ExtU32Ceil, HertzU32 as Hertz, TimerDurationU32};
 use void::Void;
 
 use super::{
-    Channel, Counter, CounterHz, Delay, Error, Instance, Pins, Pwm, PwmChannel, PwmHz, SysCounter,
+    CPin, Counter, CounterHz, Delay, ErasedChannel, Error, Instance, PwmChannel, SysCounter,
     SysCounterHz, SysDelay, WithPwm,
 };
 
@@ -139,7 +139,9 @@ impl<const FREQ: u32> Cancel for SysCounter<FREQ> {
     }
 }
 
-impl<TIM: Instance + WithPwm, const C: u8> embedded_hal_02::PwmPin for PwmChannel<TIM, C> {
+impl<TIM: Instance + WithPwm + CPin<C>, const C: u8, const COMP: bool, Otype>
+    embedded_hal_02::PwmPin for PwmChannel<TIM, C, COMP, Otype>
+{
     type Duty = u16;
 
     fn disable(&mut self) {
@@ -159,45 +161,23 @@ impl<TIM: Instance + WithPwm, const C: u8> embedded_hal_02::PwmPin for PwmChanne
     }
 }
 
-impl<TIM, PINS> embedded_hal_02::Pwm for PwmHz<TIM, PINS>
-where
-    TIM: Instance + WithPwm,
-    PINS: Pins<TIM>,
-{
-    type Channel = Channel;
+impl<TIM: Instance + WithPwm> embedded_hal_02::PwmPin for ErasedChannel<TIM> {
     type Duty = u16;
-    type Time = Hertz;
 
-    fn enable(&mut self, channel: Self::Channel) {
-        self.enable(channel)
+    fn disable(&mut self) {
+        self.disable()
     }
-
-    fn disable(&mut self, channel: Self::Channel) {
-        self.disable(channel)
+    fn enable(&mut self) {
+        self.enable()
     }
-
-    fn get_duty(&self, channel: Self::Channel) -> Self::Duty {
-        self.get_duty(channel)
+    fn get_duty(&self) -> Self::Duty {
+        self.get_duty()
     }
-
-    fn set_duty(&mut self, channel: Self::Channel, duty: Self::Duty) {
-        self.set_duty(channel, duty)
-    }
-
-    /// If `0` returned means max_duty is 2^16
     fn get_max_duty(&self) -> Self::Duty {
         self.get_max_duty()
     }
-
-    fn get_period(&self) -> Self::Time {
-        self.get_period()
-    }
-
-    fn set_period<T>(&mut self, period: T)
-    where
-        T: Into<Self::Time>,
-    {
-        self.set_period(period.into())
+    fn set_duty(&mut self, duty: Self::Duty) {
+        self.set_duty(duty)
     }
 }
 
@@ -266,47 +246,5 @@ impl<TIM: Instance, const FREQ: u32> Cancel for Counter<TIM, FREQ> {
 
     fn cancel(&mut self) -> Result<(), Self::Error> {
         self.cancel()
-    }
-}
-
-impl<TIM, PINS, const FREQ: u32> embedded_hal_02::Pwm for Pwm<TIM, PINS, FREQ>
-where
-    TIM: Instance + WithPwm,
-    PINS: Pins<TIM>,
-{
-    type Channel = Channel;
-    type Duty = u16;
-    type Time = TimerDurationU32<FREQ>;
-
-    fn enable(&mut self, channel: Self::Channel) {
-        self.enable(channel)
-    }
-
-    fn disable(&mut self, channel: Self::Channel) {
-        self.disable(channel)
-    }
-
-    fn get_duty(&self, channel: Self::Channel) -> Self::Duty {
-        self.get_duty(channel)
-    }
-
-    fn set_duty(&mut self, channel: Self::Channel, duty: Self::Duty) {
-        self.set_duty(channel, duty)
-    }
-
-    /// If `0` returned means max_duty is 2^16
-    fn get_max_duty(&self) -> Self::Duty {
-        self.get_max_duty()
-    }
-
-    fn get_period(&self) -> Self::Time {
-        self.get_period()
-    }
-
-    fn set_period<T>(&mut self, period: T)
-    where
-        T: Into<Self::Time>,
-    {
-        self.set_period(period.into())
     }
 }

--- a/src/timer/hal_1.rs
+++ b/src/timer/hal_1.rs
@@ -6,7 +6,7 @@
 use core::convert::Infallible;
 use embedded_hal::delay::DelayNs;
 
-use super::{Delay, Instance, PwmChannel, SysDelay, WithPwm};
+use super::{CPin, Delay, ErasedChannel, Instance, PwmChannel, SysDelay, WithPwm};
 use fugit::ExtU32Ceil;
 
 impl DelayNs for SysDelay {
@@ -33,11 +33,29 @@ impl<TIM: Instance, const FREQ: u32> DelayNs for Delay<TIM, FREQ> {
     }
 }
 
-impl<TIM: Instance + WithPwm, const C: u8> embedded_hal::pwm::ErrorType for PwmChannel<TIM, C> {
+impl<TIM: Instance + WithPwm + CPin<C>, const C: u8, const COMP: bool, Otype>
+    embedded_hal::pwm::ErrorType for PwmChannel<TIM, C, COMP, Otype>
+{
     type Error = Infallible;
 }
 
-impl<TIM: Instance + WithPwm, const C: u8> embedded_hal::pwm::SetDutyCycle for PwmChannel<TIM, C> {
+impl<TIM: Instance + WithPwm + CPin<C>, const C: u8, const COMP: bool, Otype>
+    embedded_hal::pwm::SetDutyCycle for PwmChannel<TIM, C, COMP, Otype>
+{
+    fn max_duty_cycle(&self) -> u16 {
+        self.get_max_duty()
+    }
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        self.set_duty(duty);
+        Ok(())
+    }
+}
+
+impl<TIM: Instance + WithPwm> embedded_hal::pwm::ErrorType for ErasedChannel<TIM> {
+    type Error = Infallible;
+}
+
+impl<TIM: Instance + WithPwm> embedded_hal::pwm::SetDutyCycle for ErasedChannel<TIM> {
     fn max_duty_cycle(&self) -> u16 {
         self.get_max_duty()
     }


### PR DESCRIPTION
The main idea is from https://github.com/stm32-rs/stm32f3xx-hal/pull/34 but with several changes.

Always split PWM on manager and channels.

The main disadvantage is removed `embedded_hal_02::Pwm` as no more `Pwm` struct.

cc @apollolabsdev @kossnikita 