### PR TITLE
Support Latest Embedded-io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as `u8` and `u16`
  - Add inherent impl of `read`/`write` methods on `Serial`
  - use `Listen` for `Rx/Tx`
+ - bumped `embedded-io` dependency to v0.7 and added Display Implementation for `embedded-io` `Error` Type.
 
 ## [v0.23.0] - 2025-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
  - Add `rcc::Instance` trait
-- Use `cfg_select` macro
+ - Use `cfg_select` macro
+
 ### Changed
 
  - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as `u8` and `u16`
  - Add inherent impl of `read`/`write` methods on `Serial`
-- use `Listen` for `Rx/Tx`
+ - use `Listen` for `Rx/Tx`
 
 ## [v0.23.0] - 2025-09-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ version = "1.0"
 version = "1.0"
 
 [dependencies.embedded-io]
-version = "0.6.1"
+version = "0.7"
 
 [dependencies.stm32_i2s_v12x]
 version = "0.5.0"

--- a/src/serial/hal_1.rs
+++ b/src/serial/hal_1.rs
@@ -105,6 +105,22 @@ mod io {
     use super::super::{Error, Instance, Rx, Serial, Tx};
     use embedded_io::Write;
 
+    impl core::fmt::Display for Error {
+        fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            let message = match self {
+                Error::Overrun => "serial receive buffer overrun",
+                Error::FrameFormat => "serial frame format error",
+                Error::Parity => "serial parity error",
+                Error::Noise => "serial noise error",
+                Error::Other => "serial error",
+            };
+
+            formatter.write_str(message)
+        }
+    }
+
+    impl core::error::Error for Error {}
+
     impl embedded_io::Error for Error {
         // TODO: fix error conversion
         fn kind(&self) -> embedded_io::ErrorKind {


### PR DESCRIPTION
This PR bumps the `embedded-io` dependency to use the latest version. Following the same pattern as the STM32F1 HAL PR: https://github.com/stm32-rs/stm32f1xx-hal/pull/565