### PR TITLE
feat(ltdc): add LtdcFramebuffer DrawTarget and F469 framebuffer demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+ - Add NT35510 LCD controller support with auto-detection for STM32F469I-DISCO [#843]
+
 ## [v0.23.0] - 2025-09-22
 
  - Implement `embedded_hal::i2c::I2c` for `I2cMasterDma` [#838]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
  - Add NT35510 LCD controller support with auto-detection for STM32F469I-DISCO [#843]
+ - Add `LtdcFramebuffer` with `embedded-graphics` DrawTarget support (feature `framebuffer`) [#TBD]
 
 ## [v0.23.0] - 2025-09-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ bare-metal = { version = "1" }
 void = { default-features = false, version = "1.0.2" }
 display-interface = { version = "0.5.0", optional = true }
 display-interface-04 = { package = "display-interface", version = "0.4.1", optional = true }
+embedded-graphics-core = { version = "0.4.0", optional = true }
 fugit = "0.3.7"
 fugit-timer = "0.1.3"
 # rtic1
@@ -495,6 +496,9 @@ usb_hs = ["dep:synopsys-usb-otg", "synopsys-usb-otg/hs"]
 ## LCD support via FMC/FSMC peripheral. See [display-interface](https://crates.io/crates/display-interface)
 fsmc_lcd = ["dep:display-interface", "dep:display-interface-04"]
 
+## LTDC framebuffer abstraction with embedded_graphics DrawTarget support
+framebuffer = ["dep:embedded-graphics-core", "ltdc"]
+
 ## SDIO peripheral support. See [sdio-host](https://crates.io/crates/sdio-host)
 sdio-host = ["dep:sdio-host"]
 
@@ -623,6 +627,10 @@ required-features = [
 [[example]]
 name = "f469disco-lcd-test"
 required-features = ["stm32f469", "defmt"]
+
+[[example]]
+name = "f469disco-framebuffer"
+required-features = ["stm32f469", "stm32-fmc", "framebuffer", "defmt"]
 
 [[example]]
 name = "hd44780"

--- a/examples/f469disco-framebuffer.rs
+++ b/examples/f469disco-framebuffer.rs
@@ -1,0 +1,201 @@
+//! STM32F469I-DISCO LCD framebuffer example using embedded-graphics
+//!
+//! Demonstrates the `LtdcFramebuffer` + `DrawTarget` abstraction on the
+//! DSI-connected 480x800 panel. Draws colour bars and rectangles using
+//! `embedded-graphics` primitives backed by SDRAM.
+//!
+//! Build (F469I-DISCO):
+//!
+//! ```bash
+//! cargo build --release --example f469disco-framebuffer --features="stm32f469,stm32-fmc,framebuffer,defmt"
+//! ```
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+use defmt_rtt as _;
+use panic_probe as _;
+
+use core::slice;
+
+use stm32f4xx_hal::{self as hal, rcc::Config};
+
+use hal::{
+    dsi::{
+        ColorCoding, DsiChannel, DsiCmdModeTransmissionKind, DsiConfig, DsiHost, DsiInterrupts,
+        DsiMode, DsiPhyTimers, DsiPllConfig, DsiVideoMode, LaneCount,
+    },
+    fmc::FmcExt,
+    gpio::alt::fmc as fmc_alt,
+    ltdc::{DisplayConfig, DisplayController, Layer, LtdcFramebuffer, PixelFormat},
+    pac::{CorePeripherals, Peripherals},
+    prelude::*,
+};
+
+use embedded_graphics::{
+    pixelcolor::Rgb565,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+};
+
+use stm32_fmc::devices::is42s32400f_6;
+
+const WIDTH: u16 = 480;
+const HEIGHT: u16 = 800;
+
+const DISPLAY_CONFIG: DisplayConfig = DisplayConfig {
+    active_width: WIDTH,
+    active_height: HEIGHT,
+    h_back_porch: 34,
+    h_front_porch: 34,
+    v_back_porch: 15,
+    v_front_porch: 16,
+    h_sync: 2,
+    v_sync: 1,
+    frame_rate: 60,
+    h_sync_pol: true,
+    v_sync_pol: true,
+    no_data_enable_pol: false,
+    pixel_clock_pol: true,
+};
+
+macro_rules! fmc_pins {
+    ($($alt:ident: $pin:expr,)*) => {
+        ($(fmc_alt::$alt::from($pin.internal_pull_up(true))),*)
+    };
+}
+
+#[entry]
+fn main() -> ! {
+    let dp = Peripherals::take().unwrap();
+    let cp = CorePeripherals::take().unwrap();
+
+    // 1. Clocks
+    let hse_freq = 8.MHz();
+    let mut rcc = dp
+        .RCC
+        .freeze(Config::hse(hse_freq).pclk2(32.MHz()).sysclk(180.MHz()));
+    let mut delay = cp.SYST.delay(&rcc.clocks);
+
+    // 2. GPIO
+    let gpioc = dp.GPIOC.split(&mut rcc);
+    let gpiod = dp.GPIOD.split(&mut rcc);
+    let gpioe = dp.GPIOE.split(&mut rcc);
+    let gpiof = dp.GPIOF.split(&mut rcc);
+    let gpiog = dp.GPIOG.split(&mut rcc);
+    let gpioh = dp.GPIOH.split(&mut rcc);
+    let gpioi = dp.GPIOI.split(&mut rcc);
+
+    // LCD reset
+    let mut lcd_reset = gpioh.ph7.into_push_pull_output();
+    lcd_reset.set_low();
+    delay.delay_ms(20u32);
+    lcd_reset.set_high();
+    delay.delay_ms(10u32);
+
+    // 3. SDRAM
+    #[rustfmt::skip]
+    let fmc_pins = fmc_pins! {
+        A0: gpiof.pf0, A1: gpiof.pf1, A2: gpiof.pf2, A3: gpiof.pf3,
+        A4: gpiof.pf4, A5: gpiof.pf5, A6: gpiof.pf12, A7: gpiof.pf13,
+        A8: gpiof.pf14, A9: gpiof.pf15, A10: gpiog.pg0, A11: gpiog.pg1,
+        Ba0: gpiog.pg4, Ba1: gpiog.pg5,
+        D0: gpiod.pd14, D1: gpiod.pd15, D2: gpiod.pd0, D3: gpiod.pd1,
+        D4: gpioe.pe7, D5: gpioe.pe8, D6: gpioe.pe9, D7: gpioe.pe10,
+        D8: gpioe.pe11, D9: gpioe.pe12, D10: gpioe.pe13, D11: gpioe.pe14,
+        D12: gpioe.pe15, D13: gpiod.pd8, D14: gpiod.pd9, D15: gpiod.pd10,
+        D16: gpioh.ph8, D17: gpioh.ph9, D18: gpioh.ph10, D19: gpioh.ph11,
+        D20: gpioh.ph12, D21: gpioh.ph13, D22: gpioh.ph14, D23: gpioh.ph15,
+        D24: gpioi.pi0, D25: gpioi.pi1, D26: gpioi.pi2, D27: gpioi.pi3,
+        D28: gpioi.pi6, D29: gpioi.pi7, D30: gpioi.pi9, D31: gpioi.pi10,
+        Nbl0: gpioe.pe0, Nbl1: gpioe.pe1, Nbl2: gpioi.pi4, Nbl3: gpioi.pi5,
+        Sdcke0: gpioh.ph2, Sdclk: gpiog.pg8,
+        Sdncas: gpiog.pg15, Sdne0: gpioh.ph3,
+        Sdnras: gpiof.pf11, Sdnwe: gpioc.pc0,
+    };
+
+    let mut sdram = dp
+        .FMC
+        .sdram(fmc_pins, is42s32400f_6::Is42s32400f6 {}, &rcc.clocks);
+
+    let fb_size = WIDTH as usize * HEIGHT as usize;
+    let sdram_ptr: *mut u16 = sdram.init(&mut delay) as *mut u16;
+    assert!(!sdram_ptr.is_null());
+    let fb = unsafe { slice::from_raw_parts_mut(sdram_ptr, fb_size) };
+    fb.fill(0); // clear to black
+
+    // 4. DSI
+    let dsi_pll_config = unsafe { DsiPllConfig::manual(125, 2, 0, 4) };
+    let dsi_config = DsiConfig {
+        mode: DsiMode::Video {
+            mode: DsiVideoMode::Burst,
+        },
+        lane_count: LaneCount::DoubleLane,
+        channel: DsiChannel::Ch0,
+        hse_freq,
+        ltdc_freq: 27_429.kHz(),
+        interrupts: DsiInterrupts::None,
+        color_coding_host: ColorCoding::SixteenBitsConfig1,
+        color_coding_wrapper: ColorCoding::SixteenBitsConfig1,
+        lp_size: 64,
+        vlp_size: 64,
+    };
+
+    let mut dsi_host = DsiHost::init(dsi_pll_config, DISPLAY_CONFIG, dsi_config, dp.DSI, &mut rcc)
+        .expect("DSI init");
+
+    dsi_host.configure_phy_timers(DsiPhyTimers {
+        dataline_hs2lp: 35,
+        dataline_lp2hs: 35,
+        clock_hs2lp: 35,
+        clock_lp2hs: 35,
+        dataline_max_read_time: 0,
+        stop_wait_time: 10,
+    });
+
+    dsi_host.set_command_mode_transmission_kind(DsiCmdModeTransmissionKind::AllInHighSpeed);
+    dsi_host.start();
+
+    // 5. LTDC
+    let mut display_ctrl =
+        DisplayController::<u16>::new_dsi(dp.LTDC, dp.DMA2D, PixelFormat::RGB565, DISPLAY_CONFIG);
+
+    display_ctrl.config_layer(Layer::L1, fb, PixelFormat::RGB565);
+    display_ctrl.enable_layer(Layer::L1);
+    display_ctrl.reload();
+
+    // 6. Create LtdcFramebuffer
+    let fb2 = unsafe { slice::from_raw_parts_mut(sdram_ptr, fb_size) };
+    let mut framebuffer = LtdcFramebuffer::new(fb2, WIDTH, HEIGHT);
+
+    // 7. Draw using embedded-graphics DrawTarget
+    defmt::info!("Drawing colour bars via LtdcFramebuffer + DrawTarget");
+
+    let bar_h = HEIGHT as u32 / 4;
+    let colors = [Rgb565::RED, Rgb565::GREEN, Rgb565::BLUE, Rgb565::WHITE];
+
+    for (i, &color) in colors.iter().enumerate() {
+        Rectangle::new(
+            Point::new(0, (i as u32 * bar_h) as i32),
+            Size::new(WIDTH as u32, bar_h),
+        )
+        .into_styled(PrimitiveStyle::with_fill(color))
+        .draw(&mut framebuffer)
+        .unwrap();
+    }
+
+    // 8. Draw a rectangle using DrawTarget (embedded-graphics)
+    Rectangle::new(Point::new(100, 300), Size::new(280, 200))
+        .into_styled(PrimitiveStyle::with_fill(Rgb565::YELLOW))
+        .draw(&mut framebuffer)
+        .unwrap();
+    display_ctrl.reload();
+
+    defmt::info!("Framebuffer demo ready.");
+    loop {
+        cortex_m::asm::wfi();
+    }
+}
+

--- a/examples/f469disco-lcd-test.rs
+++ b/examples/f469disco-lcd-test.rs
@@ -1,4 +1,16 @@
 //! This example initializes the STM32F469I-DISCO LCD and displays a test pattern
+//!
+//! This example supports both STM32F469I-DISCO board revisions:
+//! - B08 revision (NT35510 LCD controller) - auto-detected and preferred
+//! - B07 and earlier (OTM8009A LCD controller) - fallback
+//!
+//! Runtime auto-detection is used by default.
+//!
+//! ## Build
+//! ```bash
+//! cargo check --example f469disco-lcd-test --features="stm32f469,defmt"
+//! ```
+//!
 //! Run as:
 //! cargo run --release --example f469disco-lcd-test --features="stm32f469,defmt"
 
@@ -8,6 +20,9 @@
 
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
+
+#[path = "f469disco/nt35510.rs"]
+mod nt35510;
 
 use cortex_m_rt::entry;
 
@@ -21,17 +36,50 @@ use crate::hal::{
         ColorCoding, DsiChannel, DsiCmdModeTransmissionKind, DsiConfig, DsiHost, DsiInterrupts,
         DsiMode, DsiPhyTimers, DsiPllConfig, DsiVideoMode, LaneCount,
     },
+    i2c::I2c,
     ltdc::{DisplayConfig, DisplayController, PixelFormat},
     pac::{CorePeripherals, Peripherals},
     prelude::*,
 };
 
+use ft6x06::Ft6X06;
 use otm8009a::{Otm8009A, Otm8009AConfig};
+
+const FT6X06_I2C_ADDR_NEW: u8 = 0x38;
+const FT6X06_I2C_ADDR_LEGACY: u8 = 0x2A;
+// Timeout to force release when FT6x06 doesn't report release (~300ms at 10ms poll)
+const TOUCH_TIMEOUT_TICKS: u8 = 30;
+
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BoardHint {
+    NewRevisionLikely,
+    LegacyRevisionLikely,
+    Unknown,
+}
+
+// Display configurations for different controllers
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LcdController {
+    Nt35510,
+    Otm8009a,
+}
+
+impl LcdController {
+    fn display_config(self) -> DisplayConfig {
+        match self {
+            Self::Nt35510 => NT35510_DISPLAY_CONFIG,
+            Self::Otm8009a => OTM8009A_DISPLAY_CONFIG,
+        }
+    }
+}
 
 pub const WIDTH: usize = 480;
 pub const HEIGHT: usize = 800;
 
-pub const DISPLAY_CONFIGURATION: DisplayConfig = DisplayConfig {
+// NT35510 timing (B08 revision)
+pub const NT35510_DISPLAY_CONFIG: DisplayConfig = DisplayConfig {
     active_width: WIDTH as _,
     active_height: HEIGHT as _,
     h_back_porch: 34,
@@ -47,6 +95,27 @@ pub const DISPLAY_CONFIGURATION: DisplayConfig = DisplayConfig {
     pixel_clock_pol: true,
 };
 
+// OTM8009A timing (B07 and earlier revisions)
+// Values from STMicroelectronics/stm32-otm8009a otm8009a.h
+// Tested on KoD KM-040TMP-02-0621 WVGA display
+pub const OTM8009A_DISPLAY_CONFIG: DisplayConfig = DisplayConfig {
+    active_width: WIDTH as _,
+    active_height: HEIGHT as _,
+    h_back_porch: 34,
+    h_front_porch: 34,
+    v_back_porch: 15,
+    v_front_porch: 16,
+    h_sync: 2,
+    v_sync: 1,
+    frame_rate: 60,
+    h_sync_pol: true,
+    v_sync_pol: true,
+    no_data_enable_pol: false,
+    pixel_clock_pol: true,
+};
+
+const DSI_PROBE_DISPLAY_CONFIG: DisplayConfig = NT35510_DISPLAY_CONFIG;
+
 #[entry]
 fn main() -> ! {
     let dp = Peripherals::take().unwrap();
@@ -58,7 +127,33 @@ fn main() -> ! {
         .freeze(Config::hse(hse_freq).pclk2(32.MHz()).sysclk(180.MHz()));
     let mut delay = cp.SYST.delay(&rcc.clocks);
 
-    let gpioh = dp.GPIOH.split(&mut rcc);
+let gpioh = dp.GPIOH.split(&mut rcc);
+    let gpiob = dp.GPIOB.split(&mut rcc);
+    let gpioc = dp.GPIOC.split(&mut rcc);  // For touch interrupt (PC0)
+    let _gpiod = dp.GPIOD.split(&mut rcc);  // For future LD2 (PD4), LD3 (PD5)
+    let gpiog = dp.GPIOG.split(&mut rcc);  // For LD1 (PG6)
+    let mut led = gpiog.pg6.into_push_pull_output();
+    led.set_low();  // Start off
+
+let scl = gpiob.pb8;
+    let sda = gpiob.pb9;
+    let mut i2c = I2c::new(dp.I2C1, (scl, sda), 400.kHz(), &mut rcc);
+
+    let mut probe_touch_addr = |addr| {
+        let mut id = [0u8; 1];
+        i2c.read(addr, &mut id).is_ok()
+            || i2c.write_read(addr, &[0xA8], &mut id).is_ok()
+            || i2c.write_read(addr, &[0x00], &mut id).is_ok()
+    };
+
+    let board_hint = if probe_touch_addr(FT6X06_I2C_ADDR_NEW) {
+        BoardHint::NewRevisionLikely
+    } else if probe_touch_addr(FT6X06_I2C_ADDR_LEGACY) {
+        BoardHint::LegacyRevisionLikely
+    } else {
+        BoardHint::Unknown
+    };
+    defmt::info!("Board hint from touch probe: {:?}", board_hint);
 
     // Reset display
     let mut lcd_reset = gpioh.ph7.into_push_pull_output();
@@ -67,19 +162,9 @@ fn main() -> ! {
     lcd_reset.set_high();
     delay.delay_ms(10u32);
 
-    // Initialize LTDC, needed to provide pixel clock to DSI
-    defmt::info!("Initializing LTDC");
     let ltdc_freq = 27_429.kHz();
-    let _display = DisplayController::<u32>::new(
-        dp.LTDC,
-        dp.DMA2D,
-        None,
-        PixelFormat::ARGB8888,
-        DISPLAY_CONFIGURATION,
-        Some(hse_freq),
-    );
 
-    // Initialize DSI Host
+    // Initialize DSI Host with probe-compatible settings.
     // VCO = (8MHz HSE / 2 IDF) * 2 * 125 = 1000MHz
     // 1000MHz VCO / (2 * 1 ODF * 8) = 62.5MHz
     let dsi_pll_config = unsafe {
@@ -97,19 +182,21 @@ fn main() -> ! {
         interrupts: DsiInterrupts::None,
         color_coding_host: ColorCoding::TwentyFourBits,
         color_coding_wrapper: ColorCoding::TwentyFourBits,
-        lp_size: 4,
-        vlp_size: 4,
+        lp_size: 64,  // Increased for NT35510 compatibility; also works for OTM8009A
+        vlp_size: 64, // Increased for NT35510 compatibility; also works for OTM8009A
     };
 
     defmt::info!("Initializing DSI {:?} {:?}", dsi_config, dsi_pll_config);
-    let mut dsi_host = DsiHost::init(
+    let mut dsi_host = match DsiHost::init(
         dsi_pll_config,
-        DISPLAY_CONFIGURATION,
+        DSI_PROBE_DISPLAY_CONFIG,
         dsi_config,
         dp.DSI,
         &mut rcc,
-    )
-    .unwrap();
+    ) {
+        Ok(host) => host,
+        Err(e) => defmt::panic!("DSI host initialization failed: {:?}", e),
+    };
 
     dsi_host.configure_phy_timers(DsiPhyTimers {
         dataline_hs2lp: 35,
@@ -123,29 +210,239 @@ fn main() -> ! {
     dsi_host.set_command_mode_transmission_kind(DsiCmdModeTransmissionKind::AllInLowPower);
     dsi_host.start();
     dsi_host.enable_bus_turn_around(); // Must be before read attempts
-    dsi_host.set_command_mode_transmission_kind(DsiCmdModeTransmissionKind::AllInHighSpeed);
+    delay.delay_ms(20u32); // Allow panel link to settle after DSI start before probing
+
+    let controller = detect_lcd_controller(&mut dsi_host, &mut delay, board_hint);
+    defmt::info!("Detected LCD controller: {:?}", controller);
+
+    defmt::info!("Initializing LTDC for detected controller");
+    let _display = DisplayController::<u32>::new_dsi(
+        dp.LTDC,
+        dp.DMA2D,
+        PixelFormat::ARGB8888,
+        controller.display_config(),
+    );
+
+    dsi_host.set_command_mode_transmission_kind(DsiCmdModeTransmissionKind::AllInLowPower);
     dsi_host.force_rx_low_power(true);
-    dsi_host.enable_color_test(); // Must enable before display initialized
 
-    defmt::info!("Initializing OTM8009A");
-    let otm8009a_config = Otm8009AConfig {
-        frame_rate: otm8009a::FrameRate::_60Hz,
-        mode: otm8009a::Mode::Portrait,
-        color_map: otm8009a::ColorMap::Rgb,
-        cols: WIDTH as u16,
-        rows: HEIGHT as u16,
+    // Initialize the detected LCD controller
+    match controller {
+        LcdController::Nt35510 => {
+            defmt::info!("Initializing NT35510 (B08 revision)");
+            let mut nt35510 = nt35510::Nt35510::new();
+            if let Err(e) = nt35510.init(&mut dsi_host, &mut delay) {
+                defmt::panic!("NT35510 init failed: {:?}", e);
+            }
+        }
+        LcdController::Otm8009a => {
+            defmt::info!("Initializing OTM8009A (B07 and earlier revisions)");
+            let otm8009a_config = Otm8009AConfig {
+                frame_rate: otm8009a::FrameRate::_60Hz,
+                mode: otm8009a::Mode::Portrait,
+                color_map: otm8009a::ColorMap::Rgb,
+                cols: WIDTH as u16,
+                rows: HEIGHT as u16,
+            };
+            let mut otm8009a = Otm8009A::new();
+            if let Err(e) = otm8009a.init(&mut dsi_host, otm8009a_config, &mut delay) {
+                defmt::panic!("OTM8009A init failed: {:?}", e);
+            }
+        }
+    }
+
+    dsi_host.set_command_mode_transmission_kind(DsiCmdModeTransmissionKind::AllInHighSpeed);
+    dsi_host.enable_color_test();
+
+    // ========== INITIALIZE TOUCHSCREEN ==========
+    defmt::info!("Initializing touchscreen");
+    let ts_int = gpioc.pc0.into_pull_down_input();
+    let touch_addr = match board_hint {
+        BoardHint::LegacyRevisionLikely => FT6X06_I2C_ADDR_LEGACY,
+        BoardHint::NewRevisionLikely | BoardHint::Unknown => FT6X06_I2C_ADDR_NEW,
     };
-    let mut otm8009a = Otm8009A::new();
-    otm8009a
-        .init(&mut dsi_host, otm8009a_config, &mut delay)
-        .unwrap();
+    let mut touch = match Ft6X06::new(&i2c, touch_addr, ts_int) {
+        Ok(touch) => Some(touch),
+        Err(_) => {
+            defmt::warn!("Touch controller unavailable at 0x{:02x}", touch_addr);
+            None
+        }
+    };
 
-    defmt::info!("Outputting Color/BER test patterns...");
-    let delay_ms = 5000u32;
-    loop {
-        dsi_host.enable_color_test();
-        delay.delay_ms(delay_ms);
-        dsi_host.enable_ber_test();
-        delay.delay_ms(delay_ms);
+    // Run internal calibration of touchscreen (following display-touch.rs pattern)
+    if let Some(touch) = touch.as_mut() {
+        let tsc = touch.ts_calibration(&mut i2c, &mut delay);
+        match tsc {
+            Err(_) => defmt::warn!("Error from ts_calibration"),
+            Ok(u) => defmt::info!("ts_calibration returned {}", u),
+        }
+    } else {
+        defmt::warn!("Touch initialization failed; running display pattern without touch input");
+    }
+
+defmt::info!("Outputting Color/BER test patterns. Touch to toggle test mode.");
+
+    let mut current_pattern_is_color = true;
+    let mut prev_num: u8 = 0;
+    let mut touch_hold_ticks: u8 = 0;  // Timeout counter for forced release
+    let mut total_toggles = 0u32;
+    let mut touch_err_count = 0u32;
+
+    dsi_host.enable_color_test();
+
+loop {
+        if let Some(touch) = touch.as_mut() {
+            // Detect number of touches
+            let num = match touch.detect_touch(&mut i2c) {
+                Ok(n) => n,
+                Err(_) => {
+                    touch_err_count += 1;
+                    if touch_err_count % 64 == 1 {
+                        defmt::warn!("detect_touch error (count={})", touch_err_count);
+                    }
+                    prev_num = 0;
+                    touch_hold_ticks = 0;
+                    delay.delay_ms(20u32);
+                    continue;
+                }
+            };
+
+            // Always read touch data when touching to clear FT6x06 internal state
+            if num > 0 {
+                match touch.get_touch(&mut i2c, 1) {
+Ok(point) => {
+                        // Enhanced touch logging with quadrant info
+                        let quadrant = match (point.x < 240, point.y < 400) {
+                            (true, true) => "top-left",
+                            (false, true) => "top-right",
+                            (true, false) => "bottom-left",
+                            (false, false) => "bottom-right",
+                        };
+                        defmt::info!("Touch: x={}, y={}, w={}, q={}", point.x, point.y, point.weight, quadrant);
+
+                        // LED on while touching
+                        led.set_high();
+                        // Toggle on rising edge: was not touching, now touching
+                        if prev_num == 0 {
+                            touch_hold_ticks = 0;  // Reset on new touch
+                            current_pattern_is_color = !current_pattern_is_color;
+                            total_toggles += 1;
+                            if current_pattern_is_color {
+                                dsi_host.enable_color_test();
+                            } else {
+                                dsi_host.enable_ber_test();
+                            }
+                            defmt::info!("Toggle #{} -> {} at ({},{})",
+                                total_toggles,
+                                if current_pattern_is_color { "Color" } else { "BER" },
+                                point.x, point.y
+                            );
+                        }
+                    }
+                    Err(_) => {
+                        touch_err_count += 1;
+                        if touch_err_count % 64 == 1 {
+                            defmt::warn!("get_touch error (count={})", touch_err_count);
+                        }
+                    }
+                }
+} else if prev_num > 0 {
+                defmt::info!("Touch released (held {}ms)", touch_hold_ticks * 10);
+                led.set_low();  // LED off on release
+            }
+
+// Timeout: force release if FT6x06 stuck reporting num>0
+if num > 0 {
+                touch_hold_ticks = touch_hold_ticks.saturating_add(1);
+                if touch_hold_ticks >= TOUCH_TIMEOUT_TICKS {
+                    defmt::debug!("Touch timeout, forcing release");
+                    prev_num = 0;  // Force release state for next poll
+                    touch_hold_ticks = 0;
+                } else {
+                    prev_num = num;
+                }
+            } else {
+                touch_hold_ticks = 0;
+                prev_num = num;
+            }
+        }
+
+        delay.delay_ms(10u32);
+    }
+}
+
+fn detect_lcd_controller(
+    dsi_host: &mut DsiHost,
+    delay: &mut impl embedded_hal_02::blocking::delay::DelayUs<u32>,
+    board_hint: BoardHint,
+) -> LcdController {
+    defmt::info!(
+        "Auto-detecting LCD controller with hint {:?}...",
+        board_hint
+    );
+
+    const PROBE_RETRIES: u8 = 3;
+    delay.delay_us(20_000u32);
+    let mut nt35510 = nt35510::Nt35510::new();
+    let mut mismatch_count = 0u8;
+    let mut first_mismatch_id: Option<u8> = None;
+    let mut consistent_mismatch = true;
+    let mut read_error_count = 0u8;
+    let mut write_error_count = 0u8;
+    for attempt in 1..=PROBE_RETRIES {
+        match nt35510.probe(dsi_host, delay) {
+            Ok(_) => {
+                defmt::info!("NT35510 (B08) detected successfully on attempt {}", attempt);
+                return LcdController::Nt35510;
+            }
+            Err(nt35510::Nt35510Error::DsiRead) => {
+                read_error_count = read_error_count.saturating_add(1);
+                defmt::warn!("NT35510 probe attempt {} failed: DSI read error", attempt);
+            }
+            Err(nt35510::Nt35510Error::DsiWrite) => {
+                write_error_count = write_error_count.saturating_add(1);
+                defmt::warn!("NT35510 probe attempt {} failed: DSI write error", attempt);
+            }
+            Err(nt35510::Nt35510Error::ProbeMismatch(id)) => {
+                mismatch_count = mismatch_count.saturating_add(1);
+                match first_mismatch_id {
+                    None => first_mismatch_id = Some(id),
+                    Some(first) if first != id => consistent_mismatch = false,
+                    Some(_) => {}
+                }
+                defmt::info!(
+                    "NT35510 probe attempt {} mismatch: RDID2=0x{:02x}",
+                    attempt,
+                    id
+                );
+            }
+        }
+
+        delay.delay_us(5_000u32);
+    }
+
+    let fallback_to_otm = match board_hint {
+        BoardHint::LegacyRevisionLikely => mismatch_count >= 1 && consistent_mismatch,
+        BoardHint::NewRevisionLikely => mismatch_count >= PROBE_RETRIES && consistent_mismatch,
+        BoardHint::Unknown => mismatch_count >= 2 && consistent_mismatch,
+    };
+
+    if fallback_to_otm {
+        let mismatch_id = first_mismatch_id.unwrap_or(0xFF);
+        defmt::info!(
+            "Consistent non-NT35510 probe response (id=0x{:02x}, count={}); falling back to OTM8009A",
+            mismatch_id,
+            mismatch_count
+        );
+        defmt::info!("Falling back to OTM8009A (B07 and earlier revisions)");
+        LcdController::Otm8009a
+    } else {
+        defmt::warn!(
+            "Probe inconclusive (mismatch={}, read_err={}, write_err={}); defaulting to NT35510",
+            mismatch_count,
+            read_error_count,
+            write_error_count
+        );
+        LcdController::Nt35510
     }
 }

--- a/examples/f469disco/nt35510.rs
+++ b/examples/f469disco/nt35510.rs
@@ -1,0 +1,156 @@
+//! NT35510 DSI LCD controller support for STM32F469I-DISCO B08 boards.
+
+use core::result::Result;
+use embedded_display_controller::dsi::{DsiHostCtrlIo, DsiReadCommand, DsiWriteCommand};
+use embedded_hal_02::blocking::delay::DelayUs;
+use stm32f4xx_hal::dsi::DsiHost;
+
+const CMD_SLPOUT: u8 = 0x11;
+const CMD_DISPON: u8 = 0x29;
+const CMD_RAMWR: u8 = 0x2C;
+const CMD_CASET: u8 = 0x2A;
+const CMD_RASET: u8 = 0x2B;
+const CMD_MADCTL: u8 = 0x36;
+const CMD_COLMOD: u8 = 0x3A;
+const CMD_WRDISBV: u8 = 0x51;
+const CMD_WRCTRLD: u8 = 0x53;
+const CMD_WRCABC: u8 = 0x55;
+const COLMOD_RGB888: u8 = 0x77;
+
+// Used only for runtime probing; unused when `nt35510-only` or `otm8009a-only` features are enabled
+#[allow(dead_code)]
+const CMD_RDID1: u8 = 0xDA;
+#[allow(dead_code)]
+const CMD_RDID2: u8 = 0xDB;
+
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Nt35510Error {
+    // Used only in probe(); unused when `nt35510-only` or `otm8009a-only` features skip runtime detection
+    #[allow(dead_code)]
+    DsiRead,
+    DsiWrite,
+    // Used only in probe(); unused when `nt35510-only` or `otm8009a-only` features skip runtime detection
+    #[allow(dead_code)]
+    ProbeMismatch(u8),
+}
+
+pub struct Nt35510 {
+    initialized: bool,
+}
+
+impl Nt35510 {
+    pub fn new() -> Self {
+        Self { initialized: false }
+    }
+
+    // Used only for runtime detection; unused when `nt35510-only` or `otm8009a-only` features are enabled
+    #[allow(dead_code)]
+    pub fn probe<D: DelayUs<u32>>(
+        &mut self,
+        dsi_host: &mut DsiHost,
+        _delay: &mut D, // Unused for this controller; present for API consistency
+    ) -> Result<(), Nt35510Error> {
+        let mut id2 = [0u8; 1];
+        match dsi_host.read(DsiReadCommand::DcsShort { arg: CMD_RDID2 }, &mut id2) {
+            Ok(_) if id2[0] == 0x80 => {
+                defmt::info!("NT35510 detected - RDID2=0x80");
+                return Ok(());
+            }
+            Ok(_) => {
+                defmt::info!("RDID2 returned 0x{:02x}, not NT35510", id2[0]);
+                return Err(Nt35510Error::ProbeMismatch(id2[0]));
+            }
+            Err(_) => {}
+        }
+
+        let mut id1 = [0u8; 1];
+        match dsi_host.read(DsiReadCommand::DcsShort { arg: CMD_RDID1 }, &mut id1) {
+            Ok(_) if id1[0] == 0x00 => {
+                defmt::info!("NT35510 detected - RDID1=0x00");
+                Ok(())
+            }
+            Ok(_) => {
+                defmt::info!("RDID1 returned 0x{:02x}, not NT35510", id1[0]);
+                Err(Nt35510Error::ProbeMismatch(id1[0]))
+            }
+            Err(_) => Err(Nt35510Error::DsiRead),
+        }
+    }
+
+    pub fn init<D: DelayUs<u32>>(
+        &mut self,
+        dsi_host: &mut DsiHost,
+        delay: &mut D,
+    ) -> Result<(), Nt35510Error> {
+        if self.initialized {
+            defmt::warn!("NT35510 already initialized, skipping re-initialization");
+            return Ok(());
+        }
+
+        self.write_reg(dsi_host, 0xF0, &[0x55, 0xAA, 0x52, 0x08, 0x01])?;
+        self.write_reg(dsi_host, 0xB0, &[0x03, 0x03, 0x03])?;
+        self.write_reg(dsi_host, 0xB6, &[0x46, 0x46, 0x46])?;
+        self.write_reg(dsi_host, 0xB1, &[0x03, 0x03, 0x03])?;
+        self.write_reg(dsi_host, 0xB7, &[0x36, 0x36, 0x36])?;
+        self.write_reg(dsi_host, 0xB2, &[0x00, 0x00, 0x02])?;
+        self.write_reg(dsi_host, 0xB8, &[0x26, 0x26, 0x26])?;
+        self.write_reg(dsi_host, 0xBF, &[0x01])?;
+        self.write_reg(dsi_host, 0xB3, &[0x09, 0x09, 0x09])?;
+        self.write_reg(dsi_host, 0xB9, &[0x36, 0x36, 0x36])?;
+        self.write_reg(dsi_host, 0xB5, &[0x08, 0x08, 0x08])?;
+        self.write_reg(dsi_host, 0xBA, &[0x26, 0x26, 0x26])?;
+        self.write_reg(dsi_host, 0xBC, &[0x00, 0x80, 0x00])?;
+        self.write_reg(dsi_host, 0xBD, &[0x00, 0x80, 0x00])?;
+        self.write_reg(dsi_host, 0xBE, &[0x00, 0x50])?;
+
+        self.write_reg(dsi_host, 0xF0, &[0x55, 0xAA, 0x52, 0x08, 0x00])?;
+        self.write_reg(dsi_host, 0xB1, &[0xFC, 0x00])?;
+        self.write_reg(dsi_host, 0xB6, &[0x03, 0x03])?;
+        self.write_reg(dsi_host, 0xB5, &[0x50, 0x50])?;
+        self.write_reg(dsi_host, 0xB7, &[0x00, 0x00])?;
+        self.write_reg(dsi_host, 0xB8, &[0x01, 0x02, 0x02, 0x02])?;
+        self.write_reg(dsi_host, 0xBC, &[0x00, 0x00, 0x00])?;
+        self.write_reg(dsi_host, 0xCC, &[0x03, 0x00, 0x00])?;
+        self.write_reg(dsi_host, 0xBA, &[0x01, 0x01])?;
+
+        delay.delay_us(200_000);
+        self.write_cmd(dsi_host, CMD_SLPOUT, 0x00)?;
+        delay.delay_us(120_000);
+        self.write_cmd(dsi_host, CMD_COLMOD, COLMOD_RGB888)?;
+        self.write_cmd(dsi_host, CMD_MADCTL, 0x00)?;
+        self.write_reg(dsi_host, CMD_CASET, &[0x00, 0x00, 0x01, 0xDF])?;
+        self.write_reg(dsi_host, CMD_RASET, &[0x00, 0x00, 0x03, 0x1F])?;
+        self.write_cmd(dsi_host, CMD_WRDISBV, 0x7F)?;
+        self.write_cmd(dsi_host, CMD_WRCTRLD, 0x2C)?;
+        self.write_cmd(dsi_host, CMD_WRCABC, 0x00)?;
+        delay.delay_us(10_000);
+        self.write_cmd(dsi_host, CMD_DISPON, 0x00)?;
+        delay.delay_us(10_000);
+        self.write_cmd(dsi_host, CMD_RAMWR, 0x00)?;
+
+        self.initialized = true;
+        Ok(())
+    }
+
+    fn write_cmd(&self, dsi_host: &mut DsiHost, cmd: u8, param: u8) -> Result<(), Nt35510Error> {
+        dsi_host
+            .write(DsiWriteCommand::DcsShortP1 {
+                arg: cmd,
+                data: param,
+            })
+            .map_err(|_| Nt35510Error::DsiWrite)
+    }
+
+    fn write_reg(&self, dsi_host: &mut DsiHost, reg: u8, data: &[u8]) -> Result<(), Nt35510Error> {
+        if data.is_empty() {
+            self.write_cmd(dsi_host, reg, 0)
+        } else if data.len() == 1 {
+            self.write_cmd(dsi_host, reg, data[0])
+        } else {
+            dsi_host
+                .write(DsiWriteCommand::DcsLongWrite { arg: reg, data })
+                .map_err(|_| Nt35510Error::DsiWrite)
+        }
+    }
+}

--- a/src/dsi.rs
+++ b/src/dsi.rs
@@ -6,7 +6,7 @@ use crate::ltdc::DisplayConfig;
 use crate::rcc::{Enable, Rcc};
 use crate::{pac::DSI, time::Hertz};
 use core::cmp::{max, min};
-use embedded_display_controller::dsi::{DsiHostCtrlIo, DsiReadCommand, DsiWriteCommand};
+pub use embedded_display_controller::dsi::{DsiHostCtrlIo, DsiReadCommand, DsiWriteCommand};
 
 const DSI_TIMEOUT_MS: usize = 100;
 
@@ -592,18 +592,24 @@ impl DsiHostCtrlIo for DsiHost {
             Error::FifoTimeout,
         )?;
         match kind {
-            DsiWriteCommand::DcsShortP0 { .. } => todo!(),
+            DsiWriteCommand::DcsShortP0 { arg } => {
+                self.ghcr_write(0, arg, kind.discriminant());
+            }
             DsiWriteCommand::DcsShortP1 { arg, data } => {
-                // debug!("{}, short_p1: reg: {reg:02x}, data: {data:02x}", self.write_idx);
-                // self.write_idx += 1;
                 self.ghcr_write(data, arg, kind.discriminant());
             }
             DsiWriteCommand::DcsLongWrite { arg, data } => {
                 self.long_write(arg, data, kind.discriminant())?
             }
-            DsiWriteCommand::GenericShortP0 => todo!(),
-            DsiWriteCommand::GenericShortP1 => todo!(),
-            DsiWriteCommand::GenericShortP2 => todo!(),
+            DsiWriteCommand::GenericShortP0 => {
+                self.ghcr_write(0, 0, kind.discriminant());
+            }
+            DsiWriteCommand::GenericShortP1 => {
+                self.ghcr_write(0, 0, kind.discriminant());
+            }
+            DsiWriteCommand::GenericShortP2 => {
+                self.ghcr_write(0, 0, kind.discriminant());
+            }
             DsiWriteCommand::GenericLongWrite { arg, data } => {
                 self.long_write(arg, data, kind.discriminant())?
             }

--- a/src/ltdc.rs
+++ b/src/ltdc.rs
@@ -667,3 +667,154 @@ pub trait SupportedWord {}
 impl SupportedWord for u8 {}
 impl SupportedWord for u16 {}
 impl SupportedWord for u32 {}
+
+// --- LTDC framebuffer DrawTarget for embedded-graphics ----------------------
+
+#[cfg(feature = "framebuffer")]
+mod framebuffer {
+    use super::DisplayConfig;
+    use embedded_graphics_core::{
+        draw_target::DrawTarget,
+        geometry::{OriginDimensions, Size},
+        pixelcolor::{IntoStorage, Rgb565},
+        primitives::Rectangle,
+        Pixel,
+    };
+
+    /// A framebuffer-backed draw target for LTDC displays.
+    ///
+    /// Wraps an SDRAM (or SRAM) backed `&'static mut [u16]` buffer and
+    /// presents it as an [`embedded_graphics_core::draw_target::DrawTarget`]
+    /// using the [`Rgb565`] pixel format (16-bit, 5-6-5 layout).
+    ///
+    /// The framebuffer is expected to be configured as LTDC layer 1 via
+    /// [`crate::ltdc::DisplayController::config_layer`].
+    ///
+    /// # Double buffering
+    ///
+    /// This abstraction manages a **single** framebuffer. True double-buffering
+    /// (swapping between two SDRAM regions to avoid tearing) requires:
+    ///
+    /// 1. Two framebuffer regions in SDRAM
+    /// 2. Swapping the LTDC layer base address during vertical blanking
+    /// 3. Coordinating writes to the non-displayed buffer
+    pub struct LtdcFramebuffer {
+        buffer: &'static mut [u16],
+        width: u16,
+        height: u16,
+    }
+
+    impl LtdcFramebuffer {
+        /// Create a new framebuffer draw target.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `buffer.len() != width as usize * height as usize`.
+        pub fn new(buffer: &'static mut [u16], width: u16, height: u16) -> Self {
+            assert_eq!(
+                buffer.len(),
+                width as usize * height as usize,
+                "framebuffer size mismatch"
+            );
+            Self {
+                buffer,
+                width,
+                height,
+            }
+        }
+
+        /// Return the active display width in pixels.
+        pub fn width(&self) -> u16 {
+            self.width
+        }
+
+        /// Return the active display height in pixels.
+        pub fn height(&self) -> u16 {
+            self.height
+        }
+
+        /// Get a raw pointer to the start of the framebuffer.
+        ///
+        /// This is useful when configuring the LTDC layer via
+        /// [`crate::ltdc::DisplayController::config_layer`].
+        pub fn as_ptr(&self) -> *const u16 {
+            self.buffer.as_ptr()
+        }
+
+        /// Borrow the underlying pixel buffer.
+        pub fn as_slice(&self) -> &[u16] {
+            self.buffer
+        }
+
+        /// Mutably borrow the underlying pixel buffer.
+        pub fn as_mut_slice(&mut self) -> &mut [u16] {
+            self.buffer
+        }
+    }
+
+    impl DrawTarget for LtdcFramebuffer {
+        type Color = Rgb565;
+        type Error = core::convert::Infallible;
+
+        fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+        where
+            I: IntoIterator<Item = Pixel<Self::Color>>,
+        {
+            let w = self.width as i32;
+            let h = self.height as i32;
+
+            for Pixel(coord, color) in pixels {
+                let x = coord.x;
+                let y = coord.y;
+                if x >= 0 && x < w && y >= 0 && y < h {
+                    self.buffer[x as usize + self.width as usize * y as usize] =
+                        color.into_storage();
+                }
+            }
+
+            Ok(())
+        }
+
+        fn fill_solid(
+            &mut self,
+            area: &Rectangle,
+            color: Self::Color,
+        ) -> Result<(), Self::Error> {
+            let value = color.into_storage();
+            let w = self.width as i32;
+            let h = self.height as i32;
+
+            // Clamp the rectangle to the display bounds
+            let x_start = area.top_left.x.max(0).min(w) as usize;
+            let y_start = area.top_left.y.max(0).min(h) as usize;
+            let x_end = (area.top_left.x + area.size.width as i32).max(0).min(w) as usize;
+            let y_end = (area.top_left.y + area.size.height as i32).max(0).min(h) as usize;
+
+            let stride = self.width as usize;
+            for y in y_start..y_end {
+                let row_start = y * stride + x_start;
+                let row_end = y * stride + x_end;
+                self.buffer[row_start..row_end].fill(value);
+            }
+
+            Ok(())
+        }
+
+        fn clear(&mut self, color: Self::Color) -> Result<(), Self::Error> {
+            self.buffer.fill(color.into_storage());
+            Ok(())
+        }
+    }
+
+    impl OriginDimensions for LtdcFramebuffer {
+        fn size(&self) -> Size {
+            Size::new(self.width as u32, self.height as u32)
+        }
+    }
+
+    // Re-export at the crate::ltdc level when framebuffer feature is enabled.
+    pub use LtdcFramebuffer as PublicLtdcFramebuffer;
+}
+
+#[cfg(feature = "framebuffer")]
+pub use framebuffer::PublicLtdcFramebuffer as LtdcFramebuffer;


### PR DESCRIPTION
## Summary

- Add a \ feature that exposes \, a \ abstraction over an LTDC-backed framebuffer using \.
- Provide a new \ example that initializes SDRAM, DSI, and LTDC on STM32F469I-DISCO and draws colour bars and rectangles via \ primitives.
- Complements PRs #863 and #864 by demonstrating a full framebuffer-based pipeline on the NT35510/OTM8009A DSI display.


Made with [Cursor](https://cursor.com)