### PR TITLE
Added support for Input Capture timer mode for frequency and pulse duration measurement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -782,3 +782,7 @@ required-features = []
 [[example]]
 name = "fmc-sdram"
 required-features = ["stm32f469", "stm32-fmc"]
+
+[[example]]
+name = "rtic2-timer-input-capture"
+required-features = ["rtic2"]

--- a/examples/rtic2-timer-input-capture.rs
+++ b/examples/rtic2-timer-input-capture.rs
@@ -1,0 +1,78 @@
+#![no_main]
+#![no_std]
+
+use defmt_rtt as _;
+use panic_probe as _;
+use stm32f4xx_hal::{
+    pac,
+    pac::{TIM2, TIM5},
+    prelude::*,
+    timer::{
+        CcChannel, CcHzManager, Event, Flag, Polarity, PwmChannel, Timer,
+    },
+};
+
+use rtic::app;
+
+#[app(device = pac, dispatchers = [USART1], peripherals = true)]
+mod app {
+    use super::*;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        tim5: CcHzManager<TIM5>,
+        ch1: CcChannel<TIM5, 0>,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> (Shared, Local) {
+        let dp = ctx.device;
+        let rcc = dp.RCC.constrain();
+        let clocks = rcc.cfgr.sysclk(48.MHz()).freeze();
+        let gpioa = dp.GPIOA.split();
+
+        // Configuration of TIM2 in PWM mode
+        let timer = Timer::new(dp.TIM2, &clocks);
+        let (_, (ch1, ..)) = timer.pwm_hz(893.Hz());
+        let mut tim_2: PwmChannel<TIM2, 0> = ch1.with(gpioa.pa5);
+        tim_2.set_duty(50);
+        tim_2.enable();
+
+        // Configuration of TIM2 in input capture mode
+        let (mut tim5, (ch1, ..)) = Timer::new(dp.TIM5, &clocks).capture_compare_hz(48000.kHz());
+        let mut ch1 = ch1.with(gpioa.pa0);
+        tim5.listen(Event::C1);
+
+        ch1.set_polarity(Polarity::ActiveHigh);
+        ch1.enable();
+
+        defmt::info!("Start");
+
+        (Shared {}, Local { tim5, ch1 })
+    }
+
+    #[task(binds = TIM5, local = [tim5, ch1, prev_capture: u32 = 0], priority = 3)]
+    fn tim5_interrupt(cx: tim5_interrupt::Context) {
+        let timer_clock = cx.local.tim5.get_timer_clock();
+
+        if cx.local.tim5.flags().contains(Flag::C1) {
+            let current_capture = cx.local.ch1.get_capture();
+
+            let delta = if current_capture >= *cx.local.prev_capture {
+                current_capture - *cx.local.prev_capture
+            } else {
+                (u32::MAX - *cx.local.prev_capture) + current_capture
+            };
+
+            let freq = timer_clock as f32 / delta as f32;
+
+            defmt::info!("Freq: {} Hz", freq); // Output = Freq: 893.00665 Hz
+
+            *cx.local.prev_capture = current_capture;
+            cx.local.tim5.clear_flags(Flag::C1);
+        }
+    }
+}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -26,6 +26,10 @@ pub use pwm::*;
 pub mod pwm_input;
 #[cfg(not(feature = "gpio-f410"))]
 pub use pwm_input::PwmInput;
+#[cfg(not(feature = "gpio-f410"))]
+pub mod capture_compare;
+#[cfg(not(feature = "gpio-f410"))]
+pub use capture_compare::*;
 #[cfg(feature = "rtic1")]
 pub mod monotonic;
 #[cfg(feature = "rtic1")]
@@ -87,6 +91,7 @@ pub const C4: u8 = 3;
 pub enum Polarity {
     ActiveHigh,
     ActiveLow,
+    ActiveBoth,
 }
 
 /// Output Idle state
@@ -306,6 +311,18 @@ pub enum Ocm {
     PwmMode2 = 7,
 }
 
+/// Capture/Compare mode
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum Ccm {
+    // Todo Output compare (not tested)
+    // OutputCompare = 0,
+    InputCapture = 1,
+    InvChannelInputCapture = 2,
+    TriggerInputCapture = 3,
+}
+
 // Center-aligned mode selection
 pub use pac::tim1::cr1::CMS as CenterAlignedMode;
 
