### PR TITLE
docs(rcc): update module example to current Config/freeze API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Add `rcc::Instance` trait
  - Use `cfg_select` macro
 
+### Fixed
+
+ - Fix `rcc` module-level doc example to use current `Config/freeze` API [#876]
+
 ### Changed
 
  - `Serial` implements `Write<WORD>` and `Read<WORD>` for `WORD` simultaneously as `u8` and `u16`
@@ -47,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#839]: https://github.com/stm32-rs/stm32f4xx-hal/pull/839
 [#841]: https://github.com/stm32-rs/stm32f4xx-hal/pull/841
 [#859]: https://github.com/stm32-rs/stm32f4xx-hal/pull/859
+[#876]: https://github.com/stm32-rs/stm32f4xx-hal/pull/876
 
 ## [v0.22.1] - 2024-11-03
 

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -4,19 +4,19 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```rust,ignore
+//! use stm32f4xx_hal::{pac, prelude::*, rcc::Config};
+//!
 //! let dp = pac::Peripherals::take().unwrap();
-//! let rcc = dp.RCC.constrain();
-//! let clocks = rcc
-//!     .cfgr
-//!     .use_hse(8.MHz())
-//!     .sysclk(168.MHz())
-//!     .pclk1(24.MHz())
-//!     .i2s_clk(86.MHz())
-//!     .require_pll48clk()
-//!     .freeze();
-//!     // Test that the I2S clock is suitable for 48000kHz audio.
-//!     assert!(clocks.i2s_clk().unwrap() == 48.MHz().into());
+//! let rcc = dp.RCC.freeze(
+//!     Config::hse(8.MHz())
+//!         .sysclk(168.MHz())
+//!         .pclk1(24.MHz())
+//!         .i2s_clk(86.MHz())
+//!         .require_pll48clk(),
+//! );
+//! // Test that the I2S clock is suitable for 48000kHz audio.
+//! assert!(rcc.clocks.i2s_clk().unwrap() == 48.MHz().into());
 //! ```
 //!
 //! # Limitations


### PR DESCRIPTION
The `rcc` module-level example uses the old `rcc.cfgr.use_hse(...).freeze()` builder, but `cfgr` is no longer a public field, so the example does not compile against the current API.

This updates it to the `RCC.freeze(Config::hse(...)...)` form used throughout `examples/` (e.g. `i2s-audio-out.rs`, `rng-display.rs`), and reads the resulting frequency via `rcc.clocks.i2s_clk()`. Fence changed to `rust,ignore` to match the other peripheral-dependent module examples (`timer/pwm.rs`, `timer/capture.rs`).

Closes #875.