### PR TITLE
feat(dsi,ltdc): implement missing DSI commands and add DSI-compatible LTDC constructor

### DIFF
--- a/src/dsi.rs
+++ b/src/dsi.rs
@@ -6,7 +6,7 @@ use crate::ltdc::DisplayConfig;
 use crate::rcc::{Enable, Rcc};
 use crate::{pac::DSI, time::Hertz};
 use core::cmp::{max, min};
-use embedded_display_controller::dsi::{DsiHostCtrlIo, DsiReadCommand, DsiWriteCommand};
+pub use embedded_display_controller::dsi::{DsiHostCtrlIo, DsiReadCommand, DsiWriteCommand};
 
 const DSI_TIMEOUT_MS: usize = 100;
 
@@ -592,18 +592,24 @@ impl DsiHostCtrlIo for DsiHost {
             Error::FifoTimeout,
         )?;
         match kind {
-            DsiWriteCommand::DcsShortP0 { .. } => todo!(),
+            DsiWriteCommand::DcsShortP0 { arg } => {
+                self.ghcr_write(0, arg, kind.discriminant());
+            }
             DsiWriteCommand::DcsShortP1 { arg, data } => {
-                // debug!("{}, short_p1: reg: {reg:02x}, data: {data:02x}", self.write_idx);
-                // self.write_idx += 1;
                 self.ghcr_write(data, arg, kind.discriminant());
             }
             DsiWriteCommand::DcsLongWrite { arg, data } => {
                 self.long_write(arg, data, kind.discriminant())?
             }
-            DsiWriteCommand::GenericShortP0 => todo!(),
-            DsiWriteCommand::GenericShortP1 => todo!(),
-            DsiWriteCommand::GenericShortP2 => todo!(),
+            DsiWriteCommand::GenericShortP0 => {
+                self.ghcr_write(0, 0, kind.discriminant());
+            }
+            DsiWriteCommand::GenericShortP1 => {
+                self.ghcr_write(0, 0, kind.discriminant());
+            }
+            DsiWriteCommand::GenericShortP2 => {
+                self.ghcr_write(0, 0, kind.discriminant());
+            }
             DsiWriteCommand::GenericLongWrite { arg, data } => {
                 self.long_write(arg, data, kind.discriminant())?
             }


### PR DESCRIPTION
## Summary

- Re-export DSI host trait and command enums from stm32f4xx-hal so external display drivers can depend only on the HAL.
- Implement DCS short and generic short write commands in the DSI host implementation, removing remaining todo!()s.
- Add a DSI-oriented LTDC constructor that does not touch PLLSAI and works with the DSI host pixel clock.

## Notes

This PR is the first of two extracted from #843 (NT35510 display+touch example). It contains only the generic DSI/LTDC transport improvements and no example or board-specific changes.


Made with [Cursor](https://cursor.com)