@@ -320,7 +337,7 @@ pub type CCR4<T> = CCR<T, 3>;
 pub struct DMAR<T>(T);
 
 mod sealed {
-    use super::{BitFlags, CenterAlignedMode, Event, Flag, IdleState, Ocm, Polarity};
+    use super::{BitFlags, Ccm, CenterAlignedMode, Event, Flag, IdleState, Ocm, Polarity};
     pub trait General {
         type Width: Into<u32> + From<u16>;
         fn max_auto_reload() -> u32;
@@ -359,6 +376,14 @@ mod sealed {
         fn set_nchannel_polarity(channel: u8, p: Polarity);
     }
 
+    pub trait WithCcCommon: General {
+        const CC_CH_NUMBER: u8;
+        const CC_COMP_CH_NUMBER: u8;
+        fn read_cc_value(channel: u8) -> u32;
+        fn enable_channel(channel: u8, b: bool);
+        fn set_channel_polarity(channel: u8, p: Polarity);
+    }
+
     pub trait Advanced: WithPwmCommon {
         fn enable_nchannel(channel: u8, b: bool);
         fn set_dtg_value(value: u8);
@@ -373,6 +398,11 @@ mod sealed {
         fn start_pwm(&mut self);
     }
 
+    pub trait WithCc: WithCcCommon {
+        fn preload_capture_compare(&mut self, c: u8, mode: Ccm);
+        fn start_capture_compare(&mut self);
+    }
+
     pub trait MasterTimer: General {
         type Mms;
         fn master_mode(&mut self, mode: Self::Mms);
@@ -382,15 +412,23 @@ mod sealed {
         type Channels;
         fn split() -> Self::Channels;
     }
+
+    pub trait SplitCc {
+        type CcChannels;
+        fn split_cc() -> Self::CcChannels;
+    }
 }
-pub(crate) use sealed::{Advanced, General, MasterTimer, WithPwm, WithPwmCommon};
+pub(crate) use sealed::{
+    Advanced, General, MasterTimer, WithCc, WithCcCommon, WithPwm,
+    WithPwmCommon,
+};
 
 pub trait Instance:
     crate::Sealed + rcc::Enable + rcc::Reset + rcc::BusTimerClock + General
 {
 }
 
-use sealed::Split;
+use sealed::{Split, SplitCc};
 macro_rules! split {
     ($TIM:ty: 1) => {
         split!($TIM, C1);
@@ -406,6 +444,26 @@ macro_rules! split {
             type Channels = ($(PwmChannelDisabled<$TIM, $C>,)+);
             fn split() -> Self::Channels {
                 ($(PwmChannelDisabled::<_, $C>::new(),)+)
+            }
+        }
+    };
+}
+
+macro_rules! split_cc {
+    ($TIM:ty: 1) => {
+        split_cc!($TIM, C1);
+    };
+    ($TIM:ty: 2) => {
+        split_cc!($TIM, C1, C2);
+    };
+    ($TIM:ty: 4) => {
+        split_cc!($TIM, C1, C2, C3, C4);
+    };
+    ($TIM:ty, $($C:ident),+) => {
+        impl SplitCc for $TIM {
+            type CcChannels = ($(CcChannelDisabled<$TIM, $C>,)+);
+            fn split_cc() -> Self::CcChannels {
+                ($(CcChannelDisabled::<_, $C>::new(),)+)
             }
         }
     };
@@ -580,6 +638,50 @@ macro_rules! hal {
                 }
             }
 
+            impl WithCcCommon for $TIM {
+                const CC_CH_NUMBER: u8 = $cnum;
+                const CC_COMP_CH_NUMBER: u8 = $cnum;
+                #[inline(always)]
+                fn read_cc_value(c: u8) -> u32 {
+                    let tim = unsafe { &*<$TIM>::ptr() };
+                    if c < Self::CC_CH_NUMBER {
+                        tim.ccr(c as usize).read().bits()
+                    } else {
+                        0
+                    }
+                }
+
+                #[inline(always)]
+                fn enable_channel(c: u8, b: bool) {
+                    let tim = unsafe { &*<$TIM>::ptr() };
+                    if c < Self::CC_CH_NUMBER {
+                        unsafe { bb::write(tim.ccer(), c*4, b); }
+                    }
+                }
+
+                #[inline(always)]
+                fn set_channel_polarity(c: u8, p: Polarity) {
+                    let tim = unsafe { &*<$TIM>::ptr() };
+                    if c < Self::CC_CH_NUMBER {
+                        match p {
+                            Polarity::ActiveLow => {
+                                unsafe { bb::write(tim.ccer(), c*4 + 3, false); }
+                                unsafe { bb::write(tim.ccer(), c*4 + 1, true); }
+                            }
+                            Polarity::ActiveHigh => {
+                                unsafe { bb::write(tim.ccer(), c*4 + 3, false); }
+                                unsafe { bb::write(tim.ccer(), c*4 + 1, false); }
+                            }
+                            Polarity::ActiveBoth => {
+                                unsafe { bb::write(tim.ccer(), c*4 + 3, true); }
+                                unsafe { bb::write(tim.ccer(), c*4 + 1, true); }
+                            }
+                        }
+
+                    }
+                }
+            }
+
             $(
                 impl Advanced for $TIM {
                     fn enable_nchannel(c: u8, b: bool) {
@@ -618,7 +720,9 @@ macro_rules! hal {
             )?
 
             with_pwm!($TIM: $cnum $(, $aoe)?);
+            with_cc!($TIM: $cnum $(, $aoe)?);
             split!($TIM: $cnum);
+            split_cc!($TIM: $cnum);
             unsafe impl<const C: u8> PeriAddress for CCR<$TIM, C> {
                 #[inline(always)]
                 fn address(&self) -> u32 {
@@ -705,6 +809,51 @@ macro_rules! with_pwm {
             1, ccmr1_output, oc2pe, oc2m;
             2, ccmr2_output, oc3pe, oc3m;
             3, ccmr2_output, oc4pe, oc4m;
+        ] $(, $aoe)?);
+    };
+}
+
+macro_rules! with_cc {
+    ($TIM:ty: [$($Cx:literal, $ccmrx_output:ident, $ccxs:ident;)+] $(, $aoe:ident)?) => {
+        impl WithCc for $TIM {
+            #[inline(always)]
+            fn preload_capture_compare(&mut self, c: u8, mode: Ccm) {
+                match c {
+                    $(
+                        $Cx => {
+                            self.$ccmrx_output()
+                            .modify(|_, w| unsafe { w.$ccxs().bits(mode as _) } );
+                        }
+                    )+
+                    #[allow(unreachable_patterns)]
+                    _ => {},
+                }
+            }
+
+            #[inline(always)]
+            fn start_capture_compare(&mut self) {
+                // $(let $aoe = self.bdtr().modify(|_, w| w.aoe().set_bit());)?
+                self.cr1().modify(|_, w| w.cen().set_bit());
+            }
+        }
+    };
+    ($TIM:ty: 1) => {
+        with_cc!($TIM: [
+            0, ccmr1_output, cc1s;
+        ]);
+    };
+    ($TIM:ty: 2) => {
+        with_cc!($TIM: [
+            0, ccmr1_output, cc1s;
+            1, ccmr1_output, cc2s;
+        ]);
+    };
+    ($TIM:ty: 4 $(, $aoe:ident)?) => {
+        with_cc!($TIM: [
+            0, ccmr1_output, cc1s;
+            1, ccmr1_output, cc2s;
+            2, ccmr2_output, cc3s;
+            3, ccmr2_output, cc4s;
         ] $(, $aoe)?);
     };
 }

--- a/src/timer/capture_compare.rs
+++ b/src/timer/capture_compare.rs
@@ -1,0 +1,270 @@
+use super::sealed::{Split, SplitCc};
+use super::{CPin, Ccm, Instance, Polarity, Timer, WithCc};
+pub use super::{Ch, C1, C2, C3, C4};
+use crate::gpio::PushPull;
+use crate::rcc::Clocks;
+use core::ops::{Deref, DerefMut};
+use fugit::HertzU32 as Hertz;
+
+pub trait CcExt
+where
+    Self: Sized + Instance + WithCc + SplitCc,
+{
+    fn capture_compare_hz(
+        self,
+        freq: Hertz,
+        clocks: &Clocks,
+    ) -> (CcHzManager<Self>, Self::CcChannels);
+}
+
+impl<TIM> CcExt for TIM
+where
+    Self: Sized + Instance + WithCc + SplitCc,
+{
+    fn capture_compare_hz(
+        self,
+        time: Hertz,
+        clocks: &Clocks,
+    ) -> (CcHzManager<Self>, Self::CcChannels) {
+        Timer::new(self, clocks).capture_compare_hz(time)
+    }
+}
+
+impl<TIM: Instance + WithCc + SplitCc> Timer<TIM> {
+    // At a timer clock frequency of 100 MHz,
+    // the frequency should be in the range from 2000 Hz to the timer clock frequency.
+    // It is recommended to use 32-bit timers (TIM2, TIM5).
+    pub fn capture_compare_hz(
+        mut self,
+        freq: Hertz,
+    ) -> (CcHzManager<TIM>, TIM::CcChannels) {
+        // The reference manual is a bit ambiguous about when enabling this bit is really
+        // necessary, but since we MUST enable the preload for the output channels then we
+        // might as well enable for the auto-reload too
+        self.tim.enable_preload(true);
+
+        let psc = self.clk.raw() / freq.raw();
+        assert!(self.clk.raw() % freq.raw() == 0);
+        assert!(
+            psc <= u16::MAX.into(),
+            "PSC value {} exceeds 16-bit limit (65535)",
+            psc
+        );
+
+        self.tim.set_prescaler(psc as u16 - 1);
+        self.tim.set_auto_reload(TIM::max_auto_reload()).unwrap();
+
+        // Trigger update event to load the registers
+        self.tim.trigger_update();
+
+        self.tim.start_capture_compare();
+
+        (CcHzManager { timer: self }, TIM::split_cc())
+    }
+}
+
+pub struct CcChannelDisabled<TIM, const C: u8> {
+    pub(super) tim: TIM,
+}
+
+impl<TIM: crate::Steal, const C: u8> CcChannelDisabled<TIM, C> {
+    pub(crate) fn new() -> Self {
+        Self {
+            tim: unsafe { TIM::steal() },
+        }
+    }
+}
+impl<TIM: Instance + WithCc + crate::Steal, const C: u8>
+    CcChannelDisabled<TIM, C>
+where
+    TIM: CPin<C>,
+{
+    pub fn with(
+        mut self,
+        pin: impl Into<TIM::Ch<PushPull>>,
+    ) -> CcChannel<TIM, C, false, PushPull> {
+        self.tim.preload_capture_compare(C, Ccm::InputCapture);
+        CcChannel {
+            tim: self.tim,
+            lines: CaptureLines::One(pin.into()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum CaptureLines<P> {
+    One(P),
+    Two(P, P),
+    Three(P, P, P),
+    Four(P, P, P, P),
+}
+impl<P> CaptureLines<P> {
+    pub fn and(self, pin: P) -> Self {
+        match self {
+            Self::One(p) => Self::Two(p, pin),
+            Self::Two(p1, p2) => Self::Three(p1, p2, pin),
+            Self::Three(p1, p2, p3) => Self::Four(p1, p2, p3, pin),
+            Self::Four(_, _, _, _) => unreachable!(),
+        }
+    }
+}
+
+pub struct CcChannel<
+    TIM: CPin<C>,
+    const C: u8,
+    const COMP: bool = false,
+    Otype = PushPull,
+> {
+    pub(super) tim: TIM,
+    lines: CaptureLines<TIM::Ch<Otype>>,
+    // TODO: add complementary pins
+}
+
+impl<TIM: Instance + WithCc + CPin<C>, const C: u8, const COMP: bool, Otype>
+    CcChannel<TIM, C, COMP, Otype>
+{
+    pub const fn channel(&self) -> u8 {
+        C
+    }
+    pub fn release(
+        mut self,
+    ) -> (
+        CcChannelDisabled<TIM, C>,
+        CaptureLines<TIM::Ch<Otype>>,
+    ) {
+        self.disable();
+        (CcChannelDisabled { tim: self.tim }, self.lines)
+    }
+    pub fn erase(self) -> CaptureErasedChannel<TIM> {
+        CaptureErasedChannel {
+            _tim: self.tim,
+            channel: C,
+        }
+    }
+}
+impl<TIM: Instance + CPin<C>, const C: u8, const COMP: bool, Otype>
+    CcChannel<TIM, C, COMP, Otype>
+{
+    pub fn with(self, pin: impl Into<TIM::Ch<Otype>>) -> Self {
+        Self {
+            tim: self.tim,
+            lines: self.lines.and(pin.into()),
+        }
+    }
+}
+
+pub struct CaptureErasedChannel<TIM> {
+    _tim: TIM,
+    channel: u8,
+}
+
+impl<TIM> CaptureErasedChannel<TIM> {
+    pub const fn channel(&self) -> u8 {
+        self.channel
+    }
+}
+
+macro_rules! ch_impl {
+    () => {
+        /// Disable input capture/output compare channel
+        #[inline]
+        pub fn disable(&mut self) {
+            TIM::enable_channel(self.channel(), false);
+        }
+
+        /// Enable input capture/output compare channel
+        #[inline]
+        pub fn enable(&mut self) {
+            TIM::enable_channel(self.channel(), true);
+        }
+
+        /// Get capture value
+        #[inline]
+        pub fn get_capture(&self) -> u32 {
+            TIM::read_cc_value(self.channel())
+        }
+
+        /// Set Input capture/Output compare channel polarity
+        #[inline]
+        pub fn set_polarity(&mut self, p: Polarity) {
+            TIM::set_channel_polarity(self.channel(), p);
+        }
+    };
+}
+
+impl<TIM: Instance + WithCc + CPin<C>, const C: u8, const COMP: bool, Otype>
+    CcChannel<TIM, C, COMP, Otype>
+{
+    ch_impl!();
+}
+
+impl<TIM: Instance + WithCc> CaptureErasedChannel<TIM> {
+    ch_impl!();
+}
+
+pub struct CcHzManager<TIM>
+where
+    TIM: Instance + WithCc,
+{
+    pub(super) timer: Timer<TIM>,
+}
+
+impl<TIM> CcHzManager<TIM>
+where
+    TIM: Instance + WithCc + Split,
+{
+    pub fn release(mut self, _channels: TIM::Channels) -> Timer<TIM> {
+        // stop timer
+        self.tim.cr1_reset();
+        self.timer
+    }
+}
+
+impl<TIM> Deref for CcHzManager<TIM>
+where
+    TIM: Instance + WithCc,
+{
+    type Target = Timer<TIM>;
+    fn deref(&self) -> &Self::Target {
+        &self.timer
+    }
+}
+
+impl<TIM> DerefMut for CcHzManager<TIM>
+where
+    TIM: Instance + WithCc,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.timer
+    }
+}
+
+impl<TIM> CcHzManager<TIM>
+where
+    TIM: Instance + WithCc,
+{
+    /// Get the PWM frequency of the timer in Hertz
+    pub fn get_timer_clock(&self) -> u32 {
+        let clk = self.clk;
+        let psc = self.tim.read_prescaler() as u32;
+
+        // The frequency of the timer counter increment
+        (clk / (psc + 1)).raw()
+    }
+
+    /// Set the frequency of the timer counter increment
+    pub fn set_timer_clock(&mut self, freq: Hertz) {
+        let clk = self.clk;
+        let psc = clk.raw() / freq.raw();
+        assert!(self.clk.raw() % freq.raw() == 0);
+        assert!(
+            psc <= u16::MAX.into(),
+            "PSC value {} exceeds 16-bit limit (65535)",
+            psc
+        );
+
+        self.tim.set_prescaler(psc as u16 - 1);
+        self.tim.set_auto_reload(1 << 16).unwrap();
+        self.tim.cnt_reset();
+    }
+}


### PR DESCRIPTION
Added support for the Input Capture timer mode.

Why this is needed:

The Input Capture mode allows measuring signal frequency or pulse duration. This is especially useful for tasks that require precise frequency measurement, such as monitoring fan RPM, working with sensors, or analyzing signals. Additionally, a single timer can use up to four channels, enabling the measurement of multiple signals simultaneously